### PR TITLE
feat: declare the resource each task identifies

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -32,6 +32,7 @@ type ExportCommand struct {
 	overwrite  bool
 	redact     bool
 	apps       []string
+	resources  []string
 
 	host              string
 	sudo              bool
@@ -59,6 +60,8 @@ func (c *ExportCommand) Examples() map[string]string {
 		"Stream a JSON5 recipe to stdout":                       fmt.Sprintf("%s %s --output - --format json5", appName, c.Name()),
 		"Redact secrets into a fill-in-the-blanks vars-file":    fmt.Sprintf("%s %s --redact", appName, c.Name()),
 		"Export only a single app":                              fmt.Sprintf("%s %s --app my-app", appName, c.Name()),
+		"Export one resource":                                   fmt.Sprintf("%s %s --resource 'dokku_config[app=my-app]'", appName, c.Name()),
+		"Export every app's domains":                            fmt.Sprintf("%s %s --resource dokku_domains", appName, c.Name()),
 	}
 }
 
@@ -82,6 +85,7 @@ func (c *ExportCommand) FlagSet() *flag.FlagSet {
 	f.BoolVar(&c.overwrite, "overwrite", false, "overwrite existing output files without prompting")
 	f.BoolVar(&c.redact, "redact", false, "write placeholder values into the vars-file instead of real secrets")
 	f.StringArrayVar(&c.apps, "app", nil, "restrict the export to the named app (repeatable)")
+	f.StringArrayVar(&c.resources, "resource", nil, "restrict the export to the named resource address, e.g. 'dokku_config[app=my-app]' (repeatable); a bare task type exports every resource of that type")
 	f.StringVar(&c.host, "host", "", "remote [user@]host[:port] to read over SSH; overrides DOKKU_HOST")
 	f.BoolVar(&c.sudo, "sudo", false, "wrap the remote dokku call in sudo -n")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "trust an unknown SSH host key on first connect")
@@ -98,6 +102,7 @@ func (c *ExportCommand) AutocompleteFlags() complete.Flags {
 			"--overwrite":            complete.PredictNothing,
 			"--redact":               complete.PredictNothing,
 			"--app":                  complete.PredictNothing,
+			"--resource":             complete.PredictNothing,
 			"--host":                 complete.PredictNothing,
 			"--sudo":                 complete.PredictNothing,
 			"--accept-new-host-keys": complete.PredictNothing,
@@ -122,6 +127,22 @@ func (c *ExportCommand) Run(args []string) int {
 	}
 
 	formatOverride, err := parseRecipeFormatFlag("--format", c.formatFlag)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	// An address already names the app it belongs to, so combining the two
+	// filters can only express a contradiction or a redundancy.
+	if len(c.resources) > 0 && len(c.apps) > 0 {
+		c.Ui.Error("--resource and --app cannot be combined; a resource address already names its app")
+		return 1
+	}
+
+	// Addresses are parsed and checked against the registry here, before the
+	// SSH control master is opened, so a typo fails instantly rather than
+	// after a round trip to the server.
+	resources, err := tasks.ParseResourceSelectors(c.resources)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -161,9 +182,10 @@ func (c *ExportCommand) Run(args []string) int {
 	toStdout := c.output == taskFileStdin
 
 	res, err := tasks.ExportRecipe(tasks.ExportOptions{
-		Apps:   c.apps,
-		Redact: c.redact,
-		Inline: toStdout,
+		Apps:      c.apps,
+		Resources: resources,
+		Redact:    c.redact,
+		Inline:    toStdout,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("export failed: %v", err))
@@ -178,9 +200,12 @@ func (c *ExportCommand) Run(args []string) int {
 	// otherwise the existing apps are exported and the missing names are reported
 	// with a non-zero exit at the end (#346).
 	if res.PlayCount() == 0 {
-		if len(res.Report.MissingApps) > 0 {
+		switch {
+		case len(res.Report.MissingApps) > 0:
 			c.Ui.Error(fmt.Sprintf("error: %s not found on server; nothing to export", strings.Join(res.Report.MissingApps, ", ")))
-		} else {
+		case len(res.Report.MissingResources) > 0:
+			c.Ui.Error(fmt.Sprintf("error: %s not found on server; nothing to export", strings.Join(res.Report.MissingResources, ", ")))
+		default:
 			c.Ui.Error("error: nothing to export")
 		}
 		return 1
@@ -284,14 +309,15 @@ func (c *ExportCommand) Run(args []string) int {
 	return c.exitForMissingApps(res)
 }
 
-// exitForMissingApps reports any --app names that were not found on the server
-// and returns a non-zero exit code, so a typo is surfaced even though the apps
-// that do exist were still exported (#346).
+// exitForMissingApps reports any --app names or --resource addresses that were
+// not found on the server and returns a non-zero exit code, so a typo is
+// surfaced even though what does exist was still exported (#346).
 func (c *ExportCommand) exitForMissingApps(res *tasks.ExportResult) int {
-	if len(res.Report.MissingApps) == 0 {
+	missing := append(append([]string(nil), res.Report.MissingApps...), res.Report.MissingResources...)
+	if len(missing) == 0 {
 		return 0
 	}
-	c.Ui.Error(fmt.Sprintf("error: %s not found on server", strings.Join(res.Report.MissingApps, ", ")))
+	c.Ui.Error(fmt.Sprintf("error: %s not found on server", strings.Join(missing, ", ")))
 	return 1
 }
 

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -604,3 +604,77 @@ func TestExportCommandDeriveVarsOutput(t *testing.T) {
 		}
 	}
 }
+
+// TestExportCommandResourceSelectsOneResource covers the --resource flag end
+// to end: only the addressed task reaches the recipe.
+func TestExportCommandResourceSelectsOneResource(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(map[string]string{
+		"--quiet apps:list":                       "web",
+		"--quiet config:export --format json web": `{"LOG_LEVEL":"info"}`,
+		"domains:report web --domains-app-vhosts": "web.example.com",
+	}))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+
+	c, ui := newExportCommand()
+	if code := c.Run([]string{"--output", recipe, "--resource", "dokku_config[app=web]"}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0; stderr=%s", code, ui.ErrorWriter.String())
+	}
+
+	out, err := os.ReadFile(recipe)
+	if err != nil {
+		t.Fatalf("recipe not written: %v", err)
+	}
+	if !strings.Contains(string(out), "dokku_config") {
+		t.Errorf("recipe should hold the addressed task:\n%s", out)
+	}
+	if strings.Contains(string(out), "dokku_domains") {
+		t.Errorf("recipe should hold only the addressed task type:\n%s", out)
+	}
+}
+
+// TestExportCommandResourceRejectsAppCombination pins the mutual exclusion: an
+// address already names its app, so combining the two filters can only express
+// a contradiction or a redundancy.
+func TestExportCommandResourceRejectsAppCombination(t *testing.T) {
+	c, ui := newExportCommand()
+	code := c.Run([]string{"--output", "-", "--resource", "dokku_config[app=web]", "--app", "web"})
+	if code == 0 {
+		t.Fatal("expected a non-zero exit when --resource and --app are combined")
+	}
+	if !strings.Contains(ui.ErrorWriter.String(), "cannot be combined") {
+		t.Errorf("expected a clear rejection; got %q", ui.ErrorWriter.String())
+	}
+}
+
+// TestExportCommandResourceRejectsBadAddressBeforeReading asserts the address
+// is validated before the server is contacted: the fake runner is left unset,
+// so any read would answer empty and the run would fail later with a different
+// message.
+func TestExportCommandResourceRejectsBadAddressBeforeReading(t *testing.T) {
+	c, ui := newExportCommand()
+	code := c.Run([]string{"--output", "-", "--resource", "dokku_confg[app=web]"})
+	if code == 0 {
+		t.Fatal("expected a non-zero exit for an unknown task type")
+	}
+	if !strings.Contains(ui.ErrorWriter.String(), `did you mean "dokku_config"`) {
+		t.Errorf("expected a did-you-mean hint; got %q", ui.ErrorWriter.String())
+	}
+}
+
+// TestExportCommandResourceUnmatchedExitsNonZero asserts an address the server
+// has nothing for is surfaced rather than silently exporting nothing, the same
+// contract a nonexistent --app has.
+func TestExportCommandResourceUnmatchedExitsNonZero(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	c, ui := newExportCommand()
+	code := c.Run([]string{"--output", "-", "--resource", "dokku_config[app=missing]"})
+	if code == 0 {
+		t.Fatal("expected a non-zero exit for an address that matched nothing")
+	}
+	if !strings.Contains(ui.ErrorWriter.String(), "dokku_config[app=missing]") {
+		t.Errorf("expected the unmatched address to be named; got %q", ui.ErrorWriter.String())
+	}
+}

--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -3,80 +3,11 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
-	"regexp"
 	"strings"
 
 	"github.com/dokku/docket/tasks"
 	"github.com/mitchellh/cli"
 )
-
-// autoNameRE matches the auto-generated task name format from
-// tasks/main.go:generateTaskName ("task #<index> <8-byte-hex>"). When a
-// listing line carries an auto-name, the display falls back to the
-// task's TypeName plus an identifying body field so the user sees
-// something meaningful instead of an opaque random suffix.
-var autoNameRE = regexp.MustCompile(`^task #\d+ [0-9A-F]{16}$`)
-
-// listingDisplayName returns the human-friendly label for env in
-// --list-tasks output. User-supplied names pass through untouched. An
-// auto-generated name (the loader's `task #N <hex>` form) is replaced
-// with `<TypeName>` plus the first identifying body field (App, Name,
-// Service, Repository, ...) when one is present, so a recipe with
-// unnamed tasks still reads back the body the user wrote.
-func listingDisplayName(env *tasks.TaskEnvelope, fallback string) string {
-	if env == nil {
-		return fallback
-	}
-	name := env.Name
-	if name == "" {
-		name = fallback
-	}
-	if !autoNameRE.MatchString(name) {
-		return name
-	}
-	if env.TypeName == "" {
-		return name
-	}
-	if id := identifyingBodyField(env.Task); id != "" {
-		return fmt.Sprintf("%s: %s", env.TypeName, id)
-	}
-	return env.TypeName
-}
-
-// identifyingBodyField walks the task struct (via reflection) for the
-// first non-empty string field whose name matches a common identifier
-// (App, Name, Service, Repository, Mount, Url). Returns "" if no such
-// field is present, in which case the caller falls back to TypeName
-// alone.
-func identifyingBodyField(task tasks.Task) string {
-	if task == nil {
-		return ""
-	}
-	v := reflect.ValueOf(task)
-	for v.Kind() == reflect.Ptr {
-		if v.IsNil() {
-			return ""
-		}
-		v = v.Elem()
-	}
-	if v.Kind() != reflect.Struct {
-		return ""
-	}
-	for _, candidate := range []string{"App", "Name", "Service", "Repository", "Mount", "Url"} {
-		f := v.FieldByName(candidate)
-		if !f.IsValid() {
-			continue
-		}
-		if f.Kind() != reflect.String {
-			continue
-		}
-		if s := f.String(); s != "" {
-			return s
-		}
-	}
-	return ""
-}
 
 // listTasksOptions captures everything renderListTasks needs to walk the
 // resolved play set and print one line per envelope. It is constructed by
@@ -149,8 +80,7 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 
 		idx := 0
 		for _, name := range tasks.FilterByTags(play.Tasks, opts.includes, opts.skips) {
-			env := play.Tasks.GetEnvelope(name)
-			renderListEnvelope(ui, play.Name, name, env, idx, "", 0, playExprCtx, opts.jsonOut)
+			renderListEnvelope(ui, play.Name, play.Tasks.GetEnvelope(name), idx, "", 0, playExprCtx, opts.jsonOut)
 			idx++
 		}
 	}
@@ -161,9 +91,17 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 // recursively renders its block / rescue / always children indented one
 // level. indent is the leading-space count; phase labels group children
 // (matching the executor's phase decoration).
+//
+// The displayed label is the envelope name as-is. Before #427 an unnamed task
+// carried a random `task #N <hex>` name, and this function substituted the
+// task type plus the first field named App / Name / Service / ... to keep the
+// listing readable - a heuristic that collapsed every phase and option of one
+// app's dokku_docker_options onto the same line. The loader now names an
+// unnamed task after the resource it addresses, so there is nothing to
+// substitute.
 func renderListEnvelope(
 	ui cli.Ui,
-	playName, name string,
+	playName string,
 	env *tasks.TaskEnvelope,
 	index int,
 	phase string,
@@ -172,7 +110,7 @@ func renderListEnvelope(
 	jsonOut bool,
 ) {
 	skipMarker := evaluateListWhen(env, playExprCtx)
-	display := listingDisplayName(env, name)
+	display := env.Name
 	deprecation := ""
 	var probe tasks.ProbeSupport
 	if env != nil && env.Task != nil {
@@ -262,25 +200,13 @@ func renderListEnvelope(
 
 	if env.IsGroup() {
 		for i, child := range env.Block {
-			childName := child.Name
-			if childName == "" {
-				childName = fmt.Sprintf("%s.block[%d]", name, i)
-			}
-			renderListEnvelope(ui, playName, childName, child, i, "block", indent+1, playExprCtx, jsonOut)
+			renderListEnvelope(ui, playName, child, i, "block", indent+1, playExprCtx, jsonOut)
 		}
 		for i, child := range env.Rescue {
-			childName := child.Name
-			if childName == "" {
-				childName = fmt.Sprintf("%s.rescue[%d]", name, i)
-			}
-			renderListEnvelope(ui, playName, childName, child, i, "rescue", indent+1, playExprCtx, jsonOut)
+			renderListEnvelope(ui, playName, child, i, "rescue", indent+1, playExprCtx, jsonOut)
 		}
 		for i, child := range env.Always {
-			childName := child.Name
-			if childName == "" {
-				childName = fmt.Sprintf("%s.always[%d]", name, i)
-			}
-			renderListEnvelope(ui, playName, childName, child, i, "always", indent+1, playExprCtx, jsonOut)
+			renderListEnvelope(ui, playName, child, i, "always", indent+1, playExprCtx, jsonOut)
 		}
 	}
 }

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -39,12 +39,12 @@ func TestApplyListTasksPrintsResolvedPlan(t *testing.T) {
 	}
 }
 
-// TestApplyListTasksUnnamedTasksShowBodyIdentifier covers the unnamed
-// task path: a recipe with no `name:` produces an auto-generated name
-// like `task #1 <hex>` from the loader. --list-tasks substitutes a
-// `<TypeName>: <body identifier>` display so the listing stays
-// readable instead of leaking the random hex suffix.
-func TestApplyListTasksUnnamedTasksShowBodyIdentifier(t *testing.T) {
+// TestApplyListTasksUnnamedTasksShowResourceAddress covers the unnamed
+// task path: a recipe with no `name:` is named after the resource each task
+// addresses, so the listing reads back the body the user wrote. Before #427
+// the loader produced `task #1 <hex>` and this display substituted the task
+// type plus one guessed field.
+func TestApplyListTasksUnnamedTasksShowResourceAddress(t *testing.T) {
 	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
@@ -55,13 +55,37 @@ func TestApplyListTasksUnnamedTasksShowBodyIdentifier(t *testing.T) {
 	if exit != 0 {
 		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
 	}
-	for _, want := range []string{"dokku_app: docket-test-list-1", "dokku_app: docket-test-list-2"} {
+	for _, want := range []string{"dokku_app[app=docket-test-list-1]", "dokku_app[app=docket-test-list-2]"} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("listing should include %q; got:\n%s", want, stdout)
 		}
 	}
 	if strings.Contains(stdout, "task #") {
-		t.Errorf("auto-generated task name should be replaced; got:\n%s", stdout)
+		t.Errorf("no listing line should carry a positional auto-name; got:\n%s", stdout)
+	}
+}
+
+// TestApplyListTasksDistinguishesSameAppTasks is the case the old display
+// heuristic got wrong: it keyed on the first App-like field, so every phase
+// and option of one app's docker options collapsed onto the same label.
+func TestApplyListTasksDistinguishesSameAppTasks(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - dokku_docker_options: { app: api, phase: deploy, option: "--memory=512m" }
+    - dokku_docker_options: { app: api, phase: build, option: "--shm-size=1g" }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	for _, want := range []string{
+		"dokku_docker_options[app=api,phase=deploy,option=--memory=512m]",
+		"dokku_docker_options[app=api,phase=build,option=--shm-size=1g]",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("listing should include %q; got:\n%s", want, stdout)
+		}
 	}
 }
 

--- a/commands/stub_task_test.go
+++ b/commands/stub_task_test.go
@@ -15,8 +15,10 @@ import (
 // Execute(). Plan() returns a Drift / InSync result based on the
 // fixture's Changed flag plus its Error.
 type StubTask struct {
-	// Key is the lookup into stubFixtures. Required.
-	Key string `yaml:"key" required:"true"`
+	// Key is the lookup into stubFixtures. Required, and the stub's identity:
+	// one fixture per key is exactly the "which resource" question every real
+	// task answers with its `identity:"key"` fields.
+	Key string `yaml:"key" required:"true" identity:"key"`
 }
 
 // Doc / Examples are not exercised by the apply / plan tests. They

--- a/commands/task_name_test.go
+++ b/commands/task_name_test.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// jsonTaskNames runs an apply with --json and returns the `name` of every
+// `task` event, in emission order.
+func jsonTaskNames(t *testing.T, path string) []string {
+	t.Helper()
+	stdout, stderr, exit := runApply(t, path, "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("event is not JSON: %v\n%s", err, line)
+		}
+		if ev.Type == "task" {
+			names = append(names, ev.Name)
+		}
+	}
+	return names
+}
+
+// TestApplyJSONTaskNamesAreStableAcrossRuns is the guarantee #427 exists to
+// provide: `name` is the only correlation key in the event stream, so two runs
+// of one recipe have to emit the same names for the same tasks. Before the
+// change an unnamed task carried eight random bytes and a consumer diffing one
+// run against another could line nothing up.
+func TestApplyJSONTaskNamesAreStableAcrossRuns(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - dokku_stub: { key: a }
+    - dokku_stub: { key: b }
+    - name: explicit
+      dokku_stub: { key: c }
+`)
+
+	first := jsonTaskNames(t, path)
+	second := jsonTaskNames(t, path)
+
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("task names differ between runs:\n first = %v\nsecond = %v", first, second)
+	}
+	want := []string{"dokku_stub[key=a]", "dokku_stub[key=b]", "explicit"}
+	if !reflect.DeepEqual(first, want) {
+		t.Errorf("task names = %v, want %v", first, want)
+	}
+}
+
+// TestApplyStartAtTaskAcceptsGeneratedName covers the other half: an unnamed
+// task could not be named on the command line at all before, because its name
+// was different every run.
+func TestApplyStartAtTaskAcceptsGeneratedName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - dokku_stub: { key: a }
+    - dokku_stub: { key: b }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--start-at-task", "dokku_stub[key=b]")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[skipped] dokku_stub[key=a]") {
+		t.Errorf("expected the earlier task to be skipped; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "before --start-at-task") {
+		t.Errorf("expected the resume-point skip reason; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[skipped] dokku_stub[key=b]") {
+		t.Errorf("the named task should run, not be skipped; got:\n%s", stdout)
+	}
+}
+
+// TestApplyStartAtTaskUnknownNameListsGeneratedNames asserts the failure hint
+// is usable: when the name matches nothing, the available names it prints are
+// the addresses the user would have to type.
+func TestApplyStartAtTaskUnknownNameListsGeneratedNames(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - dokku_stub: { key: a }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--start-at-task", "nope")
+	if exit == 0 {
+		t.Fatalf("expected a non-zero exit; stdout=%s", stdout)
+	}
+	if !strings.Contains(stderr+stdout, "dokku_stub[key=a]") {
+		t.Errorf("expected the available names to list the generated address; got:\n%s\n%s", stdout, stderr)
+	}
+}

--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -154,6 +154,16 @@ docket's view of the result to evaluate.
 `--list-tasks` returns before any task runs, so it is unaffected by `--detailed-exitcode` and exits
 `0` or `1`.
 
+### Correlating tasks across runs
+
+`name` is the key. It is stable for the same recipe: a task the wrapper emitted without a `name:`
+is named after the [resource it manages](task-envelope.md#names-and-resource-addresses), so the same
+task carries the same `name` in a `plan` run and the `apply` that follows it.
+
+A wrapper that generates recipes should still set `name:` explicitly when it has a meaningful label
+of its own - a hand-written name is never rewritten, whereas two generated names that address the
+same resource are disambiguated with an ordinal that shifts if a task is inserted between them.
+
 ### Deriving `changed`
 
 There are three signals, and they agree. Pick whichever fits the wrapper:
@@ -217,7 +227,9 @@ means a wrapper must not diff a returned value against the one it sent.
 
 The one exception is `--list-tasks`, which renders the resolved plan before any sensitive value is
 registered and does no masking at all: an interpolated secret comes back verbatim in `name`,
-`when`, and `loop_item`. Never surface that stream to an Ansible caller.
+`when`, and `loop_item`. Never surface that stream to an Ansible caller. No task field is ever both
+an identity key and `sensitive:"true"`, so a generated `name` never embeds a task-declared secret -
+but a `sensitive: true` input interpolated into an identity field still reaches it.
 
 ## Module mapping
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -326,6 +326,17 @@ $ docket apply --list-tasks
 [3] dokku ports:add api  [tags=deploy]
 ```
 
+Those are the `name:` values from the recipe. A task with no `name:` is listed by its
+[resource address](task-envelope.md#names-and-resource-addresses) instead:
+
+```text
+$ docket apply --list-tasks
+==> Play: api
+[0] dokku_app[app=api]
+[1] dokku_config[app=api]
+[2] dokku_docker_options[app=api,phase=deploy,option=--memory=512m]
+```
+
 A `when:` that is false against the inputs renders as `[skipped]`. A `when:` that references
 `.registered.<name>` cannot be decided without running earlier tasks, so it renders as `[unknown]`
 rather than guessing.
@@ -361,11 +372,22 @@ $ docket apply --start-at-task "dokku config:set api"
 Summary: 4 tasks · 1 changed · 1 ok · 2 skipped · 0 errors  (took 1.1s)
 ```
 
+A task with no `name:` is targeted by its resource address. Quote it - the brackets are shell glob
+characters:
+
+```console
+$ docket apply --start-at-task 'dokku_config[app=api]'
+```
+
 Filters apply in this order: `--start-at-task` selects first, then `--tags` / `--skip-tags`, then
 per-task `when:` at execution time. The name search walks every play in source order, narrowed by
 `--play`. An unmatched name exits 1 with the available names listed. A `--start-at-task` target that
 is itself excluded by `--tags` / `--skip-tags` still establishes the resume point but does not itself
 run - tasks after it that pass the tag filter do.
+
+`validate --strict --start-at-task` checks the same names offline. It stands down for a play that
+contains a `loop:` entry or an input with no default, because neither can be named without the
+values a real run has; the check at apply time is the authoritative one.
 
 ## docket export
 
@@ -391,10 +413,35 @@ docket apply --tasks tasks.yml --vars-file tasks.vars.yml
 
 # Stream a JSON5 recipe to stdout and pipe it straight back in.
 docket export --output - --format json5 | docket apply --tasks-format json5 -
+
+# Read back a single resource instead of a whole app.
+docket export --resource 'dokku_config[app=api]' --output -
 ```
 
 The correctness contract is idempotency: applying an exported pair back to the same server reports
 no drift (`plan` shows every task `[ok]`).
+
+### Exporting one resource
+
+`--resource` takes a [resource address](task-envelope.md#names-and-resource-addresses) - the same
+string an unnamed task is named after - and exports only what it matches:
+
+```console
+$ docket export --resource 'dokku_config[app=api]' --output -
+$ docket export --resource 'dokku_apps_property[global=true,property=disable-autocreation]' --output -
+```
+
+Drop the brackets to take every resource of a type, across every app:
+
+```console
+$ docket export --resource dokku_domains --output -
+```
+
+The flag is repeatable and cannot be combined with `--app`, since an address already names its app.
+Each address is checked against the registry before the server is read, so an unknown task type, a
+type no exporter reaches, or a key the task does not declare fails immediately. An address that
+matches nothing on the server is reported by name and exits non-zero, the same way a nonexistent
+`--app` is.
 
 | Flag | Effect |
 |------|--------|
@@ -404,6 +451,7 @@ no drift (`plan` shows every task `[ok]`).
 | `--overwrite` | Overwrite existing output files without prompting. Without it, export prompts before replacing either file, and aborts writing nothing if declined (or if stdin is not interactive). Not valid with `--output -`. |
 | `--redact` | Write placeholder values into the vars-file instead of real secrets, producing a shareable recipe plus a fill-in-the-blanks vars template. The `required` inputs mean `apply` fails loudly until the vars-file is filled in. |
 | `--app <name>` | Restrict the export to the named app. Repeatable. |
+| `--resource <address>` | Restrict the export to a [resource address](task-envelope.md#names-and-resource-addresses), e.g. `dokku_config[app=api]`. A bare task type takes every resource of that type. Repeatable; not valid with `--app`. See [exporting one resource](#exporting-one-resource). |
 | `--host <user@host:port>` | Read a remote server over SSH. Overrides `DOKKU_HOST`. See [remote execution](remote-execution.md). |
 | `--sudo` | Wrap the remote `dokku` call in `sudo -n`. |
 | `--accept-new-host-keys` | Trust an unknown SSH host key on first connect. |

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -375,8 +375,8 @@ Summary: 4 tasks · 1 changed · 1 ok · 2 skipped · 0 errors  (took 1.1s)
 A task with no `name:` is targeted by its resource address. Quote it - the brackets are shell glob
 characters:
 
-```console
-$ docket apply --start-at-task 'dokku_config[app=api]'
+```bash
+docket apply --start-at-task 'dokku_config[app=api]'
 ```
 
 Filters apply in this order: `--start-at-task` selects first, then `--tags` / `--skip-tags`, then
@@ -426,15 +426,15 @@ no drift (`plan` shows every task `[ok]`).
 `--resource` takes a [resource address](task-envelope.md#names-and-resource-addresses) - the same
 string an unnamed task is named after - and exports only what it matches:
 
-```console
-$ docket export --resource 'dokku_config[app=api]' --output -
-$ docket export --resource 'dokku_apps_property[global=true,property=disable-autocreation]' --output -
+```bash
+docket export --resource 'dokku_config[app=api]' --output -
+docket export --resource 'dokku_apps_property[global=true,property=disable-autocreation]' --output -
 ```
 
 Drop the brackets to take every resource of a type, across every app:
 
-```console
-$ docket export --resource dokku_domains --output -
+```bash
+docket export --resource dokku_domains --output -
 ```
 
 The flag is repeatable and cannot be combined with `--app`, since an address already names its app.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -14,6 +14,21 @@ interpolate a sensitive input). Masking applies to the `apply` / `plan` run stre
 `validate --json`; the `--list-tasks --json` stream is **not** masked, so do not route it anywhere a
 secret must not land.
 
+## Correlating runs
+
+`name` is the correlation key. Two runs of the same recipe emit the same `name` for the same task,
+so a dashboard or a CI job comparing `plan` to `apply` can line them up. A task with no `name:` in
+the recipe is named after the [resource it manages](task-envelope.md#names-and-resource-addresses) -
+`dokku_config[app=api]` - which is stable for the same reason.
+
+Two caveats on masking, both of which can make two distinct tasks indistinguishable in the stream:
+
+- A generated name embeds the task's identity field values. No field is ever both an identity key
+  and declared sensitive, but a `sensitive: true` input interpolated into one still reaches the
+  name - masked in this stream, in the clear in `--list-tasks --json`.
+- Masking is substring replacement. A short sensitive value can mask a large part of two different
+  names into the same `***`-bearing string. Pin a `name:` on the tasks a consumer must tell apart.
+
 ## Events
 
 One event is emitted per play start, per task, and one summary at the end. The fields differ

--- a/docs/schemas/events-v1.schema.json
+++ b/docs/schemas/events-v1.schema.json
@@ -119,7 +119,10 @@
         "version": { "$ref": "#/$defs/version" },
         "type": { "const": "task" },
         "play": { "type": "string" },
-        "name": { "type": "string" },
+        "name": {
+          "type": "string",
+          "description": "The task's `name:`, or - when the recipe omits one - the address of the resource it manages (`dokku_config[app=api]`). Masked. Stable across runs of the same recipe, so it is the key for correlating one run with another."
+        },
         "status": {
           "type": "string",
           "enum": ["ok", "changed", "skipped", "error"]

--- a/docs/schemas/list-tasks-v1.schema.json
+++ b/docs/schemas/list-tasks-v1.schema.json
@@ -40,7 +40,10 @@
         "version": { "$ref": "#/$defs/version" },
         "type": { "const": "list_task" },
         "play": { "type": "string" },
-        "name": { "type": "string", "description": "Resolved display name of the task." },
+        "name": {
+          "type": "string",
+          "description": "The task's `name:`, or - when the recipe omits one - the address of the resource it manages (`dokku_config[app=api]`). Stable across runs of the same recipe."
+        },
         "index": {
           "type": "integer",
           "minimum": 0,

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -55,8 +55,8 @@ Two properties follow, and both are the point:
 - **You can name an unnamed task on the command line.** Quote it, because the brackets are shell
   glob characters:
 
-  ```console
-  $ docket apply --start-at-task 'dokku_config[app=api]'
+  ```bash
+  docket apply --start-at-task 'dokku_config[app=api]'
   ```
 
 The desired state is deliberately *not* part of the address. `state: absent` on an app's config

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -7,7 +7,7 @@ it you can apply it anywhere.
 
 | Key | What it does |
 |-----|--------------|
-| `name` | A human label for the task, shown in the output. Auto-generated when omitted. |
+| `name` | A human label for the task, shown in the output. [Derived from the resource](#names-and-resource-addresses) when omitted. |
 | `tags` | A tag list, filtered by `--tags` / `--skip-tags`. |
 | `when` | A condition; when false the task renders as `[skipped]`. |
 | `loop` | Expand one entry into many, once per item in a list. |
@@ -26,6 +26,57 @@ do not get confused:
 - **Task bodies** use [sigil](https://github.com/gliderlabs/sigil) templates: `{{ .app }}`.
 - **Envelope predicates** (`when`, `loop`, `changed_when`, `failed_when`) use
   [expr](https://github.com/expr-lang/expr): `app == "api"`.
+
+## Names and resource addresses
+
+A task's `name` is its identity in every output docket produces: the label in `apply` and `plan`
+output, the `name` field in the [`--json` event stream](json-output.md), and the argument
+`--start-at-task` takes.
+
+When you omit `name`, docket derives one from the resource the task manages - its **address**:
+
+```text
+dokku_config[app=api]
+dokku_apps_property[global=true,property=disable-autocreation]
+dokku_docker_options[app=api,phase=deploy,option=--memory=512m]
+```
+
+The keys are the fields that decide *which* resource the task addresses, listed in the **Identity**
+section of every [task reference page](tasks/README.md). A key you left empty is omitted, which is
+what distinguishes an app-scoped task from its global counterpart. A task with no key value at all
+is just its type: `dokku_domains`.
+
+Two properties follow, and both are the point:
+
+- **The same recipe produces the same names on every run.** A tool diffing one run against another -
+  a dashboard, a CI job comparing `plan` to `apply` - can line the tasks up by `name`. This matters
+  most for [`docket export`](command-reference.md#docket-export) output, which writes no `name:` on
+  any task.
+- **You can name an unnamed task on the command line.** Quote it, because the brackets are shell
+  glob characters:
+
+  ```console
+  $ docket apply --start-at-task 'dokku_config[app=api]'
+  ```
+
+The desired state is deliberately *not* part of the address. `state: absent` on an app's config
+addresses the same resource as `state: present`, so changing a task's state does not rename it.
+
+That means two tasks in one play can share an address - setting some config keys and unsetting
+others is a normal thing to write. The first keeps the bare address and later ones get an ordinal:
+
+```yaml
+- tasks:
+    - dokku_config: { app: api, config: { A: "1" } }        # dokku_config[app=api]
+    - dokku_config: { app: api, state: absent, config: { B: "" } }  # dokku_config[app=api] #2
+```
+
+Those ordinals shift if you insert another colliding task ahead of them. When a name has to stay
+put, write a `name:` - a name you wrote is never renamed, even when it collides with an address
+docket would otherwise have generated.
+
+A `block:` / `rescue:` / `always:` group manages no resource of its own, so an unnamed group is
+named after its position instead: `group #3`, and `group #3.block[2]` for a group nested inside one.
 
 ## Tags
 

--- a/docs/tasks/dokku_acl_app.md
+++ b/docs/tasks/dokku_acl_app.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`. Manages the whole `users` collection; entries are identified by value.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_acl_service.md
+++ b/docs/tasks/dokku_acl_service.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `service` and `type`. Fields left empty are omitted from the address. Manages the whole `users` collection; entries are identified by value.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app.md
+++ b/docs/tasks/dokku_app.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app_clone.md
+++ b/docs/tasks/dokku_app_clone.md
@@ -12,6 +12,10 @@ Not supported - an imperative clone operation, not reconstructable state.
 
 Partial - only the target app's existence is probed; the clone source and the cloned contents are never read back.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app_json_property.md
+++ b/docs/tasks/dokku_app_json_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app_lock.md
+++ b/docs/tasks/dokku_app_lock.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_apps_property.md
+++ b/docs/tasks/dokku_apps_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_dockerfile_property.md
+++ b/docs/tasks/dokku_builder_dockerfile_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_herokuish_property.md
+++ b/docs/tasks/dokku_builder_herokuish_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_lambda_property.md
+++ b/docs/tasks/dokku_builder_lambda_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_nixpacks_property.md
+++ b/docs/tasks/dokku_builder_nixpacks_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_pack_property.md
+++ b/docs/tasks/dokku_builder_pack_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_property.md
+++ b/docs/tasks/dokku_builder_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_railpack_property.md
+++ b/docs/tasks/dokku_builder_railpack_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_buildpacks.md
+++ b/docs/tasks/dokku_buildpacks.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`. Manages the whole `buildpacks` collection; entries are identified by value.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_buildpacks_property.md
+++ b/docs/tasks/dokku_buildpacks_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builds_property.md
+++ b/docs/tasks/dokku_builds_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_caddy_property.md
+++ b/docs/tasks/dokku_caddy_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_certs.md
+++ b/docs/tasks/dokku_certs.md
@@ -16,6 +16,10 @@ Partial - app and global certificate PEM material is exported (via certs:show an
 
 Partial - only whether a certificate is installed is probed; the certificate material is never read back, so replacing an existing certificate plans as in sync.
 
+## Identity
+
+Keyed by `app` and `global`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_checks_property.md
+++ b/docs/tasks/dokku_checks_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_checks_toggle.md
+++ b/docs/tasks/dokku_checks_toggle.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_config.md
+++ b/docs/tasks/dokku_config.md
@@ -12,6 +12,10 @@ Partial - config values are written to the companion vars-file.
 
 Supported.
 
+## Identity
+
+Keyed by `app`. Manages the whole `config` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_cron_property.md
+++ b/docs/tasks/dokku_cron_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_docker_options.md
+++ b/docs/tasks/dokku_docker_options.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `phase`, `process_type`, and `option`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_domains.md
+++ b/docs/tasks/dokku_domains.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app` and `global`. Fields left empty are omitted from the address. Manages the whole `domains` collection; entries are identified by value.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_domains_toggle.md
+++ b/docs/tasks/dokku_domains_toggle.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_auth.md
+++ b/docs/tasks/dokku_git_auth.md
@@ -12,6 +12,10 @@ Not supported - netrc credentials are write-only and cannot be read back.
 
 Not supported - netrc state has no read command, so the task plans as drift on every run.
 
+## Identity
+
+Keyed by `host`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_from_archive.md
+++ b/docs/tasks/dokku_git_from_archive.md
@@ -12,6 +12,10 @@ Supported.
 
 Partial - the recorded archive source is probed; the archive contents are not hashed, so a changed archive at the same url plans as in sync.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_from_image.md
+++ b/docs/tasks/dokku_git_from_image.md
@@ -12,6 +12,10 @@ Partial - the image reference is written to the companion vars-file.
 
 Partial - the recorded image reference is probed; the image digest is not, so a mutable tag that moved plans as in sync.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_property.md
+++ b/docs/tasks/dokku_git_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_sync.md
+++ b/docs/tasks/dokku_git_sync.md
@@ -12,6 +12,10 @@ Supported.
 
 Partial - dokku records the resolved commit as `<remote>#<sha>`, which cannot be compared against a branch or tag name, so only the remote and the persisted deploy branch are probed.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_haproxy_property.md
+++ b/docs/tasks/dokku_haproxy_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth.md
+++ b/docs/tasks/dokku_http_auth.md
@@ -16,6 +16,10 @@ Partial - the enabled state is exported; the seeded credentials are not carried 
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth_allowed_ip.md
+++ b/docs/tasks/dokku_http_auth_allowed_ip.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`. Manages the whole `allowed_ips` collection; entries are identified by value.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth_domain.md
+++ b/docs/tasks/dokku_http_auth_domain.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`. Manages the whole `domains` collection; entries are identified by value.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth_user.md
+++ b/docs/tasks/dokku_http_auth_user.md
@@ -16,6 +16,10 @@ Supported.
 
 Partial - an existing user's htpasswd hash is probed; a cleartext password is not readable, so a user that already exists converges only when update_password forces it.
 
+## Identity
+
+Keyed by `app`. Manages the whole `users` collection; entries are identified by `username`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_letsencrypt.md
+++ b/docs/tasks/dokku_letsencrypt.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_letsencrypt_property.md
+++ b/docs/tasks/dokku_letsencrypt_property.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_logs_property.md
+++ b/docs/tasks/dokku_logs_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_maintenance.md
+++ b/docs/tasks/dokku_maintenance.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_maintenance_custom_page.md
+++ b/docs/tasks/dokku_maintenance_custom_page.md
@@ -16,6 +16,10 @@ Partial - export reads the current page back via maintenance:custom-page-export 
 
 Partial - the page checksum is probed when the plugin reports it; plugin versions that do not report it make the page plan as drift on every run.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_network.md
+++ b/docs/tasks/dokku_network.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `name`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_network_property.md
+++ b/docs/tasks/dokku_network_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_nginx_property.md
+++ b/docs/tasks/dokku_nginx_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_openresty_property.md
+++ b/docs/tasks/dokku_openresty_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_plugin.md
+++ b/docs/tasks/dokku_plugin.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `name`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ports.md
+++ b/docs/tasks/dokku_ports.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`. Manages the whole `port_mappings` collection; entries are identified by `scheme` and `host`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_proxy_property.md
+++ b/docs/tasks/dokku_proxy_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_proxy_toggle.md
+++ b/docs/tasks/dokku_proxy_toggle.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ps_property.md
+++ b/docs/tasks/dokku_ps_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ps_scale.md
+++ b/docs/tasks/dokku_ps_scale.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`. Manages the whole `scale` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_registry_auth.md
+++ b/docs/tasks/dokku_registry_auth.md
@@ -12,6 +12,10 @@ Not supported - registry login credentials are write-only and cannot be read bac
 
 Not supported - registry login state has no read command, so the task plans as drift on every run.
 
+## Identity
+
+Keyed by `app`, `global`, and `server`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_registry_property.md
+++ b/docs/tasks/dokku_registry_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_resource_limit.md
+++ b/docs/tasks/dokku_resource_limit.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app` and `process_type`. Fields left empty are omitted from the address. Manages the whole `resources` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_resource_reserve.md
+++ b/docs/tasks/dokku_resource_reserve.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app` and `process_type`. Fields left empty are omitted from the address. Manages the whole `resources` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_docker_local_property.md
+++ b/docs/tasks/dokku_scheduler_docker_local_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app` and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_annotations.md
+++ b/docs/tasks/dokku_scheduler_k3s_annotations.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, `process_type`, and `resource_type`. Fields left empty are omitted from the address. Manages the whole `annotations` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_autoscaling_auth.md
+++ b/docs/tasks/dokku_scheduler_k3s_autoscaling_auth.md
@@ -12,6 +12,10 @@ Partial - trigger authentication metadata values are secrets, so they are writte
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `trigger`. Fields left empty are omitted from the address. Manages the whole `metadata` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_chart.md
+++ b/docs/tasks/dokku_scheduler_k3s_chart.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `chart`. Manages the whole `values` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_labels.md
+++ b/docs/tasks/dokku_scheduler_k3s_labels.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, `process_type`, and `resource_type`. Fields left empty are omitted from the address. Manages the whole `labels` collection; entries are identified by their key.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_profile.md
+++ b/docs/tasks/dokku_scheduler_k3s_profile.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `name`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_property.md
+++ b/docs/tasks/dokku_scheduler_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_backup.md
+++ b/docs/tasks/dokku_service_backup.md
@@ -16,6 +16,10 @@ Partial - the backup schedule, bucket, and use_iam flag are exported; the AWS cr
 
 Partial - the backup schedule and bucket are probed; the AWS credentials and the encryption passphrase have no read command and are re-applied on every run when supplied.
 
+## Identity
+
+Keyed by `service` and `name`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_create.md
+++ b/docs/tasks/dokku_service_create.md
@@ -16,6 +16,10 @@ Partial - the service and the image it is running are exported; the remaining cr
 
 Partial - the service's existence and image are probed; config_options, custom_env, memory, shm_size, the networks, and the passwords have no read command and are not drift-detected.
 
+## Identity
+
+Keyed by `service` and `name`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_expose.md
+++ b/docs/tasks/dokku_service_expose.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `service` and `name`. Fields left empty are omitted from the address. Manages the whole `ports` collection; entries are identified by value.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_link.md
+++ b/docs/tasks/dokku_service_link.md
@@ -16,6 +16,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `app`, `service`, and `name`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_property.md
+++ b/docs/tasks/dokku_service_property.md
@@ -16,6 +16,10 @@ Not supported - no datastore plugin exposes a machine-readable report of the pro
 
 Not supported - the service's existence is probed but the property value is not, so the task plans as drift on every run.
 
+## Identity
+
+Keyed by `service`, `name`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ssh_key.md
+++ b/docs/tasks/dokku_ssh_key.md
@@ -12,6 +12,10 @@ Supported.
 
 Supported.
 
+## Identity
+
+Keyed by `name`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_storage_ensure.md
+++ b/docs/tasks/dokku_storage_ensure.md
@@ -14,6 +14,10 @@ Not supported - deprecated; storage state is exported via dokku_storage_mount.
 
 Not supported - `storage:ensure-directory` has no read command, so the task plans as drift on every run.
 
+## Identity
+
+Keyed by `app`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_storage_entry.md
+++ b/docs/tasks/dokku_storage_entry.md
@@ -12,6 +12,10 @@ Supported.
 
 Partial - idempotency is keyed on the entry name; scheduler, size, and chown changes to an existing entry are not drift-detected (tracked in dokku/docket#439).
 
+## Identity
+
+Keyed by `name`.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_storage_mount.md
+++ b/docs/tasks/dokku_storage_mount.md
@@ -12,6 +12,10 @@ Supported.
 
 Partial - the mount source, container path, and volume options are probed; phases, process_type, subpath, readonly, and volume_chown apply at mount time and are not drift-detected.
 
+## Identity
+
+Keyed by `app` and `container_dir`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_traefik_property.md
+++ b/docs/tasks/dokku_traefik_property.md
@@ -12,6 +12,10 @@ Supported.
 
 Partial - the mapped properties are probed; the dynamic `dns-provider-*` family has no report key and plans as drift on every run.
 
+## Identity
+
+Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the address.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -30,8 +30,9 @@ named `lollipop`, `tasks/lollipop_task.go` would contain:
 package main
 
 type LollipopTask struct {
-  App   string `required:"true" yaml:"app" description:"Name of the app"`
-  State State  `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the lollipop"`
+  App     string   `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
+  Flavors []string `required:"false" identity:"collection" yaml:"flavors,omitempty" description:"Flavors to apply"`
+  State   State    `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the lollipop"`
 }
 
 func (t LollipopTask) Plan() PlanResult {
@@ -106,10 +107,46 @@ A few conventions to follow:
   `absent`". Branches reached through `planToggle`, `planProperty` and `planResource` count as your
   task's own. Declare it for the task type, not for the run - a probe that fails on a particular
   server is a `PlanWarning`, not a `ProbeUnsupported` task.
+- Every task must tag the fields that identify the resource it manages with `identity:"key"`. See
+  [declaring identity](#declaring-identity) below; a coverage test fails the build if a task ships
+  without one.
 - When a task has conditional or semantic input rules that a `required:"true"` tag cannot express -
   a list that must be non-empty only when `state: present`, mutually-exclusive fields, an enum, a
   per-item requirement on a slice field - put them in the optional `Validate() error` method (the
   `InputValidator` interface) and call it as the first line of `Plan()`. See below.
+
+## Declaring identity
+
+Two field tags say what a task addresses on the server. Nothing else in the struct does: a task's
+`required:"true"` fields describe what a recipe must supply, which is a different question.
+
+- `identity:"key"` marks a field that decides *which* resource the task manages. Declaration order
+  is key order.
+- `identity:"collection"` marks a collection the task manages wholesale. Item identity is inferred
+  from the type: the element value for a `[]string`, the map key for a map, and the element struct's
+  own `identity:"key"` fields for a slice of structs (see `PortMapping` and `HttpAuthUser`).
+
+The declaration drives three things: the **Identity** section the generator renders on the task's
+page, the name an unnamed task receives in the output and the
+[`--json` stream](task-envelope.md#names-and-resource-addresses), and what
+`docket export --resource` can select.
+
+Three rules decide what is a key, and none of them is "the required fields":
+
+- **The desired state is never a key.** `state:` says what you want done to the resource, not which
+  resource it is. Including it would rename a task when its state changed, and would give
+  `dokku_domains` four addresses for one app's domain list.
+- **A required field can be a payload rather than an address.** `dokku_git_from_image`'s `image` is
+  `required:"true"`; the task keys on `app`, because an app has one deploy source.
+- **A key need not be required.** `dokku_certs` and `dokku_domains` have no `required:"true"` field
+  at all - they key on the mutually exclusive `app` / `global` pair. An empty key is omitted from
+  the address, which is what makes the two scopes render differently.
+
+A field must never be both `identity:"key"` and `sensitive:"true"`. An identity key is rendered into
+the task name, and `--list-tasks` does not mask - `TestIdentityKeysAreNeverSensitive` enforces this.
+
+Leave a collection untagged when it is an *attribute* of the resource rather than the set of items
+the task manages: `dokku_storage_mount`'s `phases` narrows one mount, it is not a set of mounts.
 
 ## Validating inputs
 

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -256,6 +256,58 @@ func probeSupportSection(task tasks.Task) string {
 	return "## Probe support\n\n" + line + "."
 }
 
+// identitySection renders the Identity section, naming the fields that select
+// the resource the task manages and, where the task owns a collection, what
+// identifies one entry in it. Every task declares at least one identity key;
+// the section is omitted only if a task declares none, which the identity
+// coverage test prevents.
+//
+// The address form is explained once in docs/task-envelope.md rather than
+// repeated on 73 pages; what a reader needs here is which fields go into it.
+func identitySection(task tasks.Task) string {
+	keys := tasks.IdentityKeyNames(task)
+	if len(keys) == 0 {
+		return ""
+	}
+
+	line := "Keyed by " + joinCodeNames(keys) + "."
+	if len(keys) > 1 {
+		line += " Fields left empty are omitted from the address."
+	}
+	for _, collection := range tasks.TaskIdentityCollections(task) {
+		line += fmt.Sprintf(" Manages the whole `%s` collection", collection.YAMLName)
+		switch collection.Item {
+		case tasks.ItemIdentityMapKey:
+			line += "; entries are identified by their key."
+		case tasks.ItemIdentityFields:
+			if len(collection.ItemKeys) > 0 {
+				line += "; entries are identified by " + joinCodeNames(collection.ItemKeys) + "."
+			} else {
+				line += "."
+			}
+		default:
+			line += "; entries are identified by value."
+		}
+	}
+	return "## Identity\n\n" + line
+}
+
+// joinCodeNames renders a list of field names as backticked, comma-separated
+// prose with a trailing "and".
+func joinCodeNames(names []string) string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = "`" + name + "`"
+	}
+	switch len(quoted) {
+	case 1:
+		return quoted[0]
+	case 2:
+		return quoted[0] + " and " + quoted[1]
+	}
+	return strings.Join(quoted[:len(quoted)-1], ", ") + ", and " + quoted[len(quoted)-1]
+}
+
 // deprecationSection renders the Deprecated admonition for a task that
 // implements DeprecationDocer. The notice sits between the Synopsis and
 // the Requirements/Parameters sections so the reader sees it before
@@ -332,6 +384,9 @@ func renderPage(taskName string, task tasks.Task, examples []tasks.Doc) string {
 	}
 	if ps := probeSupportSection(task); ps != "" {
 		sections = append(sections, ps)
+	}
+	if id := identitySection(task); id != "" {
+		sections = append(sections, id)
 	}
 	if pt := parametersSection(buildParams(rt)); pt != "" {
 		sections = append(sections, strings.TrimRight(pt, "\n"))

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -10,10 +10,10 @@ import (
 // AclAppTask manages the dokku-acl access list for a dokku application
 type AclAppTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Users is the list of users to add or remove from the ACL
-	Users []string `required:"false" yaml:"users" description:"List of users to add or remove from the ACL"`
+	Users []string `required:"false" identity:"collection" yaml:"users" description:"List of users to add or remove from the ACL"`
 
 	// State is the desired state of the ACL entries
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ACL entries"`

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -11,13 +11,13 @@ import (
 // AclServiceTask manages the dokku-acl access list for a dokku service
 type AclServiceTask struct {
 	// Service is the name of the service instance
-	Service string `required:"true" yaml:"service" description:"Name of the service instance"`
+	Service string `required:"true" identity:"key" yaml:"service" description:"Name of the service instance"`
 
 	// Type is the type of service (e.g. redis, postgres)
-	Type string `required:"true" yaml:"type" description:"Type of service (e.g. redis, postgres)"`
+	Type string `required:"true" identity:"key" yaml:"type" description:"Type of service (e.g. redis, postgres)"`
 
 	// Users is the list of users to add or remove from the ACL
-	Users []string `required:"false" yaml:"users" description:"List of users to add or remove from the ACL"`
+	Users []string `required:"false" identity:"collection" yaml:"users" description:"List of users to add or remove from the ACL"`
 
 	// State is the desired state of the ACL entries
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ACL entries"`

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -9,7 +9,7 @@ import (
 // AppCloneTask clones an existing dokku app to a new app
 type AppCloneTask struct {
 	// App is the name of the new (target) app
-	App string `required:"true" yaml:"app" description:"Name of the new (target) app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the new (target) app"`
 
 	// SourceApp is the name of the existing app to clone from
 	SourceApp string `required:"true" yaml:"source_app" description:"Name of the existing app to clone from"`

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // AppJsonPropertyTask manages the app.json configuration for a given dokku application
 type AppJsonPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the app.json configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the app.json configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the app.json configuration should be applied globally"`
 
 	// Property is the name of the app.json property to set
-	Property string `required:"true" yaml:"property" description:"Name of the app.json property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the app.json property to set"`
 
 	// Value is the value to set for the app.json property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the app.json property"`

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -9,7 +9,7 @@ import (
 // AppLockTask locks or unlocks a dokku application from deployment
 type AppLockTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// State is the desired lock state
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired lock state"`

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -7,7 +7,7 @@ import (
 // AppTask creates or destroys an app
 type AppTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// State is the state of the app
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"State of the app"`

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // AppsPropertyTask manages the apps plugin configuration for a given dokku application or globally
 type AppsPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the apps property should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the apps property should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the apps property should be applied globally"`
 
 	// Property is the name of the apps property to set
-	Property string `required:"true" yaml:"property" description:"Name of the apps property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the apps property to set"`
 
 	// Value is the value to set for the apps property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the apps property"`

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuilderDockerfilePropertyTask manages the builder-dockerfile configuration for a given dokku application
 type BuilderDockerfilePropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-dockerfile configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-dockerfile configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-dockerfile configuration should be applied globally"`
 
 	// Property is the name of the builder-dockerfile property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builder-dockerfile property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-dockerfile property to set"`
 
 	// Value is the value to set for the builder-dockerfile property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-dockerfile property"`

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuilderHerokuishPropertyTask manages the builder-herokuish configuration for a given dokku application
 type BuilderHerokuishPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-herokuish configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-herokuish configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-herokuish configuration should be applied globally"`
 
 	// Property is the name of the builder-herokuish property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builder-herokuish property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-herokuish property to set"`
 
 	// Value is the value to set for the builder-herokuish property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-herokuish property"`

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuilderLambdaPropertyTask manages the builder-lambda configuration for a given dokku application
 type BuilderLambdaPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-lambda configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-lambda configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-lambda configuration should be applied globally"`
 
 	// Property is the name of the builder-lambda property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builder-lambda property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-lambda property to set"`
 
 	// Value is the value to set for the builder-lambda property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-lambda property"`

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuilderNixpacksPropertyTask manages the builder-nixpacks configuration for a given dokku application
 type BuilderNixpacksPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-nixpacks configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-nixpacks configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-nixpacks configuration should be applied globally"`
 
 	// Property is the name of the builder-nixpacks property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builder-nixpacks property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-nixpacks property to set"`
 
 	// Value is the value to set for the builder-nixpacks property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-nixpacks property"`

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuilderPackPropertyTask manages the builder-pack configuration for a given dokku application
 type BuilderPackPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-pack configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-pack configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-pack configuration should be applied globally"`
 
 	// Property is the name of the builder-pack property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builder-pack property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-pack property to set"`
 
 	// Value is the value to set for the builder-pack property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-pack property"`

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuilderTask manages the builder configuration for a given dokku application
 type BuilderPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder configuration should be applied globally"`
 
 	// Property is the name of the builder property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builder property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder property to set"`
 
 	// Value is the value to set for the builder property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder property"`

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuilderRailpackPropertyTask manages the builder-railpack configuration for a given dokku application
 type BuilderRailpackPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-railpack configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-railpack configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-railpack configuration should be applied globally"`
 
 	// Property is the name of the builder-railpack property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builder-railpack property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-railpack property to set"`
 
 	// Value is the value to set for the builder-railpack property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-railpack property"`

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuildpacksPropertyTask manages the buildpacks configuration for a given dokku application
 type BuildpacksPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the buildpacks configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the buildpacks configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the buildpacks configuration should be applied globally"`
 
 	// Property is the name of the buildpacks property to set
-	Property string `required:"true" yaml:"property" description:"Name of the buildpacks property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the buildpacks property to set"`
 
 	// Value is the value to set for the buildpacks property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the buildpacks property"`

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -13,10 +13,10 @@ import (
 // BuildpacksTask manages the buildpacks for a given dokku application
 type BuildpacksTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Buildpacks is the list of buildpack URLs
-	Buildpacks []string `required:"false" yaml:"buildpacks" description:"List of buildpack URLs"`
+	Buildpacks []string `required:"false" identity:"collection" yaml:"buildpacks" description:"List of buildpack URLs"`
 
 	// State is the desired state of the buildpacks
 	State State `required:"false" yaml:"state" default:"present" options:"present,absent" description:"Desired state of the buildpacks"`

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // BuildsPropertyTask manages the builds configuration for a given dokku application
 type BuildsPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builds configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builds configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builds configuration should be applied globally"`
 
 	// Property is the name of the builds property to set
-	Property string `required:"true" yaml:"property" description:"Name of the builds property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builds property to set"`
 
 	// Value is the value to set for the builds property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builds property"`

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // CaddyPropertyTask manages the caddy configuration for a given dokku application
 type CaddyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the caddy configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the caddy configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the caddy configuration should be applied globally"`
 
 	// Property is the name of the caddy property to set
-	Property string `required:"true" yaml:"property" description:"Name of the caddy property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the caddy property to set"`
 
 	// Value is the value to set for the caddy property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the caddy property"`

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -13,11 +13,11 @@ import (
 // CertsTask manages SSL certificates for a dokku app or globally
 type CertsTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the certificate should be applied globally
 	// via the dokku-global-cert plugin
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the certificate should be applied globally via the dokku-global-cert plugin"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the certificate should be applied globally via the dokku-global-cert plugin"`
 
 	// Cert is the path on the dokku server to the SSL certificate file
 	Cert string `required:"false" sensitive:"true" yaml:"cert,omitempty" description:"Path on the dokku server to the SSL certificate file. Mutually exclusive with cert_content."`

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // ChecksPropertyTask manages the checks configuration for a given dokku application
 type ChecksPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the checks configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the checks configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the checks configuration should be applied globally"`
 
 	// Property is the name of the checks property to set
-	Property string `required:"true" yaml:"property" description:"Name of the checks property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the checks property to set"`
 
 	// Value is the value to set for the checks property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the checks property"`

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -46,7 +46,7 @@ func (t ChecksToggleTask) ExportApp(app string) ([]interface{}, error) {
 // ChecksToggleTask enables or disables the checks plugin for a given dokku application
 type ChecksToggleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// State is the desired state of the checks plugin
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the checks plugin"`

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -12,7 +12,7 @@ import (
 // ConfigTask manages the configuration for a given dokku application
 type ConfigTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Restart is a flag indicating if the app should be restarted. It is a
 	// *bool so an explicit `restart: false` is distinguishable from an omitted
@@ -22,7 +22,7 @@ type ConfigTask struct {
 	Restart *bool `yaml:"restart,omitempty" default:"true" description:"Flag indicating if the app should be restarted"`
 
 	// Config is a map of configuration key-value pairs
-	Config map[string]string `yaml:"config" description:"Map of configuration key-value pairs"`
+	Config map[string]string `identity:"collection" yaml:"config" description:"Map of configuration key-value pairs"`
 
 	// State is the desired state of the configuration
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the configuration"`

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // CronPropertyTask manages the cron configuration for a given dokku application
 type CronPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the cron configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the cron configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the cron configuration should be applied globally"`
 
 	// Property is the name of the cron property to set
-	Property string `required:"true" yaml:"property" description:"Name of the cron property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the cron property to set"`
 
 	// Value is the value to set for the cron property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the cron property"`

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -19,18 +19,18 @@ const defaultDockerOptionsProcessType = "_default_"
 // DockerOptionsTask manages docker-options for a given dokku application
 type DockerOptionsTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Phase is the deployment phase the option applies to
-	Phase string `required:"true" yaml:"phase" options:"build,deploy,run" description:"Deployment phase the option applies to"`
+	Phase string `required:"true" identity:"key" yaml:"phase" options:"build,deploy,run" description:"Deployment phase the option applies to"`
 
 	// ProcessType scopes the option to a specific Procfile process type.
 	// Only valid for the deploy phase; empty applies to the default scope
 	// (every container in the app).
-	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type the option is scoped to (deploy phase only). Empty applies to the default scope (every container)."`
+	ProcessType string `required:"false" identity:"key" yaml:"process_type,omitempty" description:"Process type the option is scoped to (deploy phase only). Empty applies to the default scope (every container)."`
 
 	// Option is the docker option string (e.g. "-v /var/run/docker.sock:/var/run/docker.sock")
-	Option string `required:"true" yaml:"option" description:"Docker option string (e.g. '-v /var/run/docker.sock:/var/run/docker.sock')"`
+	Option string `required:"true" identity:"key" yaml:"option" description:"Docker option string (e.g. '-v /var/run/docker.sock:/var/run/docker.sock')"`
 
 	// State is the desired state of the docker option
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the docker option"`

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -10,13 +10,13 @@ import (
 // DomainsTask manages the domains for a given dokku application or globally
 type DomainsTask struct {
 	// App is the name of the app
-	App string `required:"false" yaml:"app" description:"Name of the app"`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Global is a flag indicating if the domains should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the domains should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the domains should be applied globally"`
 
 	// Domains is the list of domain names
-	Domains []string `required:"false" yaml:"domains,omitempty" description:"List of domain names; omit for state 'clear'"`
+	Domains []string `required:"false" identity:"collection" yaml:"domains,omitempty" description:"List of domain names; omit for state 'clear'"`
 
 	// State is the desired state of the domains
 	State State `required:"false" yaml:"state" default:"present" options:"present,absent,set,clear" description:"Desired state of the domains"`

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -35,7 +35,7 @@ func (t DomainsToggleTask) ExportApp(app string) ([]interface{}, error) {
 // DomainsToggleTask enables or disables the domains plugin for a given dokku application
 type DomainsToggleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// State is the desired state of the domains plugin
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the domains plugin"`

--- a/tasks/envelope.go
+++ b/tasks/envelope.go
@@ -17,9 +17,15 @@ import (
 // the keys today so #210 does not need to revisit the cap.
 type TaskEnvelope struct {
 	// Name is the user-supplied human label for the task. Auto-generated
-	// when the entry omits a name (see GetTasks). Loop-expansions append
-	// an `(item=<value>)` suffix to keep ordered-map keys unique.
+	// when the entry omits a name (see GetTasks): a leaf task is named after
+	// the resource it addresses (`dokku_config[app=api]`), a group after its
+	// position (`group #3`).
 	Name string
+
+	// NameGenerated records that Name was derived rather than written in the
+	// recipe. dedupeGeneratedNames renames only these, so a generated name
+	// can never displace one a recipe author wrote.
+	NameGenerated bool
 
 	// Tags is the list of tag strings on the entry. The --tags / --skip-tags
 	// CLI flags filter against this set.
@@ -244,6 +250,22 @@ func EnvelopeContainsName(env *TaskEnvelope, target string) bool {
 	return false
 }
 
+// walkEnvelopes visits every envelope reachable from envs in source order,
+// descending into block / rescue / always children. Group children live only
+// on their parent envelope, so any pass that has to see the whole play - name
+// deduplication, name collection - has to come through here.
+func walkEnvelopes(envs []*TaskEnvelope, visit func(env *TaskEnvelope)) {
+	for _, env := range envs {
+		if env == nil {
+			continue
+		}
+		visit(env)
+		walkEnvelopes(env.Block, visit)
+		walkEnvelopes(env.Rescue, visit)
+		walkEnvelopes(env.Always, visit)
+	}
+}
+
 // CollectEnvelopeNames returns every leaf and group envelope name
 // reachable from envs, walking block / rescue / always recursively.
 // Names appear in source order and are de-duplicated. Used by the
@@ -252,27 +274,12 @@ func EnvelopeContainsName(env *TaskEnvelope, target string) bool {
 func CollectEnvelopeNames(envs []*TaskEnvelope) []string {
 	seen := map[string]bool{}
 	var out []string
-	var walk func(env *TaskEnvelope)
-	walk = func(env *TaskEnvelope) {
-		if env == nil {
+	walkEnvelopes(envs, func(env *TaskEnvelope) {
+		if env.Name == "" || seen[env.Name] {
 			return
 		}
-		if env.Name != "" && !seen[env.Name] {
-			seen[env.Name] = true
-			out = append(out, env.Name)
-		}
-		for _, child := range env.Block {
-			walk(child)
-		}
-		for _, child := range env.Rescue {
-			walk(child)
-		}
-		for _, child := range env.Always {
-			walk(child)
-		}
-	}
-	for _, env := range envs {
-		walk(env)
-	}
+		seen[env.Name] = true
+		out = append(out, env.Name)
+	})
 	return out
 }

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -180,6 +180,11 @@ type ExportOptions struct {
 	// Apps restricts the export to these app names; empty means every app.
 	Apps []string
 
+	// Resources restricts the export to specific resource addresses. Empty
+	// means every resource. Mutually exclusive with Apps: an address already
+	// says which app it belongs to.
+	Resources []ResourceSelector
+
 	// Redact replaces sensitive values with placeholders instead of the real
 	// values (in the vars-file for file mode, in place for stdout mode). A
 	// value whose task would not validate when blank is lifted into a required
@@ -200,6 +205,13 @@ type ExportReport struct {
 	// server. The export still proceeds for the apps that do exist; the command
 	// surfaces these and exits non-zero so a typo is not silently dropped (#346).
 	MissingApps []string
+
+	// MissingResources lists --resource addresses that matched nothing on the
+	// server, in the order they were given. Same contract as MissingApps: the
+	// export emits what it did find and the command exits non-zero, so an
+	// address that names a resource the server does not have is not mistaken
+	// for one that exports to nothing.
+	MissingResources []string
 }
 
 // ExportResult is the outcome of ExportRecipe: the assembled recipe (as a list
@@ -210,6 +222,10 @@ type ExportResult struct {
 	Report ExportReport
 
 	usedVarNames map[string]bool
+
+	// filter narrows emission to the --resource addresses. nil for an
+	// unrestricted export, where every check it performs answers "keep".
+	filter *resourceFilter
 }
 
 // ExportRecipe reads the live Dokku server (via the current subprocess host)
@@ -220,22 +236,44 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 	res := &ExportResult{
 		Vars:         map[string]string{},
 		usedVarNames: map[string]bool{},
+		filter:       newResourceFilter(opts.Resources),
 	}
+	inApp, inGlobal := exportOrderSets()
 
 	// Global resources come first, in a leading "global" play. Skipped when
-	// the export is narrowed to specific apps with --app.
-	if len(opts.Apps) == 0 {
+	// the export is narrowed to specific apps with --app, and when every
+	// --resource address is app-scoped.
+	if len(opts.Apps) == 0 && res.filter.wantsGlobalScope(inGlobal) {
 		if global := res.exportGlobalPlay(opts); global != nil {
 			res.plays = append(res.plays, global)
 		}
+	}
+
+	// An address that pins `app=` narrows the run the same way --app does, so
+	// an export of one app's config does not enumerate every app on the
+	// server. A run whose addresses are all global-scoped wants no app plays
+	// at all, which is distinct from "no restriction".
+	wantApps := opts.Apps
+	selectedApps, restricted := res.filter.appNames(inApp)
+	if restricted {
+		if len(selectedApps) == 0 {
+			res.Report.MissingResources = res.filter.unmatchedAddresses()
+			return res, nil
+		}
+		wantApps = selectedApps
 	}
 
 	apps, err := listApps()
 	if err != nil {
 		return nil, err
 	}
-	res.Report.MissingApps = missingApps(apps, opts.Apps)
-	apps = filterApps(apps, opts.Apps)
+	// A resource-driven run derives its app list from the addresses, so an app
+	// that does not exist is reported as the address the user actually typed
+	// rather than as an app name they never wrote.
+	if !restricted {
+		res.Report.MissingApps = missingApps(apps, wantApps)
+	}
+	apps = filterApps(apps, wantApps)
 	sort.Strings(apps)
 
 	for _, app := range apps {
@@ -244,6 +282,8 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 			res.plays = append(res.plays, play)
 		}
 	}
+
+	res.Report.MissingResources = res.filter.unmatchedAddresses()
 
 	return res, nil
 }
@@ -255,6 +295,9 @@ func (res *ExportResult) exportGlobalPlay(opts ExportOptions) map[string]interfa
 	var inputs []map[string]interface{}
 
 	for _, typeKey := range globalExportOrder {
+		if !res.filter.wantsType(typeKey) {
+			continue
+		}
 		proto, ok := RegisteredTasks[typeKey]
 		if !ok {
 			continue
@@ -270,6 +313,14 @@ func (res *ExportResult) exportGlobalPlay(opts ExportOptions) map[string]interfa
 			continue
 		}
 		for _, body := range bodies {
+			keep, err := res.filter.keepBody(typeKey, body)
+			if err != nil {
+				res.Report.Warnings = append(res.Report.Warnings,
+					fmt.Sprintf("global: %s: %v", typeKey, err))
+			}
+			if !keep {
+				continue
+			}
 			body, ins := res.processBody("global", body, opts)
 			taskList = append(taskList, map[string]interface{}{typeKey: body})
 			inputs = append(inputs, ins...)
@@ -295,6 +346,9 @@ func (res *ExportResult) exportAppPlay(app string, opts ExportOptions) map[strin
 	var inputs []map[string]interface{}
 
 	for _, typeKey := range appExportOrder {
+		if !res.filter.wantsType(typeKey) {
+			continue
+		}
 		proto, ok := RegisteredTasks[typeKey]
 		if !ok {
 			continue
@@ -319,6 +373,14 @@ func (res *ExportResult) exportAppPlay(app string, opts ExportOptions) map[strin
 			continue
 		}
 		for _, body := range bodies {
+			keep, err := res.filter.keepBody(typeKey, body)
+			if err != nil {
+				res.Report.Warnings = append(res.Report.Warnings,
+					fmt.Sprintf("%s: %s: %v", app, typeKey, err))
+			}
+			if !keep {
+				continue
+			}
 			body, ins := res.processBody(app, body, opts)
 			taskList = append(taskList, map[string]interface{}{typeKey: body})
 			inputs = append(inputs, ins...)

--- a/tasks/export_resource.go
+++ b/tasks/export_resource.go
@@ -1,0 +1,216 @@
+package tasks
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ResourceSelector is one parsed `docket export --resource` address: which
+// task type to export, and which of that type's identity keys the address
+// pinned. An empty Keys map means "every resource of this type".
+type ResourceSelector struct {
+	// Address is the address as the user wrote it, for diagnostics.
+	Address string
+
+	// TypeKey is the registered task name, e.g. "dokku_config".
+	TypeKey string
+
+	// Keys are the identity key values the address pinned, by yaml name.
+	Keys map[string]string
+}
+
+// ParseResourceSelectors parses and validates every --resource value.
+//
+// Validation happens here, before the export contacts the server, so a typo in
+// an address fails immediately rather than after an SSH round trip. Three
+// things are checked: the type resolves to a registered task, that task is
+// actually reachable from ExportRecipe, and every key the address names is one
+// the task declares.
+func ParseResourceSelectors(addresses []string) ([]ResourceSelector, error) {
+	inApp, inGlobal := exportOrderSets()
+
+	out := make([]ResourceSelector, 0, len(addresses))
+	for _, address := range addresses {
+		typeKey, keys, err := ParseIdentityAddress(address)
+		if err != nil {
+			return nil, err
+		}
+
+		task, ok := RegisteredTasks[typeKey]
+		if !ok {
+			msg := fmt.Sprintf("unknown task type %q in resource address %q", typeKey, address)
+			if near := nearestEnvelopeOrTaskKey(typeKey); near != "" {
+				msg += fmt.Sprintf(" (did you mean %q?)", near)
+			}
+			return nil, fmt.Errorf("%s", msg)
+		}
+
+		if !inApp[typeKey] && !inGlobal[typeKey] {
+			reason := ""
+			if support, declared := TaskExportSupport(task); declared && support.Caveat != "" {
+				reason = ": " + support.Caveat
+			}
+			return nil, fmt.Errorf("task type %q cannot be exported%s", typeKey, reason)
+		}
+
+		declared := map[string]bool{}
+		for _, key := range TaskIdentity(task) {
+			declared[key.YAMLName] = true
+		}
+		for name := range keys {
+			if !declared[name] {
+				return nil, fmt.Errorf("resource address %q: %q is not an identity key of %s (keys: %s)",
+					address, name, typeKey, strings.Join(sortedIdentityKeyNames(task), ", "))
+			}
+		}
+
+		out = append(out, ResourceSelector{Address: address, TypeKey: typeKey, Keys: keys})
+	}
+	return out, nil
+}
+
+// exportOrderSets returns the app and global export order lists as lookup
+// sets.
+func exportOrderSets() (app, global map[string]bool) {
+	app = make(map[string]bool, len(appExportOrder))
+	global = make(map[string]bool, len(globalExportOrder))
+	for _, key := range appExportOrder {
+		app[key] = true
+	}
+	for _, key := range globalExportOrder {
+		global[key] = true
+	}
+	return app, global
+}
+
+// resourceFilter narrows an export run to the selected addresses. A nil
+// filter selects everything, which is what an unrestricted export uses.
+type resourceFilter struct {
+	selectors []ResourceSelector
+	byType    map[string][]int
+	matched   []bool
+}
+
+// newResourceFilter builds a filter from the parsed selectors, or nil when
+// there are none.
+func newResourceFilter(selectors []ResourceSelector) *resourceFilter {
+	if len(selectors) == 0 {
+		return nil
+	}
+	f := &resourceFilter{
+		selectors: selectors,
+		byType:    make(map[string][]int, len(selectors)),
+		matched:   make([]bool, len(selectors)),
+	}
+	for i, sel := range selectors {
+		f.byType[sel.TypeKey] = append(f.byType[sel.TypeKey], i)
+	}
+	return f
+}
+
+// wantsType reports whether any selector asks for this task type, so the
+// export can skip running an exporter nothing selected.
+func (f *resourceFilter) wantsType(typeKey string) bool {
+	if f == nil {
+		return true
+	}
+	return len(f.byType[typeKey]) > 0
+}
+
+// keepBody reports whether an exported task body matches a selector, and
+// records the match so an address that resolved to nothing can be reported.
+//
+// The body is matched, not the request: an exporter returns one body per
+// resource it found, each already carrying the identity field values the
+// server reported, so `IdentityMatches` answers "is this the resource the
+// address named" directly.
+//
+// Every exporter emits task struct values today. The error return covers a
+// future one that does not: dropping such a body silently would look exactly
+// like "the server does not have this resource", so the caller turns it into a
+// warning instead.
+func (f *resourceFilter) keepBody(typeKey string, body interface{}) (bool, error) {
+	if f == nil {
+		return true, nil
+	}
+	task, ok := body.(Task)
+	if !ok {
+		return false, fmt.Errorf("exported body of type %T does not implement Task, so --resource cannot match it", body)
+	}
+	keep := false
+	for _, i := range f.byType[typeKey] {
+		if IdentityMatches(task, f.selectors[i].Keys) {
+			f.matched[i] = true
+			keep = true
+		}
+	}
+	return keep, nil
+}
+
+// wantsGlobalScope reports whether the leading global play should run at all.
+// A selector pinned to an app never wants it, even when its task type also
+// has a global form.
+func (f *resourceFilter) wantsGlobalScope(inGlobal map[string]bool) bool {
+	if f == nil {
+		return true
+	}
+	for _, sel := range f.selectors {
+		if !inGlobal[sel.TypeKey] {
+			continue
+		}
+		if _, pinned := sel.Keys["app"]; pinned {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// appNames returns the app names the selectors pin, and whether that set is a
+// restriction at all. An app-scoped selector that names no app - `dokku_config`
+// on its own - means every app, so no restriction applies.
+func (f *resourceFilter) appNames(inApp map[string]bool) ([]string, bool) {
+	if f == nil {
+		return nil, false
+	}
+	seen := map[string]bool{}
+	for _, sel := range f.selectors {
+		if !inApp[sel.TypeKey] {
+			continue
+		}
+		app, pinned := sel.Keys["app"]
+		if !pinned || app == "" {
+			// One unpinned app-scoped selector widens the run to every app.
+			if _, global := sel.Keys["global"]; global {
+				continue
+			}
+			return nil, false
+		}
+		seen[app] = true
+	}
+	if len(seen) == 0 {
+		return nil, true
+	}
+	out := make([]string, 0, len(seen))
+	for app := range seen {
+		out = append(out, app)
+	}
+	sort.Strings(out)
+	return out, true
+}
+
+// unmatchedAddresses returns the addresses that selected nothing, in the
+// order they were given.
+func (f *resourceFilter) unmatchedAddresses() []string {
+	if f == nil {
+		return nil
+	}
+	var out []string
+	for i, sel := range f.selectors {
+		if !f.matched[i] {
+			out = append(out, sel.Address)
+		}
+	}
+	return out
+}

--- a/tasks/export_resource_test.go
+++ b/tasks/export_resource_test.go
@@ -1,0 +1,215 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// exportResource runs ExportRecipe restricted to the given addresses against
+// the shared fixture and returns the marshalled recipe plus the report.
+func exportResource(t *testing.T, addresses ...string) (string, ExportReport) {
+	t.Helper()
+	selectors, err := ParseResourceSelectors(addresses)
+	if err != nil {
+		t.Fatalf("ParseResourceSelectors(%v): %v", addresses, err)
+	}
+	res, err := ExportRecipe(ExportOptions{Resources: selectors, Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	return string(recipe), res.Report
+}
+
+// TestExportResourceSelectsOneResource covers the headline case the issue asks
+// for: reading back a single resource instead of a whole app play.
+func TestExportResourceSelectsOneResource(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	out, report := exportResource(t, "dokku_config[app=app-one]")
+
+	if !strings.Contains(out, "dokku_config") {
+		t.Errorf("expected the addressed task in the recipe; got:\n%s", out)
+	}
+	if strings.Contains(out, "dokku_domains") {
+		t.Errorf("expected only the addressed task type; got:\n%s", out)
+	}
+	if strings.Contains(out, "app-two") {
+		t.Errorf("expected only the addressed app; got:\n%s", out)
+	}
+	if len(report.MissingResources) > 0 {
+		t.Errorf("unexpected unmatched addresses: %v", report.MissingResources)
+	}
+}
+
+// TestExportResourceBareTypeSelectsEveryApp covers the wildcard form: an
+// address with no keys means every resource of that type, wherever it lives.
+func TestExportResourceBareTypeSelectsEveryApp(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	out, report := exportResource(t, "dokku_domains")
+
+	if !strings.Contains(out, "dokku_domains") {
+		t.Errorf("expected the addressed task type; got:\n%s", out)
+	}
+	if strings.Contains(out, "dokku_config") {
+		t.Errorf("expected only the addressed task type; got:\n%s", out)
+	}
+	if !strings.Contains(out, "app-one") {
+		t.Errorf("expected app-one's domains; got:\n%s", out)
+	}
+	if len(report.MissingResources) > 0 {
+		t.Errorf("unexpected unmatched addresses: %v", report.MissingResources)
+	}
+}
+
+// TestExportResourceCombinesAddresses covers several addresses in one run,
+// including two apps, and asserts each contributes its own play.
+func TestExportResourceCombinesAddresses(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	out, _ := exportResource(t, "dokku_config[app=app-one]", "dokku_domains[app=app-one]")
+
+	for _, want := range []string{"dokku_config", "dokku_domains", "app-one"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the recipe; got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "app-two") {
+		t.Errorf("app-two was not addressed; got:\n%s", out)
+	}
+}
+
+// TestExportResourceReportsUnmatchedAddress asserts an address the server has
+// nothing for is reported rather than silently exporting nothing, the same
+// contract --app has for a nonexistent app (#346).
+func TestExportResourceReportsUnmatchedAddress(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	_, report := exportResource(t, "dokku_config[app=app-one]", "dokku_domains[app=app-two]")
+
+	if len(report.MissingResources) != 1 || report.MissingResources[0] != "dokku_domains[app=app-two]" {
+		t.Errorf("MissingResources = %v, want [dokku_domains[app=app-two]]", report.MissingResources)
+	}
+}
+
+// TestExportResourceGlobalScope asserts a global-scoped address emits the
+// leading global play and no app plays at all - distinct from "no app
+// restriction", which would enumerate every app.
+func TestExportResourceGlobalScope(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "app-one",
+		"--quiet plugin:list --format json": `[
+			{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"","branch":""}
+		]`,
+	}))()
+
+	out, report := exportResource(t, "dokku_plugin[name=redis]")
+
+	if !strings.Contains(out, "dokku_plugin") {
+		t.Errorf("expected the global task; got:\n%s", out)
+	}
+	if strings.Contains(out, "app-one") {
+		t.Errorf("a global-scoped address must not emit app plays; got:\n%s", out)
+	}
+	if len(report.MissingResources) > 0 {
+		t.Errorf("unexpected unmatched addresses: %v", report.MissingResources)
+	}
+}
+
+// TestParseResourceSelectorsRejectsBadAddresses covers the validation that
+// runs before the export contacts the server, so a typo fails instantly.
+func TestParseResourceSelectorsRejectsBadAddresses(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		address string
+		wantErr string
+	}{
+		{
+			name:    "unknown task type suggests a near miss",
+			address: "dokku_confg[app=api]",
+			wantErr: `did you mean "dokku_config"`,
+		},
+		{
+			name:    "a task no exporter reaches",
+			address: "dokku_git_auth[host=github.com]",
+			wantErr: "cannot be exported",
+		},
+		{
+			name:    "a key the task does not declare",
+			address: "dokku_config[application=api]",
+			wantErr: "is not an identity key of dokku_config",
+		},
+		{
+			name:    "malformed address",
+			address: "dokku_config[app]",
+			wantErr: "is not key=value",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseResourceSelectors([]string{tt.address})
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got none", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestParseResourceSelectorsAcceptsValidAddresses is the positive half: every
+// exportable form parses, including a bare type key and a global scope.
+func TestParseResourceSelectorsAcceptsValidAddresses(t *testing.T) {
+	selectors, err := ParseResourceSelectors([]string{
+		"dokku_config",
+		"dokku_config[app=api]",
+		"dokku_apps_property[global=true,property=disable-autocreation]",
+	})
+	if err != nil {
+		t.Fatalf("ParseResourceSelectors: %v", err)
+	}
+	if len(selectors) != 3 {
+		t.Fatalf("got %d selectors, want 3", len(selectors))
+	}
+	if len(selectors[0].Keys) != 0 {
+		t.Errorf("a bare type key should pin no keys, got %v", selectors[0].Keys)
+	}
+	if selectors[2].Keys["global"] != "true" {
+		t.Errorf("global key = %q, want true", selectors[2].Keys["global"])
+	}
+}
+
+// TestExportedRecipeLoadsWithoutNameCollisions closes the loop on the change:
+// export emits recipes with no `name:` on any task, so every task in one is
+// auto-named. If two tasks in a play resolved to the same generated name and
+// nothing disambiguated them, the loader would reject its own export.
+func TestExportedRecipeLoadsWithoutNameCollisions(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	res, err := ExportRecipe(ExportOptions{Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+
+	plays, err := GetPlays(recipe, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("exported recipe failed to load: %v\n%s", err, recipe)
+	}
+	for _, play := range plays {
+		for _, name := range play.Tasks.Keys() {
+			if name == "" {
+				t.Errorf("play %q has an unnamed task", play.Name)
+			}
+		}
+	}
+}

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -15,7 +15,7 @@ import (
 // instead of always reporting Changed=true.
 type GitAuthTask struct {
 	// Host is the git server hostname (e.g. github.com)
-	Host string `required:"true" yaml:"host" description:"Git server hostname (e.g. github.com)"`
+	Host string `required:"true" identity:"key" yaml:"host" description:"Git server hostname (e.g. github.com)"`
 
 	// Username is the netrc username. Required when state is present.
 	Username string `required:"false" yaml:"username,omitempty" description:"Netrc username. Required when state is present."`

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -10,7 +10,7 @@ import (
 // GitFromArchiveTask deploys a git repository from an archive URL
 type GitFromArchiveTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// ArchiveURL is the URL of the archive to deploy. Tagged sensitive
 	// because URLs can embed credentials (e.g. https://user:token@host/path).

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -12,7 +12,7 @@ import (
 // GitFromImageTask deploys a git repository from a docker image
 type GitFromImageTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Image is the docker image to deploy. Tagged sensitive because image
 	// references can embed registry credentials (e.g. user:token@host/repo).

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // GitPropertyTask manages the git configuration for a given dokku application
 type GitPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the git configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the git configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the git configuration should be applied globally"`
 
 	// Property is the name of the git property to set
-	Property string `required:"true" yaml:"property" description:"Name of the git property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the git property to set"`
 
 	// Value is the value to set for the git property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the git property"`

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -12,7 +12,7 @@ import (
 // GitSyncTask syncs a git repository to a dokku application
 type GitSyncTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Remote is the git remote url to sync
 	Remote string `required:"true" yaml:"remote" description:"Git remote url to sync"`

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // HaproxyPropertyTask manages the haproxy configuration for a given dokku application
 type HaproxyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the haproxy configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the haproxy configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the haproxy configuration should be applied globally"`
 
 	// Property is the name of the haproxy property to set
-	Property string `required:"true" yaml:"property" description:"Name of the haproxy property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the haproxy property to set"`
 
 	// Value is the value to set for the haproxy property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the haproxy property"`

--- a/tasks/http_auth_allowed_ip_task.go
+++ b/tasks/http_auth_allowed_ip_task.go
@@ -14,10 +14,10 @@ import (
 // auth for a dokku application
 type HttpAuthAllowedIpTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// AllowedIps is the list of IP addresses to allow or remove
-	AllowedIps []string `required:"false" yaml:"allowed_ips" description:"List of IP addresses to allow or remove"`
+	AllowedIps []string `required:"false" identity:"collection" yaml:"allowed_ips" description:"List of IP addresses to allow or remove"`
 
 	// State is the desired state of the allowed IP entries
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the allowed IP entries"`

--- a/tasks/http_auth_domain_task.go
+++ b/tasks/http_auth_domain_task.go
@@ -14,10 +14,10 @@ import (
 // dokku application
 type HttpAuthDomainTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Domains is the list of domains to restrict HTTP auth to
-	Domains []string `required:"false" yaml:"domains,omitempty" description:"List of domains to restrict HTTP auth to; omit for state 'clear'"`
+	Domains []string `required:"false" identity:"collection" yaml:"domains,omitempty" description:"List of domains to restrict HTTP auth to; omit for state 'clear'"`
 
 	// State is the desired state of the HTTP auth domain entries
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent,set,clear" description:"Desired state of the HTTP auth domain entries"`

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -12,7 +12,7 @@ import (
 // HttpAuthTask manages HTTP authentication for a dokku application
 type HttpAuthTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Username is the HTTP auth username seeded when auth is enabled
 	Username string `required:"false" yaml:"username,omitempty" description:"HTTP auth username to seed when enabling; supplied together with password"`

--- a/tasks/http_auth_user_task.go
+++ b/tasks/http_auth_user_task.go
@@ -13,12 +13,12 @@ import (
 // HttpAuthUserTask manages the set of HTTP auth users for a dokku application
 type HttpAuthUserTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Users is the list of HTTP auth users to add or remove. The docs generator
 	// lists an item's field names but cannot express that password and hash are
 	// alternatives, nor that both are secret, so this description carries it.
-	Users []HttpAuthUser `required:"false" yaml:"users" description:"List of HTTP auth users to add or remove. Each item gives the credential as exactly one of password (cleartext, applied with http-auth:add-user) or hash (an htpasswd entry, applied with http-auth:import-users); both are sensitive"`
+	Users []HttpAuthUser `required:"false" identity:"collection" yaml:"users" description:"List of HTTP auth users to add or remove. Each item gives the credential as exactly one of password (cleartext, applied with http-auth:add-user) or hash (an htpasswd entry, applied with http-auth:import-users); both are sensitive"`
 
 	// UpdatePassword re-issues http-auth:add-user for users that already exist
 	// so their password converges. Cleartext passwords are not exposed in the
@@ -42,7 +42,7 @@ type HttpAuthUserTask struct {
 // the task's SensitiveValues method is what actually masks these values.
 type HttpAuthUser struct {
 	// Username is the HTTP auth username
-	Username string `required:"true" yaml:"username" description:"HTTP auth username"`
+	Username string `required:"true" identity:"key" yaml:"username" description:"HTTP auth username"`
 
 	// Password is the cleartext HTTP auth password, applied with
 	// http-auth:add-user. Mutually exclusive with Hash.

--- a/tasks/identity.go
+++ b/tasks/identity.go
@@ -1,0 +1,411 @@
+package tasks
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Identity declares what a task addresses on the server.
+//
+// Every task knows implicitly which resource it manages - dokku_config by
+// `app`, a property task by `app`-or-`global` plus `property`,
+// dokku_service_property by `service` plus `name` plus `property` - but before
+// #427 that knowledge lived only in the shape of each task's `required:"true"`
+// fields. It is declared here with two field tags:
+//
+//	identity:"key"         the field is part of what selects the resource
+//	identity:"collection"  the field is the set of items the task manages
+//	                       wholesale, and is *not* part of the key
+//
+// The tags sit on the field rather than in a method or a central table so a
+// field rename cannot silently orphan the declaration; TestIdentityTagsResolve
+// fails when one does.
+//
+// Three rules decide what is a key, and none of them is "the required fields":
+//
+//   - The desired state is never a key. `state:` says what you want done to the
+//     resource, not which resource it is, so editing it must not rename a task
+//     or change what `export --resource` selects.
+//   - A required field can be a payload rather than an address.
+//     dokku_git_from_image's `image` is `required:"true" sensitive:"true"`; the
+//     task keys on `app`, because an app has one deploy source.
+//   - A key need not be required. dokku_certs and dokku_domains have no
+//     `required:"true"` field at all - they key on the mutually exclusive
+//     `app` / `global` pair.
+//
+// For the set-valued tasks the issue singles out (dokku_domains, dokku_ports,
+// dokku_acl_app), the answer this encodes is that the collection *is* the
+// resource, not part of its key: dokku_domains addresses "the domain list of
+// this app", so it keys on `app`-or-`global` alone. Where the items themselves
+// have identity, it is declared on the element struct
+// (PortMapping.Scheme + .Host, HttpAuthUser.Username) instead of being left in
+// a comment.
+const (
+	identityTag           = "identity"
+	identityTagKey        = "key"
+	identityTagCollection = "collection"
+)
+
+// ItemIdentity classifies what identifies one item inside a collection field.
+type ItemIdentity string
+
+const (
+	// ItemIdentityValue means the element value is the item's identity, as in
+	// a `[]string` of domain names.
+	ItemIdentityValue ItemIdentity = "value"
+
+	// ItemIdentityMapKey means the map key is the item's identity, as in a
+	// `map[string]string` of config pairs.
+	ItemIdentityMapKey ItemIdentity = "map_key"
+
+	// ItemIdentityFields means the element is a struct whose own
+	// `identity:"key"` fields identify the item, as in PortMapping.
+	ItemIdentityFields ItemIdentity = "fields"
+)
+
+// IdentityKey is one declared key field, with the value it carries on the
+// task instance it was read from. Value is empty and Present is false when
+// read from a registry prototype, which is what the docs generator wants.
+type IdentityKey struct {
+	// Field is the Go struct field name.
+	Field string
+
+	// YAMLName is the recipe key, from the field's yaml tag.
+	YAMLName string
+
+	// Value is the field's value rendered as a string.
+	Value string
+
+	// Present is false when the field holds its zero value. A key that is not
+	// present is omitted from the address, which is what lets the mutually
+	// exclusive app / global pair render honestly.
+	Present bool
+}
+
+// IdentityCollection is one declared collection field.
+type IdentityCollection struct {
+	// Field is the Go struct field name.
+	Field string
+
+	// YAMLName is the recipe key, from the field's yaml tag.
+	YAMLName string
+
+	// Item says what identifies one entry in the collection.
+	Item ItemIdentity
+
+	// ItemKeys are the element struct's own identity key yaml names, in
+	// declaration order. Populated only when Item is ItemIdentityFields.
+	ItemKeys []string
+}
+
+// TaskIdentity returns t's declared key fields in declaration order, each
+// carrying the value it holds on t. Centralised so the loader, the export
+// filter, and the docs generator share one read site, mirroring
+// TaskProbeSupport and TaskExportSupport.
+func TaskIdentity(t Task) []IdentityKey {
+	v, ok := structValue(t)
+	if !ok {
+		return nil
+	}
+	typ := v.Type()
+
+	var out []IdentityKey
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Tag.Get(identityTag) != identityTagKey {
+			continue
+		}
+		value, present := renderIdentityValue(v.Field(i))
+		out = append(out, IdentityKey{
+			Field:    field.Name,
+			YAMLName: yamlFieldName(field),
+			Value:    value,
+			Present:  present,
+		})
+	}
+	return out
+}
+
+// TaskIdentityCollections returns t's declared collection fields in
+// declaration order. Most tasks declare none and none declares more than one
+// today, but the shape does not forbid it.
+func TaskIdentityCollections(t Task) []IdentityCollection {
+	v, ok := structValue(t)
+	if !ok {
+		return nil
+	}
+	typ := v.Type()
+
+	var out []IdentityCollection
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Tag.Get(identityTag) != identityTagCollection {
+			continue
+		}
+		item, itemKeys := collectionItemIdentity(field.Type)
+		out = append(out, IdentityCollection{
+			Field:    field.Name,
+			YAMLName: yamlFieldName(field),
+			Item:     item,
+			ItemKeys: itemKeys,
+		})
+	}
+	return out
+}
+
+// collectionItemIdentity classifies a collection field's element type and, for
+// a struct element, returns the yaml names of its own identity keys.
+func collectionItemIdentity(t reflect.Type) (ItemIdentity, []string) {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() == reflect.Map {
+		return ItemIdentityMapKey, nil
+	}
+	if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
+		return ItemIdentityValue, nil
+	}
+	elem := t.Elem()
+	for elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	if elem.Kind() != reflect.Struct {
+		return ItemIdentityValue, nil
+	}
+	var keys []string
+	for i := 0; i < elem.NumField(); i++ {
+		field := elem.Field(i)
+		if field.Tag.Get(identityTag) != identityTagKey {
+			continue
+		}
+		keys = append(keys, yamlFieldName(field))
+	}
+	return ItemIdentityFields, keys
+}
+
+// structValue dereferences t down to the struct value behind it.
+func structValue(t Task) (reflect.Value, bool) {
+	if t == nil {
+		return reflect.Value{}, false
+	}
+	v := reflect.ValueOf(t)
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return reflect.Value{}, false
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return reflect.Value{}, false
+	}
+	return v, true
+}
+
+// renderIdentityValue stringifies one key field and reports whether it holds
+// anything. A zero value is not present, which is what drops `global` from an
+// app-scoped address and `app` from a global-scoped one.
+func renderIdentityValue(v reflect.Value) (string, bool) {
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return "", false
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.String:
+		s := v.String()
+		return s, s != ""
+	case reflect.Bool:
+		if !v.Bool() {
+			return "false", false
+		}
+		return "true", true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n := v.Int()
+		return strconv.FormatInt(n, 10), n != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n := v.Uint()
+		return strconv.FormatUint(n, 10), n != 0
+	}
+	return "", false
+}
+
+// IdentityAddress renders the resource t addresses as
+// `dokku_config[app=api]`. Keys appear in declaration order; keys holding
+// their zero value are omitted, so a task with no key value at all renders as
+// the bare type key.
+//
+// The result is a parseable surface, not just a label: it is the auto-generated
+// task name in the `--json` event stream, the argument `--start-at-task`
+// accepts, and the argument `export --resource` accepts. Values are therefore
+// never truncated - a lossy address could not be resolved back.
+func IdentityAddress(typeKey string, t Task) string {
+	keys := TaskIdentity(t)
+	pairs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if !key.Present {
+			continue
+		}
+		pairs = append(pairs, key.YAMLName+"="+quoteIdentityValue(key.Value))
+	}
+	if len(pairs) == 0 {
+		return typeKey
+	}
+	return typeKey + "[" + strings.Join(pairs, ",") + "]"
+}
+
+// IdentityMatches reports whether every key in want matches t's value for that
+// key. A key naming a field t does not declare never matches. Used by
+// `export --resource` to narrow the bodies an exporter returned.
+func IdentityMatches(t Task, want map[string]string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	have := make(map[string]string, 8)
+	declared := make(map[string]bool, 8)
+	for _, key := range TaskIdentity(t) {
+		declared[key.YAMLName] = true
+		if key.Present {
+			have[key.YAMLName] = key.Value
+		}
+	}
+	for name, value := range want {
+		if !declared[name] {
+			return false
+		}
+		if have[name] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// identityQuoteChars are the characters that force a value to be quoted.
+//
+// The set is deliberately small: only what a bare value cannot survive.
+// ParseIdentityAddress splits pairs on unquoted commas and each pair on its
+// first `=`, so `option=--memory=512m` and `option=-v /host:/container` both
+// round-trip unquoted - which matters, because dokku_docker_options addresses
+// are full of both and quoting them all would make the names unreadable.
+const identityQuoteChars = ",]\""
+
+// quoteIdentityValue renders one key value, quoting it only when a bare form
+// would not parse back. An empty value is quoted so it is distinguishable
+// from an omitted key.
+func quoteIdentityValue(value string) string {
+	if value == "" || strings.ContainsAny(value, identityQuoteChars) {
+		return strconv.Quote(value)
+	}
+	return value
+}
+
+// ParseIdentityAddress parses `dokku_config[app=api]` into its type key and
+// key map. A bare type key parses to an empty map, which `export --resource`
+// reads as "every resource of this type".
+//
+// The parse is strict: it rejects an auto-generated task name carrying a
+// collision ordinal (`dokku_config[app=api] #2`), because that names a task,
+// not a resource, and two tasks can address one resource.
+func ParseIdentityAddress(address string) (string, map[string]string, error) {
+	trimmed := strings.TrimSpace(address)
+	if trimmed == "" {
+		return "", nil, fmt.Errorf("resource address is empty")
+	}
+
+	open := strings.IndexByte(trimmed, '[')
+	if open < 0 {
+		// A bare type key is a legal address meaning "every resource of this
+		// type". Anything else without brackets is a task name (an ordinal
+		// suffix, a loop `(item=…)` suffix, a hand-written label), not one.
+		if strings.ContainsAny(trimmed, "]\"= ") {
+			return "", nil, fmt.Errorf("invalid resource address %q: expected <task_type> or <task_type>[key=value,...]", address)
+		}
+		return trimmed, map[string]string{}, nil
+	}
+
+	typeKey := trimmed[:open]
+	if typeKey == "" {
+		return "", nil, fmt.Errorf("invalid resource address %q: missing task type before %q", address, "[")
+	}
+	if !strings.HasSuffix(trimmed, "]") {
+		return "", nil, fmt.Errorf("invalid resource address %q: missing closing %q", address, "]")
+	}
+
+	body := trimmed[open+1 : len(trimmed)-1]
+	if strings.TrimSpace(body) == "" {
+		return "", nil, fmt.Errorf("invalid resource address %q: %q holds no keys", address, "[]")
+	}
+
+	keys := map[string]string{}
+	for _, pair := range splitIdentityPairs(body) {
+		eq := strings.IndexByte(pair, '=')
+		if eq <= 0 {
+			return "", nil, fmt.Errorf("invalid resource address %q: %q is not key=value", address, pair)
+		}
+		name := pair[:eq]
+		raw := pair[eq+1:]
+		value := raw
+		if strings.HasPrefix(raw, `"`) {
+			unquoted, err := strconv.Unquote(raw)
+			if err != nil {
+				return "", nil, fmt.Errorf("invalid resource address %q: %s", address, err)
+			}
+			value = unquoted
+		} else if strings.ContainsAny(raw, "]\"") {
+			return "", nil, fmt.Errorf("invalid resource address %q: value for %q must be quoted", address, name)
+		}
+		if _, dup := keys[name]; dup {
+			return "", nil, fmt.Errorf("invalid resource address %q: key %q appears twice", address, name)
+		}
+		keys[name] = value
+	}
+	return typeKey, keys, nil
+}
+
+// splitIdentityPairs splits an address body on commas that are not inside a
+// quoted value.
+func splitIdentityPairs(body string) []string {
+	var (
+		out      []string
+		start    int
+		inQuotes bool
+		escaped  bool
+	)
+	for i := 0; i < len(body); i++ {
+		switch {
+		case escaped:
+			escaped = false
+		case body[i] == '\\' && inQuotes:
+			escaped = true
+		case body[i] == '"':
+			inQuotes = !inQuotes
+		case body[i] == ',' && !inQuotes:
+			out = append(out, body[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, body[start:])
+}
+
+// IdentityKeyNames returns the yaml names of t's declared keys, in declaration
+// order. Used by the docs generator, which reads a registry prototype and so
+// has no values to render.
+func IdentityKeyNames(t Task) []string {
+	keys := TaskIdentity(t)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key.YAMLName)
+	}
+	return out
+}
+
+// sortedIdentityKeyNames is IdentityKeyNames sorted, for error messages that
+// list what a task accepts.
+func sortedIdentityKeyNames(t Task) []string {
+	out := IdentityKeyNames(t)
+	sort.Strings(out)
+	return out
+}

--- a/tasks/identity_coverage_test.go
+++ b/tasks/identity_coverage_test.go
@@ -1,0 +1,165 @@
+package tasks
+
+import (
+	"reflect"
+	"testing"
+)
+
+// taskStructType returns the struct type behind a registered task prototype.
+func taskStructType(task Task) reflect.Type {
+	rt := reflect.TypeOf(task)
+	for rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	return rt
+}
+
+// TestEveryTaskDeclaresIdentity asserts that every registered task says which
+// resource it manages. This is what makes "docket knows what a task addresses"
+// enforceable: a new task without an `identity:"key"` field fails the build
+// here rather than silently shipping with no address, which would leave it
+// unnamed in the event stream and unreachable from `export --resource`.
+func TestEveryTaskDeclaresIdentity(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		if len(TaskIdentity(task)) == 0 {
+			t.Errorf("task %q declares no identity:\"key\" field (tag the fields that select the resource it manages)", name)
+		}
+	}
+}
+
+// TestIdentityKeysAreNeverSensitive is the guard on the one stream that is
+// deliberately unmasked. `--list-tasks --json` prints resolved values by
+// design (docs/json-output.md), and since #427 a task's name embeds its
+// identity fields - so a field that is both an identity key and a declared
+// secret would put that secret into the listing. Every task satisfies this
+// today: the payload fields that are sensitive (an image reference, an
+// archive URL, a password, a certificate) are never the address.
+func TestIdentityKeysAreNeverSensitive(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		rt := taskStructType(task)
+		for i := 0; i < rt.NumField(); i++ {
+			field := rt.Field(i)
+			if field.Tag.Get(identityTag) != identityTagKey {
+				continue
+			}
+			if field.Tag.Get("sensitive") == "true" {
+				t.Errorf("task %q field %s is both identity:%q and sensitive:\"true\"; an identity key is rendered into the task name, which --list-tasks does not mask",
+					name, field.Name, identityTagKey)
+			}
+		}
+	}
+}
+
+// TestIdentityTagsAreWellFormed checks the shape of every identity tag: the
+// value is one of the two the reader understands, a key is a scalar, a
+// collection is a slice or a map, and the desired state is never either.
+//
+// `state:` is excluded on purpose. The address answers "which resource", not
+// "what should happen to it": including the state would rename a task when its
+// state changed, and would give `dokku_domains` four addresses for one app's
+// domain list.
+func TestIdentityTagsAreWellFormed(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		rt := taskStructType(task)
+		for i := 0; i < rt.NumField(); i++ {
+			field := rt.Field(i)
+			tag, ok := field.Tag.Lookup(identityTag)
+			if !ok {
+				continue
+			}
+
+			if field.Name == "State" {
+				t.Errorf("task %q tags State as identity:%q; the desired state is not part of the resource address", name, tag)
+				continue
+			}
+
+			ft := field.Type
+			for ft.Kind() == reflect.Ptr {
+				ft = ft.Elem()
+			}
+
+			switch tag {
+			case identityTagKey:
+				switch ft.Kind() {
+				case reflect.String, reflect.Bool,
+					reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+					reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				default:
+					t.Errorf("task %q field %s is identity:%q but has kind %s; a key must render as a scalar", name, field.Name, tag, ft.Kind())
+				}
+			case identityTagCollection:
+				if ft.Kind() != reflect.Slice && ft.Kind() != reflect.Array && ft.Kind() != reflect.Map {
+					t.Errorf("task %q field %s is identity:%q but has kind %s; a collection must be a slice or a map", name, field.Name, tag, ft.Kind())
+				}
+			default:
+				t.Errorf("task %q field %s has identity:%q; expected %q or %q", name, field.Name, tag, identityTagKey, identityTagCollection)
+			}
+		}
+	}
+}
+
+// TestCollectionItemsDeclareTheirOwnIdentity asserts that a collection of
+// structs says what identifies one entry. Both cases in the tree state it in a
+// comment today - PortMapping's "no two may share a scheme and host port",
+// HttpAuthUser's username - and a comment is exactly what #427 set out to
+// replace with something the code can read.
+func TestCollectionItemsDeclareTheirOwnIdentity(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		for _, collection := range TaskIdentityCollections(task) {
+			if collection.Item != ItemIdentityFields {
+				continue
+			}
+			if len(collection.ItemKeys) == 0 {
+				t.Errorf("task %q collection %s holds structs but its element type declares no identity:%q field",
+					name, collection.YAMLName, identityTagKey)
+			}
+		}
+	}
+}
+
+// TestSetValuedTasksDeclareTheirCollection pins the decision #427 asked for on
+// the three tasks whose resource is an unordered set. Each keys on its scope
+// alone - the collection is the resource, not part of its key - and each says
+// so by tagging the collection rather than leaving the reader to infer it from
+// the absence of a tag.
+func TestSetValuedTasksDeclareTheirCollection(t *testing.T) {
+	want := map[string]string{
+		"dokku_domains": "domains",
+		"dokku_ports":   "port_mappings",
+		"dokku_acl_app": "users",
+	}
+	for name, field := range want {
+		task, ok := RegisteredTasks[name]
+		if !ok {
+			t.Errorf("task %q is not registered", name)
+			continue
+		}
+		collections := TaskIdentityCollections(task)
+		if len(collections) != 1 {
+			t.Errorf("task %q declares %d collections, want exactly 1", name, len(collections))
+			continue
+		}
+		if collections[0].YAMLName != field {
+			t.Errorf("task %q declares collection %q, want %q", name, collections[0].YAMLName, field)
+		}
+	}
+}
+
+// TestIdentityKeysAreDocumentedParameters asserts that every identity key is a
+// field a recipe can actually set. A key hidden behind `yaml:"-"` would render
+// into task names and export addresses while appearing nowhere in the task's
+// Parameters table, so a user could neither reproduce nor target it.
+func TestIdentityKeysAreDocumentedParameters(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		rt := taskStructType(task)
+		for i := 0; i < rt.NumField(); i++ {
+			field := rt.Field(i)
+			if field.Tag.Get(identityTag) != identityTagKey {
+				continue
+			}
+			if field.Tag.Get("yaml") == "-" {
+				t.Errorf("task %q field %s is an identity key but is excluded from yaml", name, field.Name)
+			}
+		}
+	}
+}

--- a/tasks/identity_test.go
+++ b/tasks/identity_test.go
@@ -1,0 +1,300 @@
+package tasks
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestIdentityAddressRendersDeclaredKeys covers the rendering rules the whole
+// feature rests on: keys appear in declaration order, a key holding its zero
+// value is omitted (which is what lets the mutually exclusive app / global
+// pair render honestly), and a task with no key value at all falls back to the
+// bare type key.
+func TestIdentityAddressRendersDeclaredKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		typeKey string
+		task    Task
+		want    string
+	}{
+		{
+			name:    "single key",
+			typeKey: "dokku_app",
+			task:    AppTask{App: "api"},
+			want:    "dokku_app[app=api]",
+		},
+		{
+			name:    "several keys in declaration order",
+			typeKey: "dokku_service_property",
+			task:    ServicePropertyTask{Service: "postgres", Name: "db", Property: "max-connections", Value: "100"},
+			want:    "dokku_service_property[service=postgres,name=db,property=max-connections]",
+		},
+		{
+			name:    "app scope omits the unset global flag",
+			typeKey: "dokku_apps_property",
+			task:    AppsPropertyTask{App: "api", Property: "deploy-source"},
+			want:    "dokku_apps_property[app=api,property=deploy-source]",
+		},
+		{
+			name:    "global scope omits the empty app",
+			typeKey: "dokku_apps_property",
+			task:    AppsPropertyTask{Global: true, Property: "disable-autocreation"},
+			want:    "dokku_apps_property[global=true,property=disable-autocreation]",
+		},
+		{
+			name:    "no key value renders the bare type key",
+			typeKey: "dokku_domains",
+			task:    DomainsTask{Domains: []string{"example.com"}},
+			want:    "dokku_domains",
+		},
+		{
+			name:    "an int key renders as a number",
+			typeKey: "dokku_ports",
+			task:    PortsTask{App: "api"},
+			want:    "dokku_ports[app=api]",
+		},
+		{
+			name:    "the desired state is not part of the address",
+			typeKey: "dokku_config",
+			task:    ConfigTask{App: "api", State: StateAbsent},
+			want:    "dokku_config[app=api]",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IdentityAddress(tt.typeKey, tt.task); got != tt.want {
+				t.Errorf("IdentityAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIdentityAddressQuotesOnlyWhatItMust pins the quoting rule. The address
+// is a parseable surface, so a value that would break the parse is quoted -
+// and nothing else is. A docker option is the motivating case: it is full of
+// `=`, spaces, and colons, none of which need quoting, and quoting them all
+// would make every dokku_docker_options task name unreadable.
+func TestIdentityAddressQuotesOnlyWhatItMust(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		task DockerOptionsTask
+		want string
+	}{
+		{
+			name: "equals and spaces stay bare",
+			task: DockerOptionsTask{App: "api", Phase: "deploy", Option: "-v /var/run/docker.sock:/var/run/docker.sock"},
+			want: "dokku_docker_options[app=api,phase=deploy,option=-v /var/run/docker.sock:/var/run/docker.sock]",
+		},
+		{
+			name: "a comma is quoted because it separates keys",
+			task: DockerOptionsTask{App: "api", Phase: "run", Option: "-e FOO=bar,BAZ=qux"},
+			want: `dokku_docker_options[app=api,phase=run,option="-e FOO=bar,BAZ=qux"]`,
+		},
+		{
+			name: "a closing bracket is quoted because it ends the address",
+			task: DockerOptionsTask{App: "api", Phase: "build", Option: "--label a]b"},
+			want: `dokku_docker_options[app=api,phase=build,option="--label a]b"]`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IdentityAddress("dokku_docker_options", tt.task)
+			if got != tt.want {
+				t.Fatalf("IdentityAddress() = %q, want %q", got, tt.want)
+			}
+			// Whatever the quoting, the address has to survive a round trip:
+			// it is what --start-at-task and export --resource are handed.
+			typeKey, keys, err := ParseIdentityAddress(got)
+			if err != nil {
+				t.Fatalf("ParseIdentityAddress(%q) errored: %v", got, err)
+			}
+			if typeKey != "dokku_docker_options" {
+				t.Errorf("type key = %q, want dokku_docker_options", typeKey)
+			}
+			if keys["option"] != tt.task.Option {
+				t.Errorf("option = %q, want %q", keys["option"], tt.task.Option)
+			}
+		})
+	}
+}
+
+// TestParseIdentityAddress covers the accepted forms and the rejected ones. A
+// bare type key is legal and means "every resource of this type"; a task name
+// carrying a collision ordinal or a loop suffix is not an address and must be
+// rejected rather than silently truncated to one.
+func TestParseIdentityAddress(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		address  string
+		wantType string
+		wantKeys map[string]string
+		wantErr  string
+	}{
+		{
+			name:     "bare type key",
+			address:  "dokku_config",
+			wantType: "dokku_config",
+			wantKeys: map[string]string{},
+		},
+		{
+			name:     "one key",
+			address:  "dokku_config[app=api]",
+			wantType: "dokku_config",
+			wantKeys: map[string]string{"app": "api"},
+		},
+		{
+			name:     "several keys",
+			address:  "dokku_service_property[service=postgres,name=db,property=x]",
+			wantType: "dokku_service_property",
+			wantKeys: map[string]string{"service": "postgres", "name": "db", "property": "x"},
+		},
+		{
+			name:     "quoted value holding a comma",
+			address:  `dokku_docker_options[app=api,option="-e A=1,B=2"]`,
+			wantType: "dokku_docker_options",
+			wantKeys: map[string]string{"app": "api", "option": "-e A=1,B=2"},
+		},
+		{
+			name:     "quoted empty value",
+			address:  `dokku_domains[app=""]`,
+			wantType: "dokku_domains",
+			wantKeys: map[string]string{"app": ""},
+		},
+		{
+			name:    "collision ordinal is a task name, not an address",
+			address: "dokku_config[app=api] #2",
+			wantErr: "missing closing",
+		},
+		{
+			name:    "loop suffix is a task name, not an address",
+			address: "dokku_app (item=api)",
+			wantErr: "expected <task_type>",
+		},
+		{
+			name:    "empty",
+			address: "   ",
+			wantErr: "is empty",
+		},
+		{
+			name:    "no keys between the brackets",
+			address: "dokku_config[]",
+			wantErr: "holds no keys",
+		},
+		{
+			name:    "missing type",
+			address: "[app=api]",
+			wantErr: "missing task type",
+		},
+		{
+			name:    "not key=value",
+			address: "dokku_config[app]",
+			wantErr: "is not key=value",
+		},
+		{
+			name:    "repeated key",
+			address: "dokku_config[app=a,app=b]",
+			wantErr: "appears twice",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			typeKey, keys, err := ParseIdentityAddress(tt.address)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected an error containing %q, got none", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %v, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if typeKey != tt.wantType {
+				t.Errorf("type key = %q, want %q", typeKey, tt.wantType)
+			}
+			if !reflect.DeepEqual(keys, tt.wantKeys) {
+				t.Errorf("keys = %#v, want %#v", keys, tt.wantKeys)
+			}
+		})
+	}
+}
+
+// TestIdentityMatches covers the predicate `export --resource` filters emitted
+// bodies with: an empty request matches everything, a partial request matches
+// on the keys it named, and a key the task does not declare never matches.
+func TestIdentityMatches(t *testing.T) {
+	task := AppsPropertyTask{App: "api", Property: "deploy-source", Value: "git"}
+
+	for _, tt := range []struct {
+		name string
+		want map[string]string
+		ok   bool
+	}{
+		{name: "no keys matches everything", want: nil, ok: true},
+		{name: "matching subset", want: map[string]string{"app": "api"}, ok: true},
+		{name: "all keys", want: map[string]string{"app": "api", "property": "deploy-source"}, ok: true},
+		{name: "wrong value", want: map[string]string{"app": "web"}, ok: false},
+		{name: "unset key requested", want: map[string]string{"global": "true"}, ok: false},
+		{name: "undeclared key", want: map[string]string{"nope": "x"}, ok: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IdentityMatches(task, tt.want); got != tt.ok {
+				t.Errorf("IdentityMatches(%#v) = %v, want %v", tt.want, got, tt.ok)
+			}
+		})
+	}
+}
+
+// TestTaskIdentityCollections covers the three item-identity shapes: a scalar
+// slice identified by value, a map identified by its key, and a struct slice
+// whose element declares its own keys.
+func TestTaskIdentityCollections(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		task     Task
+		field    string
+		item     ItemIdentity
+		itemKeys []string
+	}{
+		{name: "value-identified set", task: DomainsTask{}, field: "domains", item: ItemIdentityValue},
+		{name: "map-identified pairs", task: ConfigTask{}, field: "config", item: ItemIdentityMapKey},
+		{name: "struct items", task: PortsTask{}, field: "port_mappings", item: ItemIdentityFields, itemKeys: []string{"scheme", "host"}},
+		{name: "struct items with one key", task: HttpAuthUserTask{}, field: "users", item: ItemIdentityFields, itemKeys: []string{"username"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			collections := TaskIdentityCollections(tt.task)
+			if len(collections) != 1 {
+				t.Fatalf("got %d collections, want 1", len(collections))
+			}
+			got := collections[0]
+			if got.YAMLName != tt.field {
+				t.Errorf("field = %q, want %q", got.YAMLName, tt.field)
+			}
+			if got.Item != tt.item {
+				t.Errorf("item identity = %q, want %q", got.Item, tt.item)
+			}
+			if tt.itemKeys != nil && !reflect.DeepEqual(got.ItemKeys, tt.itemKeys) {
+				t.Errorf("item keys = %v, want %v", got.ItemKeys, tt.itemKeys)
+			}
+		})
+	}
+}
+
+// TestTaskIdentityReportsUnsetKeys asserts that a prototype read from the
+// registry still reports its declared keys, with Present false. The docs
+// generator relies on this: it renders the Identity section from prototypes,
+// which hold no values.
+func TestTaskIdentityReportsUnsetKeys(t *testing.T) {
+	keys := TaskIdentity(RegisteredTasks["dokku_apps_property"])
+	if len(keys) != 3 {
+		t.Fatalf("got %d keys, want 3", len(keys))
+	}
+	for _, key := range keys {
+		if key.Present {
+			t.Errorf("key %q reports Present on a zero-valued prototype", key.YAMLName)
+		}
+	}
+	if got := IdentityKeyNames(RegisteredTasks["dokku_apps_property"]); !reflect.DeepEqual(got, []string{"app", "global", "property"}) {
+		t.Errorf("IdentityKeyNames() = %v, want [app global property]", got)
+	}
+}

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // LetsencryptPropertyTask manages the letsencrypt configuration for a given dokku application
 type LetsencryptPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the letsencrypt configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the letsencrypt configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the letsencrypt configuration should be applied globally"`
 
 	// Property is the name of the letsencrypt property to set
-	Property string `required:"true" yaml:"property" description:"Name of the letsencrypt property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the letsencrypt property to set"`
 
 	// Value is the value to set for the letsencrypt property. Tagged sensitive
 	// because some letsencrypt properties carry DNS-API credentials; benign

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -10,7 +10,7 @@ import (
 // LetsencryptTask enables or disables the dokku-letsencrypt plugin for a dokku app
 type LetsencryptTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// State is the desired state of the letsencrypt integration
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the letsencrypt integration"`

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // LogsPropertyTask manages the logs configuration for a given dokku application
 type LogsPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the logs configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the logs configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the logs configuration should be applied globally"`
 
 	// Property is the name of the logs property to set
-	Property string `required:"true" yaml:"property" description:"Name of the logs property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the logs property to set"`
 
 	// Value is the value to set for the logs property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the logs property"`

--- a/tasks/loop.go
+++ b/tasks/loop.go
@@ -38,8 +38,11 @@ func expandLoop(base *TaskEnvelope, bodyBytes []byte, typeKey string, sigilConte
 		return nil, err
 	}
 
-	names := loopExpansionNames(base.Name, items)
-	out := make([]*TaskEnvelope, 0, len(items))
+	// Bodies decode first so an unnamed loop can name each iteration after the
+	// resource that iteration addresses; the `.item` substitution has already
+	// happened by then, which is what a name assigned before expansion could
+	// not see.
+	decoded := make([]Task, len(items))
 	for i, item := range items {
 		iterCtx := make(map[string]interface{}, safeCap(len(sigilContext), 2))
 		for k, v := range sigilContext {
@@ -61,18 +64,54 @@ func expandLoop(base *TaskEnvelope, bodyBytes []byte, typeKey string, sigilConte
 		if err != nil {
 			return nil, fmt.Errorf("loop iteration %d: decode error: %w", i, err)
 		}
+		decoded[i] = task
+	}
 
+	names, generated := loopIterationNames(base.Name, typeKey, decoded, items)
+	out := make([]*TaskEnvelope, 0, len(items))
+	for i, item := range items {
 		expanded := *base
-		expanded.Task = task
+		expanded.Task = decoded[i]
 		expanded.Loop = nil
 		expanded.LoopItem = item
 		expanded.LoopIndex = i
 		expanded.IsLoopExpansion = true
 		expanded.Name = names[i]
+		expanded.NameGenerated = generated
 
 		out = append(out, &expanded)
 	}
 	return out, nil
+}
+
+// loopIterationNames derives one name per loop iteration and reports whether
+// the names were generated rather than taken from a `name:` in the recipe.
+//
+// A named loop keeps the `<name> (item=<value>)` scheme unchanged. An unnamed
+// one names each iteration after the resource it addresses, which is both
+// more useful than `(item=…)` when the item feeds an identity field and the
+// only form `--start-at-task` and `export --resource` can resolve.
+//
+// The decision is made once for the whole loop, never per iteration: when any
+// two iterations address the same resource - a loop over config values for one
+// app, say - every iteration falls back to the item-suffixed form. A loop that
+// rendered some names as addresses and others as `(item=…)` would be harder to
+// read and to predict than either form alone.
+func loopIterationNames(baseName, typeKey string, decoded []Task, items []interface{}) ([]string, bool) {
+	if baseName != "" {
+		return loopExpansionNames(baseName, items), false
+	}
+
+	addresses := make([]string, len(decoded))
+	seen := make(map[string]bool, len(decoded))
+	for i, task := range decoded {
+		addresses[i] = IdentityAddress(typeKey, task)
+		if seen[addresses[i]] {
+			return loopExpansionNames(typeKey, items), true
+		}
+		seen[addresses[i]] = true
+	}
+	return addresses, true
 }
 
 // expandLoopGroup produces one group TaskEnvelope per iteration the
@@ -121,7 +160,7 @@ func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml
 		iterCtx["item"] = item
 		iterCtx["index"] = i
 
-		blockChildren, err := renderAndDecodeGroupClause(blockBytes, "block", iterCtx, sigilContext, exprContext, base.Name, i)
+		blockChildren, err := renderAndDecodeGroupClause(blockBytes, "block", iterCtx, sigilContext, exprContext, names[i], i)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +170,7 @@ func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml
 
 		var rescueChildren []*TaskEnvelope
 		if rescueBytes != nil {
-			rescueChildren, err = renderAndDecodeGroupClause(rescueBytes, "rescue", iterCtx, sigilContext, exprContext, base.Name, i)
+			rescueChildren, err = renderAndDecodeGroupClause(rescueBytes, "rescue", iterCtx, sigilContext, exprContext, names[i], i)
 			if err != nil {
 				return nil, err
 			}
@@ -139,7 +178,7 @@ func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml
 
 		var alwaysChildren []*TaskEnvelope
 		if alwaysBytes != nil {
-			alwaysChildren, err = renderAndDecodeGroupClause(alwaysBytes, "always", iterCtx, sigilContext, exprContext, base.Name, i)
+			alwaysChildren, err = renderAndDecodeGroupClause(alwaysBytes, "always", iterCtx, sigilContext, exprContext, names[i], i)
 			if err != nil {
 				return nil, err
 			}
@@ -166,7 +205,10 @@ func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml
 // task body sees the iteration value (per #211: each group iteration's
 // `.item` / `.index` is shared across all its children). The file-level
 // sigilContext stays available so other inputs continue to render.
-func renderAndDecodeGroupClause(body []byte, clause string, iterCtx, sigilContext, exprContext map[string]interface{}, baseName string, iter int) ([]*TaskEnvelope, error) {
+//
+// parentName is this iteration's group name; an unnamed child group extends
+// it, so children of two iterations of the same loop do not collide.
+func renderAndDecodeGroupClause(body []byte, clause string, iterCtx, sigilContext, exprContext map[string]interface{}, parentName string, iter int) ([]*TaskEnvelope, error) {
 	rendered, err := sigil.Execute(body, iterCtx, "loop")
 	if err != nil {
 		return nil, fmt.Errorf("loop iteration %d %s: render error: %w", iter, clause, err)
@@ -182,8 +224,9 @@ func renderAndDecodeGroupClause(body []byte, clause string, iterCtx, sigilContex
 	}
 
 	out := make([]*TaskEnvelope, 0, len(entries))
+	childPath := parentName + "." + clause
 	for i, entry := range entries {
-		envelopes, err := buildEnvelopesFromEntry(entry, sigilContext, exprContext)
+		envelopes, err := buildEnvelopesFromEntry(entry, childPath, sigilContext, exprContext)
 		if err != nil {
 			return nil, fmt.Errorf("loop iteration %d %s[%d]: %s", iter, clause, i, err)
 		}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"crypto/rand"
 	"fmt"
 	"io"
 	"reflect"
@@ -656,25 +655,34 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 		}
 
 		exprCtx := buildExprContext(playCtx)
-		play.Tasks = OrderedStringEnvelopeMap{}
+		// Envelopes are collected before any is stored, because the
+		// generated-name dedupe needs to see the whole play - including group
+		// children, which never enter play.Tasks - before it can decide which
+		// names collide.
+		built := make([]*TaskEnvelope, 0, len(perPlay.Entries))
 		for _, entry := range perPlay.Entries {
-			envelopes, err := buildEnvelopesFromEntry(entry, playCtx, exprCtx)
+			envelopes, err := buildEnvelopesFromEntry(entry, "", playCtx, exprCtx)
 			if err != nil {
 				return nil, err
 			}
-			for _, env := range envelopes {
-				if play.Tasks.GetEnvelope(env.Name) != nil {
-					// Duplicate literal names are already rejected at parse
-					// time; reaching here means two loop expansions produced
-					// the same suffixed name (#307), which would otherwise
-					// silently drop the earlier iteration.
-					return nil, fmt.Errorf("task parse error: duplicate task name %q in play %q", env.Name, play.Name)
-				}
-				if len(play.Tags) > 0 {
-					env.Tags = mergePlayTags(env.Tags, play.Tags)
-				}
-				play.Tasks.Set(env.Name, env)
+			built = append(built, envelopes...)
+		}
+		dedupeGeneratedNames(built)
+
+		play.Tasks = OrderedStringEnvelopeMap{}
+		for _, env := range built {
+			if play.Tasks.GetEnvelope(env.Name) != nil {
+				// Duplicate literal names are already rejected at parse
+				// time, and generated ones are deduped above; reaching here
+				// means two loop expansions produced the same suffixed name
+				// (#307), which would otherwise silently drop the earlier
+				// iteration.
+				return nil, fmt.Errorf("task parse error: duplicate task name %q in play %q", env.Name, play.Name)
 			}
+			if len(play.Tags) > 0 {
+				env.Tags = mergePlayTags(env.Tags, play.Tags)
+			}
+			play.Tasks.Set(env.Name, env)
 		}
 
 		plays = append(plays, play)
@@ -797,7 +805,18 @@ func mergePlayTags(envTags, playTags []string) []string {
 // the task body via decodeTaskBytes, and recurses through group children.
 // Structural problems the shared parser collected on the entry fail fast
 // here, so the loader rejects exactly what `docket validate` flags.
-func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+//
+// groupPath is the naming path of the enclosing group clause ("" at the top
+// level, `group #3.block` inside one) and is only consulted when an unnamed
+// group entry needs a name. Leaf entries do not use it: an unnamed leaf is
+// named after the resource it addresses, which is decided after its body
+// decodes, and any collision is settled by dedupeGeneratedNames.
+//
+// Diagnostics here quote e.Label, never the envelope name. The two are
+// different things - the label is the entry's position in the file, which is
+// known before anything decodes - and coupling them is what used to render
+// `task #1 "task #1 3F2A9C1E4B7D0A55"` into a compile error.
+func buildEnvelopesFromEntry(e *parsedTaskEntry, groupPath string, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
 	if len(e.Problems) > 0 {
 		return nil, problemToError(e.Problems[0])
 	}
@@ -811,20 +830,11 @@ func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[s
 		FailedWhen:   e.FailedWhen,
 		IgnoreErrors: e.IgnoreErrors,
 	}
-	index := e.Index
-
-	if envelope.Name == "" {
-		generated, err := generateTaskName(index)
-		if err != nil {
-			return nil, err
-		}
-		envelope.Name = generated
-	}
 
 	if e.LoopNode != nil {
 		var loop interface{}
 		if err := e.LoopNode.Decode(&loop); err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: loop decode error: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: loop decode error: %s", e.Label, err)
 		}
 		envelope.Loop = loop
 	}
@@ -832,7 +842,7 @@ func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[s
 	if envelope.When != "" {
 		prog, err := CompilePredicate(envelope.When)
 		if err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: when compile error: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: when compile error: %s", e.Label, err)
 		}
 		envelope.whenProgram = prog
 	}
@@ -840,7 +850,7 @@ func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[s
 	if envelope.ChangedWhen != "" {
 		prog, err := CompilePredicate(envelope.ChangedWhen)
 		if err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: changed_when compile error: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: changed_when compile error: %s", e.Label, err)
 		}
 		envelope.changedWhenProgram = prog
 	}
@@ -848,39 +858,48 @@ func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[s
 	if envelope.FailedWhen != "" {
 		prog, err := CompilePredicate(envelope.FailedWhen)
 		if err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: failed_when compile error: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: failed_when compile error: %s", e.Label, err)
 		}
 		envelope.failedWhenProgram = prog
 	}
 
 	if e.IsGroup {
+		// A group has no body and so addresses no resource. Its generated
+		// name is its path instead, which is unique by construction: group
+		// clauses restart their child indexes at 1, so a bare `group #1`
+		// would collide across nesting levels.
+		if envelope.Name == "" {
+			envelope.Name = generatedGroupName(groupPath, e.Index)
+			envelope.NameGenerated = true
+		}
+
 		if envelope.Loop != nil {
 			expanded, err := expandLoopGroup(envelope, e.BlockNode, e.RescueNode, e.AlwaysNode, sigilContext, exprContext)
 			if err != nil {
-				return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+				return nil, fmt.Errorf("task parse error: %s: %s", e.Label, err)
 			}
 			return expanded, nil
 		}
 
 		envelope.TypeName = ""
-		blockChildren, err := buildGroupClause(e.Block, "block", sigilContext, exprContext)
+		blockChildren, err := buildGroupClause(e.Block, "block", envelope.Name, sigilContext, exprContext)
 		if err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: %s", e.Label, err)
 		}
 		if len(blockChildren) == 0 {
-			return nil, fmt.Errorf("task parse error: task #%d %q: block: must contain at least one child task", index, envelope.Name)
+			return nil, fmt.Errorf("task parse error: %s: block: must contain at least one child task", e.Label)
 		}
 		envelope.Block = blockChildren
 
-		rescueChildren, err := buildGroupClause(e.Rescue, "rescue", sigilContext, exprContext)
+		rescueChildren, err := buildGroupClause(e.Rescue, "rescue", envelope.Name, sigilContext, exprContext)
 		if err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: %s", e.Label, err)
 		}
 		envelope.Rescue = rescueChildren
 
-		alwaysChildren, err := buildGroupClause(e.Always, "always", sigilContext, exprContext)
+		alwaysChildren, err := buildGroupClause(e.Always, "always", envelope.Name, sigilContext, exprContext)
 		if err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: %s", e.Label, err)
 		}
 		envelope.Always = alwaysChildren
 
@@ -891,16 +910,16 @@ func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[s
 
 	bodyBytes, err := yaml.Marshal(e.BodyNode)
 	if err != nil {
-		return nil, fmt.Errorf("task parse error: task #%d %q failed to marshal config to yaml - %s", index, envelope.Name, err)
+		return nil, fmt.Errorf("task parse error: %s failed to marshal config to yaml - %s", e.Label, err)
 	}
 
 	if envelope.Loop != nil {
 		expanded, err := expandLoop(envelope, bodyBytes, e.TypeKey, sigilContext, exprContext)
 		if err != nil {
-			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+			return nil, fmt.Errorf("task parse error: %s: %s", e.Label, err)
 		}
 		for _, exp := range expanded {
-			if err := rejectLoopVarsInTask(index, exp.Name, exp.Task); err != nil {
+			if err := rejectLoopVarsInTask(e.Label, exp.Task); err != nil {
 				return nil, err
 			}
 		}
@@ -909,30 +928,114 @@ func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[s
 
 	task, err := decodeTaskBytes(e.TypeKey, bodyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("task parse error: task #%d %q failed to decode to %s - %s", index, envelope.Name, e.TypeKey, err)
+		return nil, fmt.Errorf("task parse error: %s failed to decode to %s - %s", e.Label, e.TypeKey, err)
 	}
 	envelope.Task = task
 
-	if err := rejectLoopVarsInTask(index, envelope.Name, task); err != nil {
+	// Naming happens here, after the decode, because the name is the address
+	// of the resource the body selects.
+	if envelope.Name == "" {
+		envelope.Name = IdentityAddress(e.TypeKey, task)
+		envelope.NameGenerated = true
+	}
+
+	if err := rejectLoopVarsInTask(e.Label, task); err != nil {
 		return nil, err
 	}
 
 	return []*TaskEnvelope{envelope}, nil
 }
 
+// generatedGroupName names an unnamed group entry after its position in the
+// envelope tree: `group #3` at the top level, `group #3.block[2]` for the
+// second child of that group's block clause.
+func generatedGroupName(groupPath string, index int) string {
+	if groupPath == "" {
+		return fmt.Sprintf("group #%d", index)
+	}
+	return fmt.Sprintf("%s[%d]", groupPath, index)
+}
+
 // buildGroupClause builds the child envelopes for one already-parsed
 // block / rescue / always clause, prefixing child errors with the clause
-// name and child position the way the legacy group decoder did.
-func buildGroupClause(children []*parsedTaskEntry, clause string, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+// name and child position the way the legacy group decoder did. parentName
+// is the enclosing group's name, which children extend when they need a
+// generated name of their own.
+func buildGroupClause(children []*parsedTaskEntry, clause, parentName string, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
 	out := make([]*TaskEnvelope, 0, len(children))
+	childPath := parentName + "." + clause
 	for i, child := range children {
-		childEnvelopes, err := buildEnvelopesFromEntry(child, sigilContext, exprContext)
+		childEnvelopes, err := buildEnvelopesFromEntry(child, childPath, sigilContext, exprContext)
 		if err != nil {
 			return nil, fmt.Errorf("%s[%d]: %s", clause, i, err)
 		}
 		out = append(out, childEnvelopes...)
 	}
 	return out, nil
+}
+
+// dedupeGeneratedNames makes every auto-generated name in a play unique.
+//
+// Two tasks can legitimately address one resource - `dokku_config` on an app
+// with `state: present` and another with `state: absent` - and before #427 the
+// random suffix in every generated name hid that. The first occurrence keeps
+// the bare address; later ones get ` #2`, ` #3`. Ordinals shift if a colliding
+// task is inserted ahead of them, which is the price of not putting `state:`
+// in the address; a recipe that needs a name pinned should write one.
+//
+// The two passes matter. Reserving every user-supplied name first is what
+// stops a generated name from displacing one a recipe author wrote when the
+// generated one happens to come first in the file.
+//
+// The walk recurses into block / rescue / always: group children never enter
+// play.Tasks, so nothing else would catch a collision between them, yet
+// EnvelopeContainsName resolves --start-at-task against them.
+func dedupeGeneratedNames(envs []*TaskEnvelope) {
+	var (
+		names     []string
+		generated []bool
+		ordered   []*TaskEnvelope
+	)
+	walkEnvelopes(envs, func(env *TaskEnvelope) {
+		names = append(names, env.Name)
+		generated = append(generated, env.NameGenerated)
+		ordered = append(ordered, env)
+	})
+	for i, name := range disambiguateNames(names, generated) {
+		ordered[i].Name = name
+	}
+}
+
+// disambiguateNames suffixes duplicate generated names with ` #2`, ` #3`, and
+// so on, leaving names the recipe author wrote untouched. names and generated
+// are parallel and in source order.
+//
+// Reserving every non-generated name before assigning any generated one is
+// what makes the result independent of which came first in the file.
+//
+// Shared with the validator so `validate --strict --start-at-task` resolves
+// the same names the loader will produce.
+func disambiguateNames(names []string, generated []bool) []string {
+	taken := make(map[string]bool, len(names))
+	for i, name := range names {
+		if !generated[i] {
+			taken[name] = true
+		}
+	}
+	out := make([]string, len(names))
+	for i, name := range names {
+		if !generated[i] {
+			out[i] = name
+			continue
+		}
+		candidate := name
+		for n := 2; taken[candidate]; n++ {
+			candidate = fmt.Sprintf("%s #%d", name, n)
+		}
+		out[i] = candidate
+		taken[candidate] = true
+	}
+	return out
 }
 
 // decodeTags coerces a yaml-parsed tags value into a []string. Supports
@@ -955,16 +1058,6 @@ func decodeTags(value interface{}) ([]string, error) {
 		return out, nil
 	}
 	return nil, fmt.Errorf("tags must be a list of strings, got %T", value)
-}
-
-// generateTaskName returns a unique task name when the user did not
-// supply one. The format mirrors the legacy `task #N XXXX` pattern.
-func generateTaskName(index int) (string, error) {
-	b := make([]byte, 8)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("task parse error: task #%d had no task name and there was a failure to generate random task name - %s", index, err)
-	}
-	return fmt.Sprintf("task #%d %X", index, b), nil
 }
 
 // nearestEnvelopeOrTaskKey returns the envelope-allowlist or registered
@@ -1010,13 +1103,13 @@ func buildExprContext(context map[string]interface{}) map[string]interface{} {
 // and pipelined forms) and returns an error when it finds one. Loop
 // expansions render those tokens to real values, so any survivor implies
 // the user referenced a loop variable from a non-loop task.
-func rejectLoopVarsInTask(index int, name string, task Task) error {
+func rejectLoopVarsInTask(label string, task Task) error {
 	bytes, err := yaml.Marshal(task)
 	if err != nil {
 		return nil
 	}
 	if m := loopVarSentinelPattern.FindStringSubmatch(string(bytes)); m != nil {
-		return fmt.Errorf("task parse error: task #%d %q: .%s is only available inside a loop body", index, name, m[1])
+		return fmt.Errorf("task parse error: %s: .%s is only available inside a loop body", label, m[1])
 	}
 	return nil
 }

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -113,6 +113,9 @@ func TestGetTasksTooManyProperties(t *testing.T) {
 	}
 }
 
+// TestGetTasksAutoGeneratesName pins the auto-name to the address of the
+// resource the task manages. Before #427 this was `task #1 <16 hex>`, which
+// differed on every run and so could correlate nothing.
 func TestGetTasksAutoGeneratesName(t *testing.T) {
 	data := []byte(`---
 - tasks:
@@ -131,8 +134,8 @@ func TestGetTasksAutoGeneratesName(t *testing.T) {
 		t.Fatalf("expected 1 task, got %d", len(keys))
 	}
 
-	if !strings.HasPrefix(keys[0], "task #1 ") {
-		t.Errorf("expected auto-generated name starting with 'task #1 ', got '%s'", keys[0])
+	if keys[0] != "dokku_app[app=test-app]" {
+		t.Errorf("expected auto-generated name 'dokku_app[app=test-app]', got '%s'", keys[0])
 	}
 }
 

--- a/tasks/maintenance_custom_page_task.go
+++ b/tasks/maintenance_custom_page_task.go
@@ -22,7 +22,7 @@ import (
 // built from inline HTML (Content) or read from a tarball on disk (Tarball).
 type MaintenanceCustomPageTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Content is inline HTML stored as maintenance.html. Mutually exclusive
 	// with Tarball.

--- a/tasks/maintenance_task.go
+++ b/tasks/maintenance_task.go
@@ -44,7 +44,7 @@ func (t MaintenanceTask) ExportApp(app string) ([]interface{}, error) {
 // MaintenanceTask enables or disables maintenance mode for a given dokku application
 type MaintenanceTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// State is the desired state of maintenance mode
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of maintenance mode"`

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // NetworkPropertyTask manages the network property for a given dokku application
 type NetworkPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the network property should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the network property should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the network property should be applied globally"`
 
 	// Property is the name of the network property to set
-	Property string `required:"true" yaml:"property" description:"Name of the network property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the network property to set"`
 
 	// Value is the value of the network property to set
 	Value string `required:"false" yaml:"value,omitempty" description:"Value of the network property to set"`

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -11,7 +11,7 @@ import (
 // NetworkTask creates or destroys a Docker network
 type NetworkTask struct {
 	// Name is the name of the network
-	Name string `required:"true" yaml:"name" description:"Name of the network"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the network"`
 
 	// State is the state of the network
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"State of the network"`

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // NginxPropertyTask manages the nginx configuration for a given dokku application
 type NginxPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the nginx configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the nginx configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the nginx configuration should be applied globally"`
 
 	// Property is the name of the nginx property to set
-	Property string `required:"true" yaml:"property" description:"Name of the nginx property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the nginx property to set"`
 
 	// Value is the value to set for the nginx property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the nginx property"`

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // OpenrestyPropertyTask manages the openresty configuration for a given dokku application
 type OpenrestyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the openresty configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the openresty configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the openresty configuration should be applied globally"`
 
 	// Property is the name of the openresty property to set
-	Property string `required:"true" yaml:"property" description:"Name of the openresty property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the openresty property to set"`
 
 	// Value is the value to set for the openresty property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the openresty property"`

--- a/tasks/plugin_task.go
+++ b/tasks/plugin_task.go
@@ -18,7 +18,7 @@ import (
 // committish on an already-installed plugin is not detected.
 type PluginTask struct {
 	// Name is the plugin name as it appears in plugin:list
-	Name string `required:"true" yaml:"name" description:"Plugin name as it appears in plugin:list"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Plugin name as it appears in plugin:list"`
 
 	// URL is the git URL to install from. Required when state is present.
 	URL string `required:"false" yaml:"url,omitempty" description:"Git URL to install the plugin from. Required when state is present."`

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -12,10 +12,10 @@ import (
 // PortsTask manages the ports for a given dokku application
 type PortsTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// PortMappings are the port mappings to set
-	PortMappings []PortMapping `required:"false" yaml:"port_mappings,omitempty" description:"Port mappings to set; omit for state 'clear'; under state 'present' and 'set' no two may share a scheme and host port"`
+	PortMappings []PortMapping `required:"false" identity:"collection" yaml:"port_mappings,omitempty" description:"Port mappings to set; omit for state 'clear'; under state 'present' and 'set' no two may share a scheme and host port"`
 
 	// State is the desired state of the ports
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent,set,clear" description:"Desired state of the ports"`
@@ -38,10 +38,10 @@ func (e PortsTaskExample) GetName() string {
 // PortMapping represents a port mapping
 type PortMapping struct {
 	// Scheme is the scheme of the port mapping
-	Scheme string `required:"true" yaml:"scheme" description:"Scheme of the port mapping"`
+	Scheme string `required:"true" identity:"key" yaml:"scheme" description:"Scheme of the port mapping"`
 
 	// Host is the host of the port mapping
-	Host int `required:"true" yaml:"host" description:"Host of the port mapping"`
+	Host int `required:"true" identity:"key" yaml:"host" description:"Host of the port mapping"`
 
 	// Container is the container of the port mapping
 	Container int `required:"true" yaml:"container" description:"Container of the port mapping"`

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // ProxyPropertyTask manages the proxy configuration for a given dokku application
 type ProxyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the proxy configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the proxy configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the proxy configuration should be applied globally"`
 
 	// Property is the name of the proxy property to set
-	Property string `required:"true" yaml:"property" description:"Name of the proxy property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the proxy property to set"`
 
 	// Value is the value to set for the proxy property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the proxy property"`

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -35,7 +35,7 @@ func (t ProxyToggleTask) ExportApp(app string) ([]interface{}, error) {
 // ProxyToggleTask manages the proxy for a given dokku application
 type ProxyToggleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// State is the desired state of the proxy
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the proxy"`

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // PsPropertyTask manages the ps configuration for a given dokku application
 type PsPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the ps configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the ps configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the ps configuration should be applied globally"`
 
 	// Property is the name of the ps property to set
-	Property string `required:"true" yaml:"property" description:"Name of the ps property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the ps property to set"`
 
 	// Value is the value to set for the ps property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the ps property"`

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -12,10 +12,10 @@ import (
 // PsScaleTask manages the process scale for a given dokku application
 type PsScaleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Scale is a map of process types to quantities
-	Scale map[string]int `required:"true" yaml:"scale" description:"Map of process types to quantities"`
+	Scale map[string]int `required:"true" identity:"collection" yaml:"scale" description:"Map of process types to quantities"`
 
 	// SkipDeploy skips the corresponding deploy. It is a *bool so the value
 	// survives decoding unchanged; nil defaults to false.

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -10,13 +10,13 @@ import (
 // RegistryAuthTask manages docker registry authentication for a dokku application or globally
 type RegistryAuthTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the registry credential should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the registry credential should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the registry credential should be applied globally"`
 
 	// Server is the docker registry hostname (e.g. docker.io, ghcr.io)
-	Server string `required:"true" yaml:"server" description:"Docker registry hostname (e.g. docker.io, ghcr.io)"`
+	Server string `required:"true" identity:"key" yaml:"server" description:"Docker registry hostname (e.g. docker.io, ghcr.io)"`
 
 	// Username is the registry username (required when state is present)
 	Username string `required:"false" yaml:"username,omitempty" description:"Registry username (required when state is present)"`

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // RegistryPropertyTask manages the registry configuration for a given dokku application
 type RegistryPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the registry configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the registry configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the registry configuration should be applied globally"`
 
 	// Property is the name of the registry property to set
-	Property string `required:"true" yaml:"property" description:"Name of the registry property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the registry property to set"`
 
 	// Value is the value to set for the registry property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the registry property"`

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -3,13 +3,13 @@ package tasks
 // ResourceLimitTask manages the resource limits for a given dokku application
 type ResourceLimitTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// ProcessType is the process type to set resource limits for
-	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to set resource limits for"`
+	ProcessType string `required:"false" identity:"key" yaml:"process_type,omitempty" description:"Process type to set resource limits for"`
 
 	// Resources is a map of resource type to quantity
-	Resources map[string]string `yaml:"resources" description:"Map of resource type to quantity"`
+	Resources map[string]string `identity:"collection" yaml:"resources" description:"Map of resource type to quantity"`
 
 	// ClearBefore clears all resource limits before applying new ones. It is a
 	// *bool so the value survives decoding unchanged; nil defaults to false.

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -3,13 +3,13 @@ package tasks
 // ResourceReserveTask manages the resource reservations for a given dokku application
 type ResourceReserveTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// ProcessType is the process type to set resource reservations for
-	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to set resource reservations for"`
+	ProcessType string `required:"false" identity:"key" yaml:"process_type,omitempty" description:"Process type to set resource reservations for"`
 
 	// Resources is a map of resource type to quantity
-	Resources map[string]string `yaml:"resources" description:"Map of resource type to quantity"`
+	Resources map[string]string `identity:"collection" yaml:"resources" description:"Map of resource type to quantity"`
 
 	// ClearBefore clears all resource reservations before applying new ones. It
 	// is a *bool so the value survives decoding unchanged; nil defaults to false.

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -3,10 +3,10 @@ package tasks
 // SchedulerDockerLocalPropertyTask manages the scheduler-docker-local configuration for a given dokku application
 type SchedulerDockerLocalPropertyTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Property is the name of the scheduler-docker-local property to set
-	Property string `required:"true" yaml:"property" description:"Name of the scheduler-docker-local property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the scheduler-docker-local property to set"`
 
 	// Value is the value to set for the scheduler-docker-local property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler-docker-local property"`

--- a/tasks/scheduler_k3s_annotations_task.go
+++ b/tasks/scheduler_k3s_annotations_task.go
@@ -5,24 +5,24 @@ package tasks
 // globally.
 type SchedulerK3sAnnotationsTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the annotations should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the annotations should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the annotations should be applied globally"`
 
 	// ProcessType narrows the annotations to a specific process type. When
 	// empty, dokku stores the annotations under its default global process
 	// type.
-	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to scope the annotations to. Defaults to the global process type when empty."`
+	ProcessType string `required:"false" identity:"key" yaml:"process_type,omitempty" description:"Process type to scope the annotations to. Defaults to the global process type when empty."`
 
 	// ResourceType narrows the annotations to a specific kubernetes resource
 	// type (e.g. deployment, ingress, service). Required, mirroring dokku's
 	// own scheduler-k3s:annotations:set rejection of empty resource types.
-	ResourceType string `required:"true" yaml:"resource_type" description:"Kubernetes resource type to scope the annotations to (e.g. deployment, ingress)."`
+	ResourceType string `required:"true" identity:"key" yaml:"resource_type" description:"Kubernetes resource type to scope the annotations to (e.g. deployment, ingress)."`
 
 	// Annotations is the desired set of annotation key/value pairs to apply at
 	// the (process_type, resource_type) scope.
-	Annotations map[string]string `required:"false" yaml:"annotations,omitempty" description:"Map of annotation key to value to apply at the scope."`
+	Annotations map[string]string `required:"false" identity:"collection" yaml:"annotations,omitempty" description:"Map of annotation key to value to apply at the scope."`
 
 	// State is the desired state of the annotations
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the annotations"`

--- a/tasks/scheduler_k3s_autoscaling_auth_task.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task.go
@@ -4,21 +4,21 @@ package tasks
 // metadata stored under a single trigger for a dokku application or globally.
 type SchedulerK3sAutoscalingAuthTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the trigger authentication should be
 	// applied globally instead of on a single app.
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the trigger authentication should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the trigger authentication should be applied globally"`
 
 	// Trigger is the name of the KEDA trigger authentication resource that
 	// groups the metadata keys.
-	Trigger string `required:"true" yaml:"trigger" description:"Name of the KEDA trigger authentication resource"`
+	Trigger string `required:"true" identity:"key" yaml:"trigger" description:"Name of the KEDA trigger authentication resource"`
 
 	// Metadata is the set of metadata key/value pairs to apply to the
 	// trigger. On present, these keys are written and merged with any other
 	// keys dokku already stores under the trigger. On absent, only the listed
 	// keys are cleared; their values are ignored.
-	Metadata map[string]string `required:"false" yaml:"metadata,omitempty" description:"Map of metadata key to value for the trigger authentication. On absent, only the keys are read."`
+	Metadata map[string]string `required:"false" identity:"collection" yaml:"metadata,omitempty" description:"Map of metadata key to value for the trigger authentication. On absent, only the keys are read."`
 
 	// State is the desired state of the trigger authentication metadata.
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the trigger authentication metadata"`

--- a/tasks/scheduler_k3s_chart_task.go
+++ b/tasks/scheduler_k3s_chart_task.go
@@ -17,7 +17,7 @@ import (
 type SchedulerK3sChartTask struct {
 	// Chart is the helm chart whose values to manage. Dokku validates the
 	// chart name against its known HelmCharts list at apply time.
-	Chart string `required:"true" yaml:"chart" description:"Name of the helm chart whose values to set (validated by dokku against its bundled HelmCharts list)."`
+	Chart string `required:"true" identity:"key" yaml:"chart" description:"Name of the helm chart whose values to set (validated by dokku against its bundled HelmCharts list)."`
 
 	// Values is the desired set of helm value overrides. It accepts either
 	// a flat map of dotted Helm property paths (e.g. resources.limits.cpu)
@@ -26,7 +26,7 @@ type SchedulerK3sChartTask struct {
 	// flattenChartValues for the exact coalescing rules, including the
 	// nested-segment escaping that lets dotted leaf keys survive Helm's
 	// strvals parser.
-	Values map[string]any `required:"true" yaml:"values,omitempty" description:"Helm-style values for the chart. Accepts a flat map of dotted property paths or a nested tree; both coalesce to the same key/value form before being applied. In nested form, literal dots in a key segment are escaped to \\. so they reach Helm as a single annotation/label key."`
+	Values map[string]any `required:"true" identity:"collection" yaml:"values,omitempty" description:"Helm-style values for the chart. Accepts a flat map of dotted property paths or a nested tree; both coalesce to the same key/value form before being applied. In nested form, literal dots in a key segment are escaped to \\. so they reach Helm as a single annotation/label key."`
 
 	// State is the desired state of the chart values.
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the chart values."`

--- a/tasks/scheduler_k3s_labels_task.go
+++ b/tasks/scheduler_k3s_labels_task.go
@@ -4,23 +4,23 @@ package tasks
 // (process_type, resource_type) pair on a dokku application or globally.
 type SchedulerK3sLabelsTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the labels should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the labels should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the labels should be applied globally"`
 
 	// ProcessType narrows the labels to a specific process type. When empty,
 	// dokku stores the labels under its default global process type.
-	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to scope the labels to. Defaults to the global process type when empty."`
+	ProcessType string `required:"false" identity:"key" yaml:"process_type,omitempty" description:"Process type to scope the labels to. Defaults to the global process type when empty."`
 
 	// ResourceType narrows the labels to a specific kubernetes resource type
 	// (e.g. deployment, ingress, service). Required, mirroring dokku's own
 	// scheduler-k3s:labels:set rejection of empty resource types.
-	ResourceType string `required:"true" yaml:"resource_type" description:"Kubernetes resource type to scope the labels to (e.g. deployment, ingress)."`
+	ResourceType string `required:"true" identity:"key" yaml:"resource_type" description:"Kubernetes resource type to scope the labels to (e.g. deployment, ingress)."`
 
 	// Labels is the desired set of label key/value pairs to apply at the
 	// (process_type, resource_type) scope.
-	Labels map[string]string `required:"false" yaml:"labels,omitempty" description:"Map of label key to value to apply at the scope."`
+	Labels map[string]string `required:"false" identity:"collection" yaml:"labels,omitempty" description:"Map of label key to value to apply at the scope."`
 
 	// State is the desired state of the labels
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the labels"`

--- a/tasks/scheduler_k3s_profile_task.go
+++ b/tasks/scheduler_k3s_profile_task.go
@@ -18,7 +18,7 @@ import (
 type SchedulerK3sProfileTask struct {
 	// Name is the profile name. It is the lookup key both for the on-disk
 	// global property and for `scheduler-k3s:profiles:list --format json`.
-	Name string `required:"true" yaml:"name" description:"Name of the node profile."`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the node profile."`
 
 	// Role is the k3s role nodes joined with this profile take. Required and
 	// validated up front; dokku also rejects unknown values but failing in the

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -8,13 +8,13 @@ import (
 // SchedulerK3sPropertyTask manages the scheduler-k3s configuration for a given dokku application
 type SchedulerK3sPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the scheduler-k3s configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the scheduler-k3s configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the scheduler-k3s configuration should be applied globally"`
 
 	// Property is the name of the scheduler-k3s property to set
-	Property string `required:"true" yaml:"property" description:"Name of the scheduler-k3s property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the scheduler-k3s property to set"`
 
 	// Value is the value to set for the scheduler-k3s property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler-k3s property"`

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // SchedulerPropertyTask manages the scheduler configuration for a given dokku application
 type SchedulerPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the scheduler configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the scheduler configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the scheduler configuration should be applied globally"`
 
 	// Property is the name of the scheduler property to set
-	Property string `required:"true" yaml:"property" description:"Name of the scheduler property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the scheduler property to set"`
 
 	// Value is the value to set for the scheduler property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler property"`

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -19,10 +19,10 @@ import (
 // no-probe pattern used by dokku_git_auth and dokku_registry_auth.
 type ServiceBackupTask struct {
 	// Service is the type of service to back up (e.g. redis, postgres, mysql)
-	Service string `required:"true" yaml:"service" description:"Type of service to back up (e.g. redis, postgres, mysql)"`
+	Service string `required:"true" identity:"key" yaml:"service" description:"Type of service to back up (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
-	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the service instance"`
 
 	// Schedule is the cron schedule for backups. Requires bucket.
 	Schedule string `required:"false" yaml:"schedule,omitempty" description:"Cron schedule for backups (requires bucket)"`

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -26,10 +26,10 @@ import (
 // (tracked in #435).
 type ServiceCreateTask struct {
 	// Service is the type of service to create (e.g. redis, postgres, mysql)
-	Service string `required:"true" yaml:"service" description:"Type of service to create (e.g. redis, postgres, mysql)"`
+	Service string `required:"true" identity:"key" yaml:"service" description:"Type of service to create (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
-	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the service instance"`
 
 	// Image is the image the service container is started from.
 	Image string `required:"false" yaml:"image,omitempty" description:"Image to start the service with, e.g. postgis/postgis. Applied only when the service is created."`

--- a/tasks/service_expose_task.go
+++ b/tasks/service_expose_task.go
@@ -12,13 +12,13 @@ import (
 // ServiceExposeTask exposes or unexposes a dokku service on host ports
 type ServiceExposeTask struct {
 	// Service is the type of service to expose (e.g. redis, postgres, mysql)
-	Service string `required:"true" yaml:"service" description:"Type of service to expose (e.g. redis, postgres, mysql)"`
+	Service string `required:"true" identity:"key" yaml:"service" description:"Type of service to expose (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
-	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the service instance"`
 
 	// Ports are the host ports to expose the service on. Required when state is present.
-	Ports []string `required:"false" yaml:"ports,omitempty" description:"Host ports to expose the service on. Required when state is present."`
+	Ports []string `required:"false" identity:"collection" yaml:"ports,omitempty" description:"Host ports to expose the service on. Required when state is present."`
 
 	// State is the desired state of the service exposure
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the service exposure"`

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -8,13 +8,13 @@ import (
 // ServiceLinkTask links or unlinks a dokku service to an app
 type ServiceLinkTask struct {
 	// App is the name of the app to link the service to
-	App string `required:"true" yaml:"app" description:"Name of the app to link the service to"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app to link the service to"`
 
 	// Service is the type of service to link (e.g. redis, postgres, mysql)
-	Service string `required:"true" yaml:"service" description:"Type of service to link (e.g. redis, postgres, mysql)"`
+	Service string `required:"true" identity:"key" yaml:"service" description:"Type of service to link (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
-	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the service instance"`
 
 	// State is the desired state of the service link
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the service link"`

--- a/tasks/service_property_task.go
+++ b/tasks/service_property_task.go
@@ -20,13 +20,13 @@ import (
 // always reporting Changed=true, and its export can move off unsupported.
 type ServicePropertyTask struct {
 	// Service is the type of service to configure (e.g. redis, postgres, mysql)
-	Service string `required:"true" yaml:"service" description:"Type of service to configure (e.g. redis, postgres, mysql)"`
+	Service string `required:"true" identity:"key" yaml:"service" description:"Type of service to configure (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
-	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the service instance"`
 
 	// Property is the name of the property to set
-	Property string `required:"true" yaml:"property" description:"Name of the property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the property to set"`
 
 	// Value is the value to set the property to. Required when state is present.
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set the property to. Required when state is present."`

--- a/tasks/ssh_key_task.go
+++ b/tasks/ssh_key_task.go
@@ -15,7 +15,7 @@ import (
 // core ssh-keys plugin.
 type SshKeyTask struct {
 	// Name identifies the key in dokku
-	Name string `required:"true" yaml:"name" description:"Name that identifies the key in dokku"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name that identifies the key in dokku"`
 
 	// Key is the public key contents. Required when state is present.
 	Key string `required:"false" yaml:"key,omitempty" description:"Public key contents. Required when state is present."`

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -11,7 +11,7 @@ import (
 // StorageEnsureTask manages the storage for a given dokku application
 type StorageEnsureTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// Chown is the chown value to set
 	Chown string `required:"false" yaml:"chown,omitempty" options:"heroku,herokuish,paketo,root,false" description:"Chown value to set: an ownership preset or a numeric uid (0-65535)"`

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -27,7 +27,7 @@ import (
 // directory.
 type StorageEntryTask struct {
 	// Name is the name of the storage entry
-	Name string `required:"true" yaml:"name" description:"Name of the storage entry"`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the storage entry"`
 
 	// Path is the host path for the entry. Optional; on docker-local it
 	// defaults to the dokku storage root + name.

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -36,7 +36,7 @@ const storageDefaultProcessType = "_default_"
 // reconstructs every attribute in full.
 type StorageMountTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app" description:"Name of the app"`
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
 
 	// EntryName is the named storage registry entry to attach. Mutually
 	// exclusive with host_dir.
@@ -47,7 +47,7 @@ type StorageMountTask struct {
 	HostDir string `required:"false" yaml:"host_dir,omitempty" description:"Host directory to mount in the legacy bind-mount form (mutually exclusive with entry_name)"`
 
 	// ContainerDir is the container directory to mount
-	ContainerDir string `required:"true" yaml:"container_dir" description:"Container directory to mount"`
+	ContainerDir string `required:"true" identity:"key" yaml:"container_dir" description:"Container directory to mount"`
 
 	// Phases is the deployment phases the attachment applies to (deploy, run).
 	// Empty defers to the dokku default (both phases).

--- a/tasks/task_name_test.go
+++ b/tasks/task_name_test.go
@@ -1,0 +1,261 @@
+package tasks
+
+import (
+	"reflect"
+	"testing"
+)
+
+// playTaskNames loads a single-play recipe and returns its task names in
+// source order.
+func playTaskNames(t *testing.T, recipe string) []string {
+	t.Helper()
+	envelopes, err := GetTasks([]byte(recipe), map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks errored: %v", err)
+	}
+	return envelopes.Keys()
+}
+
+// TestGeneratedNamesAreStableAcrossRuns is the regression the issue is about.
+// Before #427 an unnamed task's name carried eight random bytes, so two runs
+// of one recipe emitted different `name` values for the same task and nothing
+// consuming the --json stream could line them up.
+func TestGeneratedNamesAreStableAcrossRuns(t *testing.T) {
+	recipe := `---
+- tasks:
+    - dokku_app: { app: api }
+    - dokku_config: { app: api, config: { A: "1" } }
+    - name: hand written
+      dokku_domains: { app: api, domains: [api.example.com] }
+    - block:
+        - dokku_app_lock: { app: api }
+`
+	first := playTaskNames(t, recipe)
+	second := playTaskNames(t, recipe)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("names differ between runs:\n first = %v\nsecond = %v", first, second)
+	}
+
+	want := []string{
+		"dokku_app[app=api]",
+		"dokku_config[app=api]",
+		"hand written",
+		"group #4",
+	}
+	if !reflect.DeepEqual(first, want) {
+		t.Errorf("names = %v, want %v", first, want)
+	}
+}
+
+// TestGeneratedNamesDisambiguateCollisions covers two tasks addressing one
+// resource, which is a normal thing for a recipe to do - setting some config
+// keys and unsetting others - and which the old random suffix hid.
+func TestGeneratedNamesDisambiguateCollisions(t *testing.T) {
+	names := playTaskNames(t, `---
+- tasks:
+    - dokku_config: { app: api, config: { A: "1" } }
+    - dokku_config: { app: api, state: absent, config: { B: "" } }
+    - dokku_config: { app: api, config: { C: "3" } }
+`)
+	want := []string{
+		"dokku_config[app=api]",
+		"dokku_config[app=api] #2",
+		"dokku_config[app=api] #3",
+	}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+}
+
+// TestUserNameWinsOverGeneratedCollision asserts the two-phase rename: a name
+// the recipe author wrote is reserved before any generated name is assigned,
+// so it keeps its name whichever order the two appear in.
+func TestUserNameWinsOverGeneratedCollision(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		recipe string
+	}{
+		{
+			name: "user name second",
+			recipe: `---
+- tasks:
+    - dokku_app: { app: api }
+    - name: dokku_app[app=api]
+      dokku_app_lock: { app: api }
+`,
+		},
+		{
+			name: "user name first",
+			recipe: `---
+- tasks:
+    - name: dokku_app[app=api]
+      dokku_app_lock: { app: api }
+    - dokku_app: { app: api }
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			names := playTaskNames(t, tt.recipe)
+			var lock, generated string
+			for _, n := range names {
+				if n == "dokku_app[app=api]" {
+					lock = n
+				}
+				if n == "dokku_app[app=api] #2" {
+					generated = n
+				}
+			}
+			if lock == "" {
+				t.Errorf("the hand-written name was renamed; got %v", names)
+			}
+			if generated == "" {
+				t.Errorf("the generated name was not disambiguated; got %v", names)
+			}
+		})
+	}
+}
+
+// TestGroupNamesArePathBased covers the one envelope kind with no resource to
+// address. Group clauses restart their child indexes at 1, so a name derived
+// from the index alone would collide across nesting levels.
+func TestGroupNamesArePathBased(t *testing.T) {
+	plays, err := GetPlays([]byte(`---
+- tasks:
+    - block:
+        - dokku_app: { app: api }
+        - block:
+            - dokku_app_lock: { app: api }
+`), map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays errored: %v", err)
+	}
+
+	outer := plays[0].Tasks.GetEnvelope("group #1")
+	if outer == nil {
+		t.Fatalf("expected a top-level group named 'group #1', got %v", plays[0].Tasks.Keys())
+	}
+	if len(outer.Block) != 2 {
+		t.Fatalf("expected 2 block children, got %d", len(outer.Block))
+	}
+	if got := outer.Block[0].Name; got != "dokku_app[app=api]" {
+		t.Errorf("leaf child name = %q, want the resource address", got)
+	}
+	if got := outer.Block[1].Name; got != "group #1.block[2]" {
+		t.Errorf("nested group name = %q, want 'group #1.block[2]'", got)
+	}
+}
+
+// TestIdenticalLeavesInDifferentBlocksAreDisambiguated is the case group
+// children used to escape entirely: they never enter play.Tasks, so nothing
+// checked them for collisions, and --start-at-task would silently resolve to
+// whichever came first.
+func TestIdenticalLeavesInDifferentBlocksAreDisambiguated(t *testing.T) {
+	plays, err := GetPlays([]byte(`---
+- tasks:
+    - block:
+        - dokku_app: { app: api }
+    - block:
+        - dokku_app: { app: api }
+`), map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays errored: %v", err)
+	}
+
+	names := CollectEnvelopeNames([]*TaskEnvelope{
+		plays[0].Tasks.GetEnvelope("group #1"),
+		plays[0].Tasks.GetEnvelope("group #2"),
+	})
+	want := []string{"group #1", "dokku_app[app=api]", "group #2", "dokku_app[app=api] #2"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+}
+
+// TestUnnamedLoopNamesIterationsByAddress covers the common loop shape, where
+// the item feeds an identity field. Each iteration addresses a different
+// resource, so each gets its own address - which is both more informative than
+// `(item=…)` and the only form --start-at-task can resolve.
+func TestUnnamedLoopNamesIterationsByAddress(t *testing.T) {
+	names := playTaskNames(t, `---
+- tasks:
+    - loop: [api, web, worker]
+      dokku_app: { app: "{{ .item }}" }
+`)
+	want := []string{
+		"dokku_app[app=api]",
+		"dokku_app[app=web]",
+		"dokku_app[app=worker]",
+	}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+}
+
+// TestUnnamedLoopFallsBackWholesale covers a loop whose iterations all address
+// the same resource - here one app's config, one key per iteration. The
+// decision is made once for the whole loop, so the listing never mixes
+// addresses with `(item=…)` suffixes.
+func TestUnnamedLoopFallsBackWholesale(t *testing.T) {
+	names := playTaskNames(t, `---
+- tasks:
+    - loop: [A, B]
+      dokku_config:
+        app: api
+        config: { "{{ .item }}": "1" }
+`)
+	want := []string{
+		"dokku_config (item=A)",
+		"dokku_config (item=B)",
+	}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+}
+
+// TestNamedLoopKeepsItemSuffix asserts the unchanged half: a loop with a
+// `name:` still reads `<name> (item=<value>)`, because the recipe author
+// already said what to call it.
+func TestNamedLoopKeepsItemSuffix(t *testing.T) {
+	names := playTaskNames(t, `---
+- tasks:
+    - name: create apps
+      loop: [api, web]
+      dokku_app: { app: "{{ .item }}" }
+`)
+	want := []string{"create apps (item=api)", "create apps (item=web)"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+}
+
+// TestParseErrorsQuoteTheEntryLabel asserts that a loader diagnostic names the
+// entry's position in the file rather than its envelope name. The old form
+// rendered the random auto-name into the message - `task #1 "task #1
+// 3F2A9C1E4B7D0A55"` - and, now that naming happens after the body decodes,
+// there would be no name to quote at all.
+func TestParseErrorsQuoteTheEntryLabel(t *testing.T) {
+	_, err := GetTasks([]byte(`---
+- tasks:
+    - when: "))"
+      dokku_app: { app: api }
+`), map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected a when compile error")
+	}
+	want := `task parse error: task #1: when compile error`
+	if got := err.Error(); len(got) < len(want) || got[:len(want)] != want {
+		t.Errorf("error = %q, want it to start with %q", got, want)
+	}
+}
+
+// TestDisambiguateNames covers the pure rename helper the loader and the
+// validator share, including the ordinal skipping a name already reserved.
+func TestDisambiguateNames(t *testing.T) {
+	names := []string{"a", "a", "a #2", "b"}
+	generated := []bool{true, true, false, true}
+	got := disambiguateNames(names, generated)
+	want := []string{"a", "a #3", "a #2", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("disambiguateNames() = %v, want %v", got, want)
+	}
+}

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -3,13 +3,13 @@ package tasks
 // TraefikPropertyTask manages the traefik configuration for a given dokku application
 type TraefikPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the traefik configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the traefik configuration should be applied globally"`
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the traefik configuration should be applied globally"`
 
 	// Property is the name of the traefik property to set
-	Property string `required:"true" yaml:"property" description:"Name of the traefik property to set"`
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the traefik property to set"`
 
 	// Value is the value to set for the traefik property
 	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the traefik property"`

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -248,7 +248,7 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 		problems = append(problems, validatePlay(play, inputs, opts, registerSeen)...)
 	}
 
-	problems = append(problems, validateCLIReferences(ast.Doc, opts)...)
+	problems = append(problems, validateCLIReferences(ast, opts)...)
 
 	return problems
 }
@@ -258,13 +258,23 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 // recipe. The audit runs only under --strict so casual `validate` runs
 // (without --strict) never error solely on missing CLI references.
 //
-// --start-at-task is checked against task `name:` fields walked through
-// every play's `tasks:` and through the block / rescue / always
-// children of group entries (#211). Loop expansions are not enumerated
-// here because their per-iteration suffix is only resolved at apply
-// time; the runtime check in commands/apply.go is authoritative.
-func validateCLIReferences(doc *yaml.Node, opts ValidateOptions) []Problem {
-	if doc == nil || !opts.Strict {
+// --start-at-task is checked against the names the loader will produce, not
+// just the `name:` fields written in the recipe: since #427 an unnamed task
+// is named after the resource it addresses, and that name is a legal
+// --start-at-task target. Resolving it means decoding the task body here, the
+// same decode validateTaskBody performs, and running the loader's
+// disambiguateNames over the result so collision ordinals line up.
+//
+// Two shapes cannot be resolved offline: a `loop:` entry, whose per-iteration
+// name depends on values only apply time has, and a body still carrying the
+// validatePlaceholder sentinel, whose address would name the placeholder
+// rather than the real input. Rather than report those as unknown, the whole
+// --start-at-task check is skipped when a play contains one. A missed typo is
+// recoverable - the runtime check in commands/apply.go is authoritative - but
+// failing a valid recipe is not. This also retires the pre-existing false
+// positive on `--start-at-task "deploy (item=a)"` against a named loop task.
+func validateCLIReferences(ast *parsedRecipe, opts ValidateOptions) []Problem {
+	if ast == nil || !opts.Strict {
 		return nil
 	}
 	if opts.PlayName == "" && opts.StartAtTask == "" {
@@ -274,36 +284,39 @@ func validateCLIReferences(doc *yaml.Node, opts ValidateOptions) []Problem {
 	var problems []Problem
 	var playNames []string
 	taskNamesByPlay := map[string][]string{}
+	unresolvedByPlay := map[string]bool{}
 	var allTaskNames []string
+	anyUnresolved := false
 	seen := map[string]bool{}
 
-	for i, play := range doc.Content {
-		if play.Kind != yaml.MappingNode {
-			continue
-		}
-		playLabel := scalarChild(play, "name")
+	for _, play := range ast.Plays {
+		playLabel := play.Name
 		if playLabel == "" {
-			playLabel = fmt.Sprintf("play #%d", i+1)
+			playLabel = play.Label
 		}
 		playNames = append(playNames, playLabel)
 
-		tasksNode := mappingValue(play, "tasks")
-		if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
-			continue
+		var collected []entryName
+		unresolved := collectEntryNames(play.Entries, "", &collected)
+		unresolvedByPlay[playLabel] = unresolved
+		if unresolved {
+			anyUnresolved = true
 		}
-		var names []string
-		walkGroupEntries(tasksNode, playLabel, func(task *yaml.Node, _ string) {
-			n := scalarChild(task, "name")
-			if n == "" {
-				return
-			}
-			names = append(names, n)
+
+		raw := make([]string, len(collected))
+		generated := make([]bool, len(collected))
+		for i, entry := range collected {
+			raw[i] = entry.name
+			generated[i] = entry.generated
+		}
+		names := disambiguateNames(raw, generated)
+		taskNamesByPlay[playLabel] = names
+		for _, n := range names {
 			if !seen[n] {
 				seen[n] = true
 				allTaskNames = append(allTaskNames, n)
 			}
-		})
-		taskNamesByPlay[playLabel] = names
+		}
 	}
 
 	if opts.PlayName != "" {
@@ -325,9 +338,11 @@ func validateCLIReferences(doc *yaml.Node, opts ValidateOptions) []Problem {
 
 	if opts.StartAtTask != "" {
 		candidates := allTaskNames
+		incomplete := anyUnresolved
 		if opts.PlayName != "" {
 			if names, ok := taskNamesByPlay[opts.PlayName]; ok {
 				candidates = names
+				incomplete = unresolvedByPlay[opts.PlayName]
 			}
 		}
 		found := false
@@ -337,7 +352,7 @@ func validateCLIReferences(doc *yaml.Node, opts ValidateOptions) []Problem {
 				break
 			}
 		}
-		if !found {
+		if !found && !incomplete {
 			problems = append(problems, Problem{
 				Code:    "unknown_start_at_task",
 				Message: fmt.Sprintf("--start-at-task %q does not match any task in the recipe", opts.StartAtTask),
@@ -347,6 +362,84 @@ func validateCLIReferences(doc *yaml.Node, opts ValidateOptions) []Problem {
 	}
 
 	return problems
+}
+
+// entryName is one task name the loader will produce, and whether it was
+// derived rather than written in the recipe.
+type entryName struct {
+	name      string
+	generated bool
+}
+
+// collectEntryNames appends the name of every entry reachable from entries,
+// mirroring what buildEnvelopesFromEntry assigns: a written `name:` as-is, a
+// group named after its path, and a leaf named after the resource its body
+// addresses. Returns true when at least one entry could not be resolved
+// offline, which tells the caller its list is incomplete.
+func collectEntryNames(entries []*parsedTaskEntry, groupPath string, out *[]entryName) bool {
+	unresolved := false
+	for _, e := range entries {
+		if len(e.Problems) > 0 {
+			unresolved = true
+			continue
+		}
+		if e.LoopNode != nil {
+			unresolved = true
+			continue
+		}
+		if e.IsGroup {
+			name := e.Name
+			generated := false
+			if name == "" {
+				name = generatedGroupName(groupPath, e.Index)
+				generated = true
+			}
+			*out = append(*out, entryName{name: name, generated: generated})
+			if collectEntryNames(e.Block, name+".block", out) {
+				unresolved = true
+			}
+			if collectEntryNames(e.Rescue, name+".rescue", out) {
+				unresolved = true
+			}
+			if collectEntryNames(e.Always, name+".always", out) {
+				unresolved = true
+			}
+			continue
+		}
+		if e.Name != "" {
+			*out = append(*out, entryName{name: e.Name})
+			continue
+		}
+		address, ok := entryIdentityAddress(e)
+		if !ok {
+			unresolved = true
+			continue
+		}
+		*out = append(*out, entryName{name: address, generated: true})
+	}
+	return unresolved
+}
+
+// entryIdentityAddress decodes an entry's body and returns the address the
+// loader will name it after. Reports false when the body cannot be decoded
+// offline or still holds a required-no-default input's placeholder, whose
+// real value is unknown here.
+func entryIdentityAddress(e *parsedTaskEntry) (string, bool) {
+	if e.TypeKey == "" || e.BodyNode == nil {
+		return "", false
+	}
+	marshaled, err := yaml.Marshal(e.BodyNode)
+	if err != nil {
+		return "", false
+	}
+	if strings.Contains(string(marshaled), validatePlaceholder) {
+		return "", false
+	}
+	task, err := decodeTaskBytes(e.TypeKey, marshaled)
+	if err != nil {
+		return "", false
+	}
+	return IdentityAddress(e.TypeKey, task), true
 }
 
 // quotedNamesOrNone formats a slice of names as a comma-separated list

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -1329,6 +1329,98 @@ func TestValidateStartAtTaskMatchesGroupChild(t *testing.T) {
 	}
 }
 
+// TestValidateStartAtTaskMatchesGeneratedName asserts the audit resolves the
+// names the loader generates, not only the ones a recipe author wrote. Since
+// #427 an unnamed task is named after the resource it addresses and that name
+// is a legal --start-at-task target, so reporting it as unknown would fail a
+// valid invocation.
+func TestValidateStartAtTaskMatchesGeneratedName(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_app: { app: api }
+    - dokku_config: { app: api, config: { A: "1" } }
+`)
+	problems := Validate(data, ValidateOptions{Strict: true, StartAtTask: "dokku_config[app=api]"})
+	if p := findProblem(problems, "unknown_start_at_task"); p != nil {
+		t.Fatalf("did not expect unknown_start_at_task for a generated name; got: %+v", *p)
+	}
+}
+
+// TestValidateStartAtTaskMatchesGeneratedCollisionOrdinal asserts the audit
+// applies the loader's disambiguation too, so the ` #2` a second task on the
+// same resource receives resolves as well.
+func TestValidateStartAtTaskMatchesGeneratedCollisionOrdinal(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_config: { app: api, config: { A: "1" } }
+    - dokku_config: { app: api, state: absent, config: { B: "" } }
+`)
+	problems := Validate(data, ValidateOptions{Strict: true, StartAtTask: "dokku_config[app=api] #2"})
+	if p := findProblem(problems, "unknown_start_at_task"); p != nil {
+		t.Fatalf("did not expect unknown_start_at_task for a disambiguated name; got: %+v", *p)
+	}
+}
+
+// TestValidateStartAtTaskGeneratedNameStillCatchesTypos asserts the audit did
+// not become vacuous: a name matching nothing is still reported, and the hint
+// lists the generated names so the user can see what to type.
+func TestValidateStartAtTaskGeneratedNameStillCatchesTypos(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_app: { app: api }
+`)
+	problems := Validate(data, ValidateOptions{Strict: true, StartAtTask: "dokku_app[app=web]"})
+	p := findProblem(problems, "unknown_start_at_task")
+	if p == nil {
+		t.Fatalf("expected unknown_start_at_task; got: %+v", problems)
+	}
+	if !strings.Contains(p.Hint, `"dokku_app[app=api]"`) {
+		t.Errorf("hint should list the generated name; got %q", p.Hint)
+	}
+}
+
+// TestValidateStartAtTaskSkippedWhenNamesCannotResolve covers the two shapes
+// that cannot be named offline. A `loop:` entry's per-iteration name and a
+// body still holding an input placeholder both depend on values only apply
+// time has, so the check stands down rather than reporting a valid name as
+// unknown. commands/apply.go remains authoritative.
+func TestValidateStartAtTaskSkippedWhenNamesCannotResolve(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		data string
+		opts ValidateOptions
+	}{
+		{
+			name: "loop entry",
+			data: `---
+- tasks:
+    - name: deploy
+      loop: [a, b]
+      dokku_app: { app: "{{ .item }}" }
+`,
+			opts: ValidateOptions{Strict: true, StartAtTask: "deploy (item=a)"},
+		},
+		{
+			name: "unresolved input placeholder",
+			data: `---
+- inputs:
+    - name: appname
+      required: true
+  tasks:
+    - dokku_app: { app: "{{ .appname }}" }
+`,
+			opts: ValidateOptions{Strict: true, StartAtTask: "dokku_app[app=api]"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			problems := Validate([]byte(tt.data), tt.opts)
+			if p := findProblem(problems, "unknown_start_at_task"); p != nil {
+				t.Fatalf("expected the check to stand down; got: %+v", *p)
+			}
+		})
+	}
+}
+
 // TestValidateCLIReferencesSkippedWithoutStrict pins the gating
 // behaviour: passing --play/--start-at-task without --strict does not
 // trigger the cross-reference audit, matching the issue's contract

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -34,6 +34,50 @@ teardown() {
   assert_output --partial "docket-test-export"
 }
 
+@test "docket export --resource rejects a combination with --app" {
+  # No server needed: an address already names its app, so the two filters are
+  # rejected before anything is read.
+  run "$(docket_bin)" export --resource 'dokku_config[app=docket-test-export]' --app docket-test-export --output -
+  assert_failure
+  assert_output --partial "cannot be combined"
+}
+
+@test "docket export --resource rejects an unknown task type" {
+  run "$(docket_bin)" export --resource 'dokku_confg[app=docket-test-export]' --output -
+  assert_failure
+  assert_output --partial 'did you mean "dokku_config"'
+}
+
+@test "docket export --resource rejects a key the task does not declare" {
+  run "$(docket_bin)" export --resource 'dokku_config[application=docket-test-export]' --output -
+  assert_failure
+  assert_output --partial "is not an identity key of dokku_config"
+}
+
+@test "docket export --resource emits only the addressed resource" {
+  require_dokku
+  dokku apps:create docket-test-export
+  dokku config:set --no-restart docket-test-export EXPORT_ONE=1
+  dokku domains:add docket-test-export docket-test-export.example.com
+  run "$(docket_bin)" export --resource 'dokku_config[app=docket-test-export]' --output "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_success
+  run cat "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_success
+  assert_output --partial "dokku_config"
+  refute_output --partial "dokku_domains"
+  refute_output --partial "dokku_app:"
+}
+
+@test "docket export --resource fails on an address the server has nothing for" {
+  require_dokku
+  run "$(docket_bin)" export --resource 'dokku_config[app=docket-nonexistent-xyz]' --output "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_failure
+  assert_output --partial "dokku_config[app=docket-nonexistent-xyz]"
+  assert_output --partial "not found on server"
+  run test -f "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_failure
+}
+
 @test "docket export --app reports the app count without the global play" {
   require_dokku
   dokku apps:create docket-test-export

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -93,6 +93,9 @@ EOF
 }
 
 @test "--list-tasks expands loops" {
+  # An unnamed loop whose item feeds an identity field names each iteration
+  # after the resource that iteration addresses (#427), which is both more
+  # informative than an (item=) suffix and the form --start-at-task accepts.
   write_tasks_file <<EOF
 ---
 - tasks:
@@ -101,15 +104,32 @@ EOF
 EOF
   run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
   assert_success
-  assert_output --partial "item=a"
-  assert_output --partial "item=b"
-  assert_output --partial "item=c"
+  assert_output --partial "dokku_app[app=docket-test-list-loop-a]"
+  assert_output --partial "dokku_app[app=docket-test-list-loop-b]"
+  assert_output --partial "dokku_app[app=docket-test-list-loop-c]"
+}
+
+@test "--list-tasks names a named loop by item" {
+  # A loop the recipe author named keeps the <name> (item=<value>) form: the
+  # author already said what to call it.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: create apps
+      loop: [a, b]
+      dokku_app: { app: "docket-test-list-named-{{ .item }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "create apps (item=a)"
+  assert_output --partial "create apps (item=b)"
 }
 
 @test "--list-tasks keeps both iterations for duplicate loop items" {
   # Duplicate scalar items used to collide into one envelope name and
   # trip the duplicate-name guard, dropping an iteration (#320). Both
-  # iterations must survive with disambiguated names.
+  # iterations must survive with disambiguated names - here each renders a
+  # different app, so each addresses a different resource.
   write_tasks_file <<EOF
 ---
 - tasks:
@@ -118,9 +138,110 @@ EOF
 EOF
   run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
   assert_success
-  assert_output --partial "(item=web) #0"
-  assert_output --partial "(item=web) #1"
+  assert_output --partial "dokku_app[app=docket-test-list-dup-0]"
+  assert_output --partial "dokku_app[app=docket-test-list-dup-1]"
   refute_output --partial "duplicate task name"
+}
+
+@test "--list-tasks falls back to item names when a loop addresses one resource" {
+  # Every iteration here sets a key on the same app, so every iteration
+  # addresses the same resource. The fallback is all-or-nothing so one loop
+  # never renders a mix of addresses and item suffixes.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - loop: [A, B]
+      dokku_config:
+        app: docket-test-list-same
+        config: { "{{ .item }}": "1" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "dokku_config (item=A)"
+  assert_output --partial "dokku_config (item=B)"
+  refute_output --partial "duplicate task name"
+}
+
+@test "--list-tasks names unnamed tasks after the resource they manage" {
+  # The old display heuristic keyed on the first App-like field, so every
+  # phase and option of one app collapsed onto the same label (#427).
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_docker_options:
+        app: docket-test-list-opts
+        phase: deploy
+        option: "--memory=512m"
+    - dokku_docker_options:
+        app: docket-test-list-opts
+        phase: build
+        option: "--shm-size=1g"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "dokku_docker_options[app=docket-test-list-opts,phase=deploy,option=--memory=512m]"
+  assert_output --partial "dokku_docker_options[app=docket-test-list-opts,phase=build,option=--shm-size=1g]"
+  refute_output --partial "task #"
+}
+
+@test "--list-tasks output is identical across runs" {
+  # The correlation guarantee: a consumer diffing one run against another has
+  # to be able to line the tasks up. Before #427 unnamed tasks carried eight
+  # random bytes and nothing lined up.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app: { app: docket-test-list-stable }
+    - dokku_config: { app: docket-test-list-stable, config: { A: "1" } }
+    - dokku_config: { app: docket-test-list-stable, state: absent, config: { B: "" } }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  first="$output"
+  assert_output --partial "dokku_config[app=docket-test-list-stable]"
+  assert_output --partial "dokku_config[app=docket-test-list-stable] #2"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  [ "$output" = "$first" ]
+}
+
+@test "--start-at-task resumes at a generated name" {
+  # An unnamed task could not be named on the command line at all before
+  # #427, because its name differed on every run.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app: { app: docket-test-resume-1 }
+    - dokku_app: { app: docket-test-resume-2 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --start-at-task 'dokku_app[app=docket-test-resume-2]'
+  assert_success
+  assert_output --partial "dokku_app[app=docket-test-resume-2]"
+}
+
+@test "validate --strict accepts a generated --start-at-task name" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app: { app: docket-test-validate-resume }
+    - dokku_config: { app: docket-test-validate-resume, config: { A: "1" } }
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --strict --start-at-task 'dokku_config[app=docket-test-validate-resume]'
+  assert_success
+  refute_output --partial "unknown_start_at_task"
+}
+
+@test "validate --strict still rejects an unknown --start-at-task name" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app: { app: docket-test-validate-typo }
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --strict --start-at-task 'dokku_app[app=nope]'
+  assert_failure
+  assert_output --partial 'does not match any task in the recipe'
+  assert_output --partial "dokku_app[app=docket-test-validate-typo]"
 }
 
 @test "--list-tasks shows [skipped] for when:false" {


### PR DESCRIPTION
Every task knows implicitly which resource it manages - `dokku_config` by `app`, a property task by `app`-or-`global` plus `property`, `dokku_service_property` by `service` plus `name` plus `property` - but that knowledge only existed in the shape of each task's `required:"true"` fields. Two field tags write it down instead: `identity:"key"` on each field that selects the resource, and `identity:"collection"` on a collection the task manages wholesale, whose per-item identity is the element value, the map key, or the element struct's own keys. A new `tasks/identity.go` reads them and renders a resource address, `dokku_config[app=api]`, which parses back. Each task's reference page gains an Identity section.

The keys are not simply the required fields, and the three directions that heuristic fails in each have real tasks in them. A required field can be a payload rather than an address: `dokku_git_from_image`'s `image` is required, but an app has one deploy source, so the task keys on `app`. A required collection is not a key: `dokku_ps_scale`'s `scale` is the managed item set. And a key need not be required at all: `dokku_certs` and `dokku_domains` have no required field between them and key on the mutually exclusive `app` / `global` pair. The desired state is never a key - `state:` says what to do to a resource, not which one it is - so editing it does not rename a task. For the set-valued tasks the issue singles out, the recorded decision is that the collection is the resource rather than part of its key, which is why `dokku_domains` keys on its scope alone.

An unnamed task used to be named `task #3 9F2A1C4D`, with eight random bytes appended. `name` is the only correlation key in the `--json` event stream, so two runs of one recipe emitted different names for the same task and a dashboard or a CI job comparing plan to apply could line nothing up; `--start-at-task` could not name an unnamed task at all, which is most of them, since `docket export` writes no `name:` on anything it emits. An unnamed task is now named after the resource it addresses. Two tasks in one play can legitimately address one resource, so later occurrences take an ordinal, and a name the recipe author wrote is reserved before any generated name is assigned so it is never displaced. An unnamed group takes its position in the tree instead, since it manages no resource, and an unnamed loop names each iteration after the resource that iteration addresses, falling back to the item suffix for the whole loop when the iterations address the same resource.

`--list-tasks` drops the display heuristic it used to paper over the random names with. That heuristic picked the first non-empty field named App, Name, Service, Repository, Mount, or Url, which collapsed every phase and option of one app's docker options onto the same label; the listing and the run stream now agree on one name. `validate --strict --start-at-task` resolves the generated names too, standing down for a play holding a `loop:` entry or an input with no default rather than reporting a valid name as unknown. Loader parse errors now quote the entry's position in the file instead of the envelope name, which had been rendering the random suffix into compile errors.

`docket export --resource` takes one of those addresses and reads back a single resource, rather than reconstructing whole app plays as the only granularity available. A bare task type means every resource of that type, the flag is repeatable and cannot be combined with `--app`, and an unknown type, an unexportable one, or a key the task does not declare is rejected before the server is contacted.

No field is both an identity key and `sensitive:"true"`, enforced by a coverage test, because a generated name is rendered into `--list-tasks` output, which is deliberately unmasked. Whether that stream should mask at all is dokku/docket#455. The twenty-seven byte-identical property task structs that this change had to tag by hand are dokku/docket#454.

Fixes #427
