### PR TITLE
feat: emit a machine-readable catalog of task types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: run unit tests
-        run: go test -v -count=1 . ./commands/ ./tasks/ ./subprocess/
+        run: go test -v -count=1 . ./commands/ ./tasks/ ./subprocess/ ./generate/
 
   integration-test:
     name: integration-test

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ docs:
 
 .PHONY: test
 test:
-	go test -v -count=1 . ./commands/ ./tasks/ ./subprocess/
+	go test -v -count=1 . ./commands/ ./tasks/ ./subprocess/ ./generate/
 
 .PHONY: test-integration
 test-integration:

--- a/commands/schema_command.go
+++ b/commands/schema_command.go
@@ -1,0 +1,135 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/dokku/docket/tasks"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// SchemaCommand prints the machine-readable catalog of task types.
+//
+// docket knows the full shape of every task it registers - fields, types,
+// defaults, choices, which values are secrets, what each task addresses, and
+// for a property task the exact set of property names it accepts. Until this
+// command existed, the only way to get at that was to read the generated
+// markdown under docs/tasks/ or to vendor the reflection (#422). The catalog is
+// the same data the reference pages are rendered from, so the two can never
+// disagree.
+//
+// It is offline by contract: no subprocess, no server, and no recipe. The
+// answer depends only on which docket binary is running, which is why the
+// catalog is not a committed file - it cannot go stale.
+//
+// The whole catalog is the only thing it emits today; narrowing it to named
+// task types is #459, which `jq` covers in the meantime.
+type SchemaCommand struct {
+	command.Meta
+
+	output string
+}
+
+func (c *SchemaCommand) Name() string {
+	return "schema"
+}
+
+func (c *SchemaCommand) Synopsis() string {
+	return "Prints the machine-readable catalog of task types"
+}
+
+func (c *SchemaCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *SchemaCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Print the catalog to stdout":     fmt.Sprintf("%s %s", appName, c.Name()),
+		"Write the catalog to a file":     fmt.Sprintf("%s %s --output catalog.json", appName, c.Name()),
+		"List every task type":            fmt.Sprintf("%s %s | jq -r '.tasks[].type'", appName, c.Name()),
+		"Show one task's fields":          fmt.Sprintf("%s %s | jq '.tasks[] | select(.type==\"dokku_config\") | .fields'", appName, c.Name()),
+		"List a property task's settings": fmt.Sprintf("%s %s | jq -r '.tasks[] | select(.type==\"dokku_nginx_property\") | .property_schema.properties[].name'", appName, c.Name()),
+	}
+}
+
+func (c *SchemaCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *SchemaCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *SchemaCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *SchemaCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.StringVar(&c.output, "output", "-", "path to write the catalog to; - writes to stdout")
+	return f
+}
+
+func (c *SchemaCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--output": complete.PredictFiles("*.json"),
+		},
+	)
+}
+
+// Run builds the catalog and writes it. Exit codes:
+//
+//	0 - catalog written
+//	1 - flag parse error, unexpected positional argument, or IO error
+func (c *SchemaCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+	if rest := flags.Args(); len(rest) > 0 {
+		c.Ui.Error(fmt.Sprintf("unexpected argument %q: schema takes no arguments", rest[0]))
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	catalog, err := tasks.Catalog()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("failed to build the task catalog: %v", err))
+		return 1
+	}
+
+	// Encode into memory first so a serialization failure cannot leave a
+	// half-written document on stdout or a truncated file on disk.
+	var buf bytes.Buffer
+	if err := catalog.Encode(&buf); err != nil {
+		c.Ui.Error(fmt.Sprintf("failed to encode the task catalog: %v", err))
+		return 1
+	}
+
+	// The catalog goes straight to stdout rather than through c.Ui, which is
+	// wrapped in a human log formatter. Same reason init and export write
+	// their rendered output directly.
+	if c.output == "-" {
+		if _, err := os.Stdout.Write(buf.Bytes()); err != nil {
+			c.Ui.Error(fmt.Sprintf("write error: %v", err))
+			return 1
+		}
+		return 0
+	}
+
+	if err := os.WriteFile(c.output, buf.Bytes(), 0o644); err != nil {
+		c.Ui.Error(fmt.Sprintf("write error: %v", err))
+		return 1
+	}
+	return 0
+}

--- a/commands/schema_command_test.go
+++ b/commands/schema_command_test.go
@@ -1,0 +1,307 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// runSchema drives the command and returns its stdout, the Ui's stderr, and
+// the exit code. The catalog goes to os.Stdout rather than through the Ui, so
+// the capture has to happen at the file descriptor.
+func runSchema(t *testing.T, args ...string) (string, string, int) {
+	t.Helper()
+	c := &SchemaCommand{}
+	c.Meta = command.Meta{Ui: cli.NewMockUi()}
+	out, exit := captureStdout(t, func() int { return c.Run(args) })
+	return out, c.Ui.(*cli.MockUi).ErrorWriter.String(), exit
+}
+
+// decodeCatalog parses an emitted catalog into a generic document.
+func decodeCatalog(t *testing.T, out string) map[string]interface{} {
+	t.Helper()
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("decode catalog: %v\nraw: %s", err, out)
+	}
+	return doc
+}
+
+// catalogTasks returns the emitted task entries keyed by type.
+func catalogTasks(t *testing.T, doc map[string]interface{}) map[string]map[string]interface{} {
+	t.Helper()
+	list, ok := doc["tasks"].([]interface{})
+	if !ok {
+		t.Fatalf("catalog has no tasks array: %v", doc["tasks"])
+	}
+	out := map[string]map[string]interface{}{}
+	for _, entry := range list {
+		task, ok := entry.(map[string]interface{})
+		if !ok {
+			t.Fatalf("task entry is not an object: %v", entry)
+		}
+		name, _ := task["type"].(string)
+		out[name] = task
+	}
+	return out
+}
+
+func TestSchemaCommandMetadata(t *testing.T) {
+	c := &SchemaCommand{}
+	if c.Name() != "schema" {
+		t.Errorf("Name = %q, want %q", c.Name(), "schema")
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis must not be empty")
+	}
+}
+
+func TestSchemaCommandExamples(t *testing.T) {
+	c := &SchemaCommand{}
+	examples := c.Examples()
+	if len(examples) == 0 {
+		t.Fatal("expected at least one example")
+	}
+	for label, example := range examples {
+		if example == "" {
+			t.Errorf("example %q is empty", label)
+		}
+	}
+}
+
+func TestSchemaCommandHelpDoesNotPanic(t *testing.T) {
+	c := &SchemaCommand{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FlagSet panicked: %v", r)
+		}
+	}()
+	_ = c.FlagSet()
+}
+
+func TestSchemaCommandEmitsEveryRegisteredTask(t *testing.T) {
+	out, stderr, exit := runSchema(t)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", exit, stderr)
+	}
+
+	doc := decodeCatalog(t, out)
+	if version, _ := doc["version"].(float64); int(version) != tasks.CatalogVersion {
+		t.Errorf("version = %v; want %d", doc["version"], tasks.CatalogVersion)
+	}
+
+	emitted := catalogTasks(t, doc)
+	if len(emitted) != len(tasks.RegisteredTasks) {
+		t.Errorf("catalog has %d tasks; registry has %d", len(emitted), len(tasks.RegisteredTasks))
+	}
+	for name := range tasks.RegisteredTasks {
+		if _, ok := emitted[name]; !ok {
+			t.Errorf("catalog is missing task %q", name)
+		}
+	}
+}
+
+// TestSchemaCommandMatchesSchema validates the real emitted document against
+// the published JSON Schema, so a field that exists in the code but not in the
+// schema fails CI - the same contract the three JSON-lines streams have.
+func TestSchemaCommandMatchesSchema(t *testing.T) {
+	out, stderr, exit := runSchema(t)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", exit, stderr)
+	}
+	assertMatchesSchema(t, taskCatalogSchemaPath, out)
+}
+
+// TestTaskCatalogSchemaRejectsUnknownField is the self-check on the guard: if
+// the schema stopped forbidding extra properties, TestSchemaCommandMatchesSchema
+// would quietly become a no-op.
+func TestTaskCatalogSchemaRejectsUnknownField(t *testing.T) {
+	out, _, exit := runSchema(t)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+
+	doc := decodeCatalog(t, out)
+	list, _ := doc["tasks"].([]interface{})
+	if len(list) == 0 {
+		t.Fatal("catalog has no tasks to corrupt")
+	}
+	first, _ := list[0].(map[string]interface{})
+	first["not_a_real_field"] = "x"
+
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	inst, err := jsonschema.UnmarshalJSON(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := loadSchema(t, taskCatalogSchemaPath).Validate(inst); err == nil {
+		t.Error("expected an unknown field to fail validation; schema must set additionalProperties: false")
+	}
+}
+
+// TestSchemaCommandPublishesPropertyTables covers the half of the catalog the
+// reference pages could not express before: which names a property task's
+// free-form-looking `property` field actually accepts.
+func TestSchemaCommandPublishesPropertyTables(t *testing.T) {
+	out, _, exit := runSchema(t)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	emitted := catalogTasks(t, decodeCatalog(t, out))
+
+	apps, ok := emitted["dokku_apps_property"]["property_schema"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("dokku_apps_property has no property_schema: %v", emitted["dokku_apps_property"])
+	}
+	if apps["plugin"] != "apps" || apps["subcommand"] != "apps:set" || apps["field"] != "property" {
+		t.Errorf("apps property_schema = %v", apps)
+	}
+
+	properties, _ := apps["properties"].([]interface{})
+	scopes := map[string][]interface{}{}
+	for _, entry := range properties {
+		property, _ := entry.(map[string]interface{})
+		name, _ := property["name"].(string)
+		scopes[name], _ = property["scopes"].([]interface{})
+	}
+	if got := scopes["disable-autocreation"]; len(got) != 1 || got[0] != "global" {
+		t.Errorf("disable-autocreation scopes = %v; want [global]", got)
+	}
+	if got := scopes["deploy-source"]; len(got) != 1 || got[0] != "app" {
+		t.Errorf("deploy-source scopes = %v; want [app]", got)
+	}
+
+	// A free-form property field must not be published as an empty table: the
+	// difference between "no legal names" and "docket cannot enumerate them"
+	// is the whole point.
+	if _, ok := emitted["dokku_service_property"]["property_schema"]; ok {
+		t.Error("dokku_service_property must not publish a property_schema")
+	}
+}
+
+// TestSchemaCommandMarksSensitiveFields guards the fact a consumer most needs
+// from the catalog: which values it must not echo.
+func TestSchemaCommandMarksSensitiveFields(t *testing.T) {
+	out, _, exit := runSchema(t)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	emitted := catalogTasks(t, decodeCatalog(t, out))
+
+	fields, _ := emitted["dokku_git_from_image"]["fields"].([]interface{})
+	found := false
+	for _, entry := range fields {
+		field, _ := entry.(map[string]interface{})
+		if field["name"] != "image" {
+			continue
+		}
+		found = true
+		if field["sensitive"] != true {
+			t.Errorf("dokku_git_from_image.image sensitive = %v; want true", field["sensitive"])
+		}
+	}
+	if !found {
+		t.Error("dokku_git_from_image has no image field")
+	}
+}
+
+// TestSchemaCommandIncludesExamples checks the catalog carries the snippets the
+// reference pages publish, so a consumer does not have to scrape the markdown
+// to get them.
+func TestSchemaCommandIncludesExamples(t *testing.T) {
+	out, _, exit := runSchema(t)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+
+	for name, task := range catalogTasks(t, decodeCatalog(t, out)) {
+		examples, _ := task["examples"].([]interface{})
+		if len(examples) == 0 {
+			t.Errorf("task %q publishes no examples", name)
+			continue
+		}
+		for _, entry := range examples {
+			example, _ := entry.(map[string]interface{})
+			if example["name"] == "" || example["yaml"] == "" {
+				t.Errorf("task %q has an empty example: %v", name, example)
+			}
+			if body, _ := example["yaml"].(string); !strings.Contains(body, name+":") {
+				t.Errorf("task %q example does not name the task type: %q", name, body)
+			}
+		}
+	}
+}
+
+// TestSchemaCommandOutputIsStable pins that two runs of the same binary agree,
+// so a consumer can diff catalogs across versions and see only real changes.
+func TestSchemaCommandOutputIsStable(t *testing.T) {
+	first, _, _ := runSchema(t)
+	second, _, _ := runSchema(t)
+	if first != second {
+		t.Error("two runs of docket schema produced different output")
+	}
+}
+
+func TestSchemaCommandWritesToFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.json")
+
+	out, stderr, exit := runSchema(t, "--output", path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", exit, stderr)
+	}
+	if out != "" {
+		t.Errorf("--output wrote %d bytes to stdout; want none", len(out))
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	stdout, _, _ := runSchema(t)
+	if string(written) != stdout {
+		t.Error("the file and the stream disagree")
+	}
+}
+
+func TestSchemaCommandRejectsUnknownFlag(t *testing.T) {
+	_, stderr, exit := runSchema(t, "--nope")
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if stderr == "" {
+		t.Error("expected an error message on stderr")
+	}
+}
+
+func TestSchemaCommandRejectsPositionalArgument(t *testing.T) {
+	_, stderr, exit := runSchema(t, "dokku_app")
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, "takes no arguments") {
+		t.Errorf("stderr = %q; want it to explain the command takes no arguments", stderr)
+	}
+}
+
+func TestSchemaCommandReportsAnUnwritableOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-dir", "catalog.json")
+
+	_, stderr, exit := runSchema(t, "--output", path)
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, "write error") {
+		t.Errorf("stderr = %q; want a write error", stderr)
+	}
+}

--- a/commands/schema_test.go
+++ b/commands/schema_test.go
@@ -27,6 +27,10 @@ const (
 	eventsSchemaPath    = "../docs/schemas/events-v1.schema.json"
 	listTasksSchemaPath = "../docs/schemas/list-tasks-v1.schema.json"
 	validateSchemaPath  = "../docs/schemas/validate-v1.schema.json"
+
+	// taskCatalogSchemaPath describes one whole document rather than one
+	// line, since `docket schema` emits a single JSON object.
+	taskCatalogSchemaPath = "../docs/schemas/task-catalog-v1.schema.json"
 )
 
 var (

--- a/commands/stub_task_test.go
+++ b/commands/stub_task_test.go
@@ -21,10 +21,41 @@ type StubTask struct {
 	Key string `yaml:"key" required:"true" identity:"key"`
 }
 
-// Doc / Examples are not exercised by the apply / plan tests. They
-// exist so StubTask satisfies the Task interface.
-func (t StubTask) Doc() string                    { return "stub task for tests" }
-func (t StubTask) Examples() ([]tasks.Doc, error) { return nil, nil }
+// StubTaskExample wraps the stub under its recipe key, the way every real
+// task's example type does.
+type StubTaskExample struct {
+	// Name is the task name holding the StubTask description
+	Name string `yaml:"-"`
+
+	// StubTask is the StubTask configuration
+	StubTask StubTask `yaml:"dokku_stub"`
+}
+
+// GetName returns the name of the example
+func (e StubTaskExample) GetName() string { return e.Name }
+
+// Doc / Examples are not exercised by the apply / plan tests. They exist so
+// StubTask satisfies the Task interface.
+func (t StubTask) Doc() string { return "stub task for tests" }
+
+func (t StubTask) Examples() ([]tasks.Doc, error) {
+	return tasks.MarshalExamples([]StubTaskExample{
+		{Name: "Run the stub", StubTask: StubTask{Key: "example"}},
+	})
+}
+
+// ExportSupport / ProbeSupport are declared for the same reason every real
+// task declares them: the stub stands in for one, and anything that walks the
+// registry - the task catalog, --list-tasks - would otherwise see a task with
+// no declaration at all, which the coverage tests make impossible for a task
+// that actually ships.
+func (t StubTask) ExportSupport() tasks.ExportSupport {
+	return tasks.ExportSupport{Status: tasks.ExportUnsupported, Caveat: "a test fixture has no server state to read back"}
+}
+
+func (t StubTask) ProbeSupport() tasks.ProbeSupport {
+	return tasks.ProbeSupport{Status: tasks.ProbeSupported}
+}
 
 func (t StubTask) Plan() tasks.PlanResult {
 	fixture := stubGet(t.Key)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Complete documentation for docket, a declarative way to pre-package and ship app
 
 - [Command reference](command-reference.md) -- every command and flag
 - [Tasks](tasks/README.md) -- reference for every task type
+- [Task catalog](task-catalog.md) -- the `docket schema` document, the same reference for tooling
 
 ## Guides
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,6 +1,6 @@
 # Command reference
 
-docket has seven commands. Running `docket` with no subcommand prints the list:
+docket has eight commands. Running `docket` with no subcommand prints the list:
 
 | Command | What it does |
 |---------|--------------|
@@ -10,6 +10,7 @@ docket has seven commands. Running `docket` with no subcommand prints the list:
 | [`docket plan`](#docket-plan) | Preview what `apply` would change. |
 | [`docket apply`](#docket-apply) | Run the recipe, making changes as needed. |
 | [`docket export`](#docket-export) | Read a live server and write a recipe describing it. |
+| [`docket schema`](#docket-schema) | Print the machine-readable catalog of task types. |
 | [`docket version`](#docket-version) | Print the binary's version. |
 
 `apply`, `plan`, `validate`, and `fmt` all accept either YAML or JSON5 recipes. When `--tasks` is
@@ -464,6 +465,43 @@ example a value that is lifted into the vars-file), or not exportable (write-onl
 as `dokku_git_auth`, or `dokku_service_property`, which no datastore plugin can read back).
 Resources that cannot be read back are reported as warnings and left out of the recipe.
 
+## docket schema
+
+`docket schema` prints a machine-readable description of every task type docket registers - the
+recipe keys each one accepts, their types, defaults, choices and descriptions, which values are
+secrets, what resource the task addresses, its export and probe support, its documented examples,
+and for a property task the exact set of property names it accepts. It is the same data the
+[task reference](tasks/README.md) pages are rendered from, in a form something other than a reader
+can consume.
+
+The output is a single pretty-printed JSON document on stdout, described by
+[`schemas/task-catalog-v1.schema.json`](schemas/task-catalog-v1.schema.json). See
+[task catalog](task-catalog.md) for the key-by-key contract.
+
+```bash
+# Print the catalog.
+docket schema
+
+# List every task type.
+docket schema | jq -r '.tasks[].type'
+
+# What fields does dokku_config take?
+docket schema | jq '.tasks[] | select(.type=="dokku_config") | .fields'
+
+# Which property names does dokku_nginx_property accept?
+docket schema | jq -r '.tasks[] | select(.type=="dokku_nginx_property") | .property_schema.properties[].name'
+```
+
+Like `init` and `validate`, `schema` is offline: it opens no subprocess and contacts no server. It
+also reads no recipe, so it takes no `--tasks` and no positional argument. Two runs of the same
+binary emit byte-identical output, which is what makes diffing catalogs across docket versions
+useful.
+
+| Flag | Effect |
+|------|--------|
+| (default) | Write the catalog to stdout. |
+| `--output <path>` | Write to a path instead; `-` writes to stdout. An existing file is overwritten, since the catalog is wholly derived and holds nothing of yours. |
+
 ## docket version
 
 `docket version` prints the binary's version and exits.
@@ -477,4 +515,5 @@ docket version
 - [Recipes](recipes.md) - the recipe file, plays, and `--play` / `--fail-fast`
 - [Task envelope](task-envelope.md) - `tags`, `when`, `loop`, and the rest
 - [JSON output](json-output.md) - the `--json` event schema
+- [Task catalog](task-catalog.md) - the `docket schema` document
 - [Remote execution](remote-execution.md) - running against a remote server over SSH

--- a/docs/docs.yaml
+++ b/docs/docs.yaml
@@ -7,6 +7,7 @@ docs:
   - task-envelope.md
   - remote-execution.md
   - json-output.md
+  - task-catalog.md
   - ansible-dokku.md
   - writing-tasks.md
   - roadmap.md

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -154,6 +154,12 @@ the whole stream: split on newlines and validate each line independently.
 | `apply --list-tasks --json`, `plan --list-tasks --json` | [`schemas/list-tasks-v1.schema.json`](schemas/list-tasks-v1.schema.json) |
 | `validate --json` | [`schemas/validate-v1.schema.json`](schemas/validate-v1.schema.json) |
 
+[`docket schema`](task-catalog.md) also emits JSON, but it is not one of these streams: it is a
+single document describing docket's task types rather than a line-per-event record of a run, and
+its schema - [`schemas/task-catalog-v1.schema.json`](schemas/task-catalog-v1.schema.json) -
+validates the whole document at once. Its `version` is its own, independent of the `version` on
+the events above.
+
 `--list-tasks --json` has its own schema because it is a different stream, not a subset of the run
 stream: no task executes, no server is contacted, its per-task event is `list_task` rather than
 `task`, there is no `summary`, and its `play_skipped` carries `play` where the run stream's carries
@@ -194,5 +200,6 @@ non-zero exit with empty stdout as a failure whose detail is on stderr, or run
 ## See also
 
 - [Command reference](command-reference.md) - the `--json` and `--detailed-exitcode` flags
+- [Task catalog](task-catalog.md) - the `docket schema` document, a separate JSON format
 - [Wrapping docket from ansible-dokku](ansible-dokku.md) - a worked consumer of these streams
 - [Task envelope](task-envelope.md#ignore_errors-continue-past-a-failure) - how `ignore_errors` shows up as `"ignored": true`

--- a/docs/schemas/task-catalog-v1.schema.json
+++ b/docs/schemas/task-catalog-v1.schema.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/dokku/docket/main/docs/schemas/task-catalog-v1.schema.json",
+  "title": "docket task catalog",
+  "description": "The document `docket schema` emits: a machine-readable description of every task type docket registers. Unlike the other schemas in this directory, which each describe one line of a JSON-lines stream, this describes one whole document - validate it as a unit. See docs/task-catalog.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "tasks"],
+  "properties": {
+    "version": {
+      "const": 1,
+      "description": "The catalog wire format. Independent of the --json event stream's version; branch on it so a future schema change does not silently break a consumer."
+    },
+    "tasks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/task" },
+      "description": "Every registered task type, sorted by `type`."
+    }
+  },
+  "$defs": {
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "synopsis", "export", "probe", "identity", "fields"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The registry key - the name a recipe uses to invoke the task, such as `dokku_apps_property`."
+        },
+        "synopsis": {
+          "type": "string",
+          "description": "One-line description of what the task manages."
+        },
+        "deprecation": {
+          "type": "string",
+          "description": "The deprecation notice. Present only on a deprecated task; it names the replacement."
+        },
+        "requirements": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Non-core dokku plugins the task needs. Absent when it needs nothing beyond dokku core."
+        },
+        "export": {
+          "$ref": "#/$defs/support",
+          "description": "Whether `docket export` can reconstruct the task from a live server."
+        },
+        "probe": {
+          "$ref": "#/$defs/support",
+          "description": "How much of its own state the task can read back. `unsupported` means it reports drift on every run and never converges."
+        },
+        "identity": { "$ref": "#/$defs/identity" },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/field" },
+          "description": "The recipe keys the task accepts, in declaration order."
+        },
+        "property_schema": {
+          "$ref": "#/$defs/property_schema",
+          "description": "Present only for a task that manages an enumerable dokku property table. Its absence on a task that has a `property` field means the legal names are not enumerable from docket, not that there are none."
+        },
+        "examples": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/example" },
+          "description": "The task's documented examples, the same ones its reference page publishes."
+        }
+      }
+    },
+
+    "support": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["supported", "partial", "unsupported"] },
+        "caveat": {
+          "type": "string",
+          "description": "Human-readable note explaining anything short of supported."
+        }
+      }
+    },
+
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["keys"],
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "The recipe keys that decide which resource the task manages, in the order a resource address renders them. A key holding its zero value is omitted from the address. Equal to the fields carrying `\"identity\": \"key\"`, in declaration order."
+        },
+        "collections": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/identity_collection" },
+          "description": "The collection fields the task manages wholesale."
+        }
+      }
+    },
+
+    "identity_collection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "item"],
+      "properties": {
+        "name": { "type": "string", "description": "The collection's recipe key." },
+        "item": {
+          "enum": ["value", "map_key", "fields"],
+          "description": "What identifies one entry: the element value, the map key, or the element struct's own identity keys."
+        },
+        "item_keys": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "The element's own identity key names. Present only when `item` is `fields`."
+        }
+      }
+    },
+
+    "field": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "required"],
+      "properties": {
+        "name": { "type": "string", "description": "The recipe key." },
+        "type": {
+          "enum": ["string", "bool", "int", "float", "list", "dict", "any"],
+          "description": "The doc-facing type. A named string type such as a state enum is `string`; an optional pointer field is its element type."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether a recipe must supply the field. A field carrying a `default` is never required, because the default is filled in before the missing-field check runs."
+        },
+        "default": {
+          "type": "string",
+          "description": "The literal default, to be read according to `type`. On a pointer field it documents what the task coerces an omitted key to, not a value written into the recipe."
+        },
+        "choices": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "The permitted values. Absent when the field is not an enum."
+        },
+        "description": { "type": "string" },
+        "sensitive": {
+          "const": true,
+          "description": "The value is a secret. A consumer that echoes a recipe must mask it."
+        },
+        "identity": {
+          "enum": ["key", "collection"],
+          "description": "`key` selects which resource the task manages; `collection` is a set of items the task manages wholesale. Absent on a field that is neither."
+        },
+        "item": {
+          "$ref": "#/$defs/item",
+          "description": "The element shape of a list or dict. Absent on a scalar."
+        }
+      }
+    },
+
+    "item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "key_type": {
+          "enum": ["string"],
+          "description": "The map key's type. Present only on a dict."
+        },
+        "type": {
+          "enum": ["string", "bool", "int", "float", "list", "dict", "any", "object"],
+          "description": "The element's type. `object` means the element is a structured entry whose shape is spelled out in `fields`; `any` means the element is untyped."
+        },
+        "identity": {
+          "enum": ["value", "map_key", "fields"],
+          "description": "What identifies one entry. Present only on a field tagged as a collection - an untagged list is an attribute of the resource rather than the set of items the task manages."
+        },
+        "keys": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "The element's own identity key names. Present only when `identity` is `fields`."
+        },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/field" },
+          "description": "The element's own fields, in declaration order. Present only when `type` is `object`. An element declares the same tags a task does, which is where a consumer learns that a nested value is a secret."
+        }
+      }
+    },
+
+    "property_schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plugin", "subcommand", "field", "properties"],
+      "properties": {
+        "plugin": { "type": "string", "description": "The dokku plugin, e.g. `apps`." },
+        "subcommand": {
+          "type": "string",
+          "description": "The dokku subcommand a set or unset runs, e.g. `apps:set`."
+        },
+        "field": {
+          "const": "property",
+          "description": "The recipe key this table constrains."
+        },
+        "properties": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/property_entry" },
+          "description": "The enumerable property names, sorted."
+        },
+        "dynamic": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/dynamic_property" },
+          "description": "Name families the table cannot enumerate, because dokku validates them through the set subcommand rather than through its report schema. A name matching one of these prefixes is legal even though it is absent from `properties`."
+        }
+      }
+    },
+
+    "property_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "scopes"],
+      "properties": {
+        "name": { "type": "string", "description": "The value a recipe puts in `property:`." },
+        "scopes": {
+          "type": "array",
+          "items": { "enum": ["app", "global"] },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Where the property may be used. Using it in a scope it does not list is rejected at validate time, matching dokku's own rejection."
+        },
+        "app_report_key": {
+          "type": "string",
+          "description": "The key `dokku <plugin>:report --format json` emits for the property per app. Absent when the property has no per-app form."
+        },
+        "global_report_key": {
+          "type": "string",
+          "description": "The key `dokku <plugin>:report --global --format json` emits for the property. Absent when the property has no global form."
+        },
+        "sensitive": {
+          "const": true,
+          "description": "The value is a secret."
+        }
+      }
+    },
+
+    "dynamic_property": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prefix", "probeable"],
+      "properties": {
+        "prefix": { "type": "string", "description": "What a member's name starts with." },
+        "probeable": {
+          "type": "boolean",
+          "description": "Whether the plugin's report surfaces a row per set member, so docket can read the value back. `false` means a recipe using the family reports drift on every run and never converges."
+        },
+        "sensitive": {
+          "const": true,
+          "description": "Members' values are treated as secrets."
+        }
+      }
+    },
+
+    "example": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "yaml"],
+      "properties": {
+        "name": { "type": "string", "description": "The heading the reference page gives the example." },
+        "yaml": { "type": "string", "description": "The YAML snippet, ready to paste into a recipe's task list." }
+      }
+    }
+  }
+}

--- a/docs/task-catalog.md
+++ b/docs/task-catalog.md
@@ -1,0 +1,199 @@
+# Task catalog
+
+`docket schema` prints a machine-readable description of every task type docket registers: the
+recipe keys each one accepts, their types, defaults, choices and descriptions, which values are
+secrets, what resource the task addresses, whether it can be exported and probed, and - for a
+property task - the exact set of property names it accepts.
+
+It is the same data the [task reference](tasks/README.md) pages are rendered from, so the two can
+never disagree. Reach for it when something other than a human needs to know the shape of a
+recipe: a schema for another recipe format, an editor completing task bodies, a linter checking a
+recipe before it reaches a server.
+
+```bash
+docket schema
+docket schema --output catalog.json
+```
+
+The command is offline: it opens no subprocess and contacts no server. The answer depends only on
+which docket binary is running, which is why the catalog is not a file in this repository - it
+cannot go stale.
+
+## The document
+
+One JSON object, pretty-printed, with a `version` and a `tasks` array sorted by task type:
+
+```json
+{
+  "version": 1,
+  "tasks": [
+    {
+      "type": "dokku_domains",
+      "synopsis": "Manages the domains for a given dokku application or globally",
+      "export": { "status": "supported" },
+      "probe": { "status": "supported" },
+      "identity": {
+        "keys": ["app", "global"],
+        "collections": [{ "name": "domains", "item": "value" }]
+      },
+      "fields": [
+        { "name": "app", "type": "string", "required": false, "identity": "key",
+          "description": "Name of the app" },
+        { "name": "global", "type": "bool", "required": false, "identity": "key",
+          "description": "Flag indicating if the domains should be applied globally" },
+        { "name": "domains", "type": "list", "required": false, "identity": "collection",
+          "description": "List of domain names; omit for state 'clear'",
+          "item": { "type": "string", "identity": "value" } },
+        { "name": "state", "type": "string", "required": false, "default": "present",
+          "choices": ["present", "absent", "set", "clear"],
+          "description": "Desired state of the domains" }
+      ],
+      "examples": [
+        { "name": "Add a domain to an app", "yaml": "dokku_domains:\n    app: node-js-app\n..." }
+      ]
+    }
+  ]
+}
+```
+
+Every name in the document is a key a recipe author types. Go type names and Go field names are
+deliberately absent - the catalog describes the recipe surface, not docket's implementation.
+
+There is a [JSON Schema](schemas/task-catalog-v1.schema.json) for the whole thing. Unlike the
+[JSON-lines streams](json-output.md), which validate one line at a time, this one validates the
+document as a unit.
+
+## Versioning
+
+`version` is the catalog's wire format, pinned at `1`. Branch on it so a future schema change does
+not silently break a consumer. It is independent of the `version` on
+[`--json` events](json-output.md): they are different formats with different consumers, and a
+breaking change to one does not force the other's consumers to re-branch. Adding a key within a
+major version does not bump it.
+
+The binary's own version is deliberately not in the document, so two builds of the same code emit
+byte-identical catalogs and a diff shows only real changes. Use `docket version` for that.
+
+## Fields
+
+Each entry in `fields` is one recipe key, in the order the task declares them - which is the order
+the reference page lists them in.
+
+| Key | Meaning |
+|-----|---------|
+| `name` | The recipe key. |
+| `type` | `string`, `bool`, `int`, `float`, `list`, `dict`, or `any`. |
+| `required` | Whether a recipe must supply it. |
+| `default` | The default, as a literal string to be read according to `type`. Absent when there is none. |
+| `choices` | The permitted values. Absent when the field is not an enum. |
+| `description` | Prose for a human. |
+| `sensitive` | Present and `true` when the value is a secret. |
+| `identity` | `key` or `collection`. Absent on a field that is neither. |
+| `item` | The element shape of a `list` or `dict`. Absent on a scalar. |
+
+Two of these need care:
+
+- **`required: false` plus a `default`** means optional, and the server sees the default. A field
+  carrying a default is never required, whatever its declaration says, because the default is
+  filled in before the missing-field check runs.
+- **A `default` on a field docket treats as optional-with-a-nil-default** documents what the task
+  coerces an omitted key to, not a value written into the recipe. `dokku_config`'s `restart` is
+  the example: the catalog reports `"default": "true"`, and an explicit `restart: false` is still
+  honoured.
+
+### Item shapes
+
+`list` is the same word for a list of strings and a list of structured entries, so a collection
+field carries an `item` describing its elements. When the element is structured, `item.type` is
+`object` and `item.fields` is a full field list for it - which is where a consumer learns that a
+`dokku_http_auth_user` entry's `password` is a secret:
+
+```json
+{ "name": "users", "type": "list", "identity": "collection",
+  "item": {
+    "type": "object", "identity": "fields", "keys": ["username"],
+    "fields": [
+      { "name": "username", "type": "string", "required": true, "identity": "key" },
+      { "name": "password", "type": "string", "required": false, "sensitive": true },
+      { "name": "hash", "type": "string", "required": false, "sensitive": true }
+    ]
+  } }
+```
+
+A `dict` carries `item.key_type` (always `string`) alongside `item.type`, so a
+`map[string]string` of config pairs and a map of arbitrary values are distinguishable.
+
+`item.identity` says what identifies one entry - `value` for a list of scalars, `map_key` for a
+dict, `fields` (plus `keys`) for structured entries. It is present only on a field tagged as a
+collection: an untagged list is an attribute of the resource rather than the set of items the task
+manages, so it has no item identity to declare.
+
+The catalog cannot express every rule a task enforces. Mutually exclusive fields, per-item
+requirements and conditional requirements live in each task's own validation and in the field
+descriptions; `docket validate` is the authority.
+
+## Identity
+
+`identity.keys` are the recipe keys that decide *which* resource the task manages, in the order a
+[resource address](task-envelope.md#names-and-resource-addresses) renders them. A key holding its
+zero value is omitted from the address, which is what lets the mutually exclusive `app` / `global`
+pair produce two different addresses for the same task type.
+
+It is the same list as the fields carrying `"identity": "key"`, in declaration order, and is
+repeated at the top level because building an address is the main thing a consumer does with it.
+
+`identity.collections` names the collections the task manages wholesale, and how one entry in each
+is identified.
+
+## Property tasks
+
+A `*_property` task looks like it takes a free-form `property: string`. It does not: each one
+manages a fixed table of property names, and until this catalog existed the only way to discover
+them was to trigger a validation error. `property_schema` publishes the table:
+
+```json
+"property_schema": {
+  "plugin": "apps",
+  "subcommand": "apps:set",
+  "field": "property",
+  "properties": [
+    { "name": "deploy-source", "scopes": ["app"], "app_report_key": "deploy-source" },
+    { "name": "disable-autocreation", "scopes": ["global"],
+      "global_report_key": "global-disable-autocreation" }
+  ]
+}
+```
+
+`scopes` is what a consumer usually wants: a property listed only under `global` may be set with
+`global: true` and is rejected for an app, matching dokku's own rejection. The report keys are what
+docket reads from `dokku <plugin>:report --format json` to detect drift.
+
+Some plugins accept a family of names that cannot be enumerated - dokku validates them through the
+set subcommand rather than through its report schema. Those are published as prefixes, so a
+consumer does not reject a legal recipe:
+
+```json
+"dynamic": [ { "prefix": "dns-provider-", "probeable": true, "sensitive": true } ]
+```
+
+`probeable: false` means docket cannot read those values back, so a recipe using that family
+reports drift on every run and never converges.
+
+**An absent `property_schema` on a task that has a `property` field means the legal names are not
+enumerable from docket, not that there are none.** `dokku_service_property` is the case: its names
+come from whichever datastore plugin backs the service, and no plugin exposes a report that lists
+them.
+
+## Stability
+
+- Tasks are sorted by `type`; properties by `name`; dynamic families by `prefix`.
+- Fields, identity keys, requirements and choices keep declaration order, because that order is
+  meaningful.
+- Two runs of the same binary produce byte-identical output.
+
+## See also
+
+- [Command reference](command-reference.md#docket-schema) - the command and its flags
+- [Tasks](tasks/README.md) - the same information rendered for a human
+- [JSON output](json-output.md) - the `--json` event streams, a separate format
+- [Writing tasks](writing-tasks.md) - the declarations a task makes to fill the catalog

--- a/docs/tasks/dokku_app_json_property.md
+++ b/docs/tasks/dokku_app_json_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the app.json property |
 | `state` | string | no | present | present, absent | Desired state of the app.json configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku app-json:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `appjson-path` | app, global | `appjson-path` | `global-appjson-path` |
+
 ## Examples
 
 ### Setting the appjson-path for an app

--- a/docs/tasks/dokku_apps_property.md
+++ b/docs/tasks/dokku_apps_property.md
@@ -26,6 +26,16 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the apps property |
 | `state` | string | no | present | present, absent | Desired state of the apps configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku apps:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `deploy-source` | app | `deploy-source` |  |
+| `deploy-source-metadata` | app | `deploy-source-metadata` |  |
+| `disable-autocreation` | global |  | `global-disable-autocreation` |
+
 ## Examples
 
 ### Disabling app auto-creation globally

--- a/docs/tasks/dokku_builder_dockerfile_property.md
+++ b/docs/tasks/dokku_builder_dockerfile_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builder-dockerfile property |
 | `state` | string | no | present | present, absent | Desired state of the builder-dockerfile configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builder-dockerfile:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `dockerfile-path` | app, global | `dockerfile-path` | `global-dockerfile-path` |
+
 ## Examples
 
 ### Setting the dockerfile path for an app

--- a/docs/tasks/dokku_builder_herokuish_property.md
+++ b/docs/tasks/dokku_builder_herokuish_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builder-herokuish property |
 | `state` | string | no | present | present, absent | Desired state of the builder-herokuish configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builder-herokuish:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `allowed` | app, global | `allowed` | `global-allowed` |
+
 ## Examples
 
 ### Allowing the herokuish builder for an app

--- a/docs/tasks/dokku_builder_lambda_property.md
+++ b/docs/tasks/dokku_builder_lambda_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builder-lambda property |
 | `state` | string | no | present | present, absent | Desired state of the builder-lambda configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builder-lambda:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `lambdayml-path` | app, global | `lambdayml-path` | `global-lambdayml-path` |
+
 ## Examples
 
 ### Setting the lambda.yml path for an app

--- a/docs/tasks/dokku_builder_nixpacks_property.md
+++ b/docs/tasks/dokku_builder_nixpacks_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builder-nixpacks property |
 | `state` | string | no | present | present, absent | Desired state of the builder-nixpacks configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builder-nixpacks:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `nixpackstoml-path` | app, global | `nixpackstoml-path` | `global-nixpackstoml-path` |
+
 ## Examples
 
 ### Setting the nixpacks.toml path for an app

--- a/docs/tasks/dokku_builder_pack_property.md
+++ b/docs/tasks/dokku_builder_pack_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builder-pack property |
 | `state` | string | no | present | present, absent | Desired state of the builder-pack configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builder-pack:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `projecttoml-path` | app, global | `projecttoml-path` | `global-projecttoml-path` |
+
 ## Examples
 
 ### Setting the project.toml path for an app

--- a/docs/tasks/dokku_builder_property.md
+++ b/docs/tasks/dokku_builder_property.md
@@ -26,6 +26,16 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builder property |
 | `state` | string | no | present | present, absent | Desired state of the builder configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builder:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `build-dir` | app, global | `build-dir` | `global-build-dir` |
+| `selected` | app, global | `selected` | `global-selected` |
+| `skip-cleanup` | app, global | `skip-cleanup` | `global-skip-cleanup` |
+
 ## Examples
 
 ### Overriding the auto-selected builder

--- a/docs/tasks/dokku_builder_railpack_property.md
+++ b/docs/tasks/dokku_builder_railpack_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builder-railpack property |
 | `state` | string | no | present | present, absent | Desired state of the builder-railpack configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builder-railpack:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `railpackjson-path` | app, global | `railpackjson-path` | `global-railpackjson-path` |
+
 ## Examples
 
 ### Setting the railpack.json path for an app

--- a/docs/tasks/dokku_buildpacks_property.md
+++ b/docs/tasks/dokku_buildpacks_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the buildpacks property |
 | `state` | string | no | present | present, absent | Desired state of the buildpacks configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku buildpacks:set-property`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `stack` | app, global | `stack` | `global-stack` |
+
 ## Examples
 
 ### Setting the stack value for an app

--- a/docs/tasks/dokku_builds_property.md
+++ b/docs/tasks/dokku_builds_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the builds property |
 | `state` | string | no | present | present, absent | Desired state of the builds configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku builds:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `retention` | app, global | `retention` | `global-retention` |
+
 ## Examples
 
 ### Setting the retention value for an app

--- a/docs/tasks/dokku_caddy_property.md
+++ b/docs/tasks/dokku_caddy_property.md
@@ -26,6 +26,19 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the caddy property |
 | `state` | string | no | present | present, absent | Desired state of the caddy configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku caddy:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `image` | global |  | `global-image` |
+| `letsencrypt-email` | global |  | `global-letsencrypt-email` |
+| `letsencrypt-server` | global |  | `global-letsencrypt-server` |
+| `log-level` | global |  | `global-log-level` |
+| `polling-interval` | global |  | `global-polling-interval` |
+| `tls-internal` | app, global | `tls-internal` | `global-tls-internal` |
+
 ## Examples
 
 ### Enabling internal TLS for an app

--- a/docs/tasks/dokku_checks_property.md
+++ b/docs/tasks/dokku_checks_property.md
@@ -26,6 +26,14 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the checks property |
 | `state` | string | no | present | present, absent | Desired state of the checks configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku checks:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `wait-to-retire` | app, global | `wait-to-retire` | `global-wait-to-retire` |
+
 ## Examples
 
 ### Setting the wait-to-retire value for an app

--- a/docs/tasks/dokku_cron_property.md
+++ b/docs/tasks/dokku_cron_property.md
@@ -26,6 +26,16 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the cron property |
 | `state` | string | no | present | present, absent | Desired state of the cron configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku cron:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `mailfrom` | global |  | `global-mailfrom` |
+| `mailto` | global |  | `global-mailto` |
+| `maintenance` | app, global | `maintenance` | `global-maintenance` |
+
 ## Examples
 
 ### Enabling maintenance mode for an app

--- a/docs/tasks/dokku_git_property.md
+++ b/docs/tasks/dokku_git_property.md
@@ -26,6 +26,19 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the git property |
 | `state` | string | no | present | present, absent | Desired state of the git configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku git:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `archive-max-files` | global |  | `global-archive-max-files` |
+| `archive-max-size` | global |  | `global-archive-max-size` |
+| `deploy-branch` | app, global | `deploy-branch` | `global-deploy-branch` |
+| `keep-git-dir` | app, global | `keep-git-dir` | `global-keep-git-dir` |
+| `rev-env-var` | app | `rev-env-var` |  |
+| `source-image` | app | `source-image` |  |
+
 ## Examples
 
 ### Setting the deploy branch for an app

--- a/docs/tasks/dokku_haproxy_property.md
+++ b/docs/tasks/dokku_haproxy_property.md
@@ -26,6 +26,18 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the haproxy property |
 | `state` | string | no | present | present, absent | Desired state of the haproxy configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku haproxy:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `image` | global |  | `global-image` |
+| `letsencrypt-email` | global |  | `global-letsencrypt-email` |
+| `letsencrypt-server` | global |  | `global-letsencrypt-server` |
+| `log-level` | global |  | `global-log-level` |
+| `refresh-conf` | global |  | `global-refresh-conf` |
+
 ## Examples
 
 ### Setting the letsencrypt email globally

--- a/docs/tasks/dokku_letsencrypt_property.md
+++ b/docs/tasks/dokku_letsencrypt_property.md
@@ -30,6 +30,21 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the letsencrypt property (sensitive) |
 | `state` | string | no | present | present, absent | Desired state of the letsencrypt configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku letsencrypt:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `dns-provider` | app, global | `dns-provider` | `global-dns-provider` |
+| `email` | app, global | `email` | `global-email` |
+| `graceperiod` | app, global | `graceperiod` | `global-graceperiod` |
+| `lego-args` | app, global | `lego-args` | `global-lego-args` |
+| `lego-docker-options` | app, global | `lego-docker-options` | `global-lego-docker-options` |
+| `server` | app, global | `server` | `global-server` |
+
+Names starting with `dns-provider-` are also accepted. dokku validates them through `letsencrypt:set` rather than through its report schema, so they cannot be listed above. The plugin reports each one it has been given, so they probe for drift like any listed property. Their values are treated as secrets and masked.
+
 ## Examples
 
 ### Setting the letsencrypt email for an app

--- a/docs/tasks/dokku_logs_property.md
+++ b/docs/tasks/dokku_logs_property.md
@@ -26,6 +26,18 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the logs property |
 | `state` | string | no | present | present, absent | Desired state of the logs configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku logs:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `app-label-alias` | app, global | `app-label-alias` | `global-app-label-alias` |
+| `max-size` | app, global | `max-size` | `global-max-size` |
+| `vector-image` | global |  | `global-vector-image` |
+| `vector-networks` | global |  | `global-vector-networks` |
+| `vector-sink` | app, global | `vector-sink` | `global-vector-sink` |
+
 ## Examples
 
 ### Setting the max-size value for an app

--- a/docs/tasks/dokku_network_property.md
+++ b/docs/tasks/dokku_network_property.md
@@ -26,6 +26,19 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value of the network property to set |
 | `state` | string | no | present | present, absent | Desired state of the network property |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku network:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `attach-post-create` | app, global | `attach-post-create` | `global-attach-post-create` |
+| `attach-post-deploy` | app, global | `attach-post-deploy` | `global-attach-post-deploy` |
+| `bind-all-interfaces` | app, global | `bind-all-interfaces` | `global-bind-all-interfaces` |
+| `initial-network` | app, global | `initial-network` | `global-initial-network` |
+| `static-web-listener` | app | `static-web-listener` |  |
+| `tld` | app, global | `tld` | `global-tld` |
+
 ## Examples
 
 ### Associates a network after a container is created but before it is started

--- a/docs/tasks/dokku_nginx_property.md
+++ b/docs/tasks/dokku_nginx_property.md
@@ -26,6 +26,44 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the nginx property |
 | `state` | string | no | present | present, absent | Desired state of the nginx configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku nginx:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `access-log-format` | app, global | `access-log-format` | `global-access-log-format` |
+| `access-log-path` | app, global | `access-log-path` | `global-access-log-path` |
+| `bind-address-ipv4` | app, global | `bind-address-ipv4` | `global-bind-address-ipv4` |
+| `bind-address-ipv6` | app, global | `bind-address-ipv6` | `global-bind-address-ipv6` |
+| `client-body-timeout` | app, global | `client-body-timeout` | `global-client-body-timeout` |
+| `client-header-timeout` | app, global | `client-header-timeout` | `global-client-header-timeout` |
+| `client-max-body-size` | app, global | `client-max-body-size` | `global-client-max-body-size` |
+| `disable-custom-config` | app, global | `disable-custom-config` | `global-disable-custom-config` |
+| `error-log-path` | app, global | `error-log-path` | `global-error-log-path` |
+| `hsts` | app, global | `hsts` | `global-hsts` |
+| `hsts-include-subdomains` | app, global | `hsts-include-subdomains` | `global-hsts-include-subdomains` |
+| `hsts-max-age` | app, global | `hsts-max-age` | `global-hsts-max-age` |
+| `hsts-preload` | app, global | `hsts-preload` | `global-hsts-preload` |
+| `keepalive-timeout` | app, global | `keepalive-timeout` | `global-keepalive-timeout` |
+| `lingering-timeout` | app, global | `lingering-timeout` | `global-lingering-timeout` |
+| `nginx-conf-sigil-path` | app, global | `nginx-conf-sigil-path` | `global-nginx-conf-sigil-path` |
+| `nginx-service-command` | app, global | `nginx-service-command` | `global-nginx-service-command` |
+| `proxy-buffer-size` | app, global | `proxy-buffer-size` | `global-proxy-buffer-size` |
+| `proxy-buffering` | app, global | `proxy-buffering` | `global-proxy-buffering` |
+| `proxy-buffers` | app, global | `proxy-buffers` | `global-proxy-buffers` |
+| `proxy-busy-buffers-size` | app, global | `proxy-busy-buffers-size` | `global-proxy-busy-buffers-size` |
+| `proxy-connect-timeout` | app, global | `proxy-connect-timeout` | `global-proxy-connect-timeout` |
+| `proxy-keepalive` | app, global | `proxy-keepalive` | `global-proxy-keepalive` |
+| `proxy-read-timeout` | app, global | `proxy-read-timeout` | `global-proxy-read-timeout` |
+| `proxy-send-timeout` | app, global | `proxy-send-timeout` | `global-proxy-send-timeout` |
+| `send-timeout` | app, global | `send-timeout` | `global-send-timeout` |
+| `underscore-in-headers` | app, global | `underscore-in-headers` | `global-underscore-in-headers` |
+| `x-forwarded-for-value` | app, global | `x-forwarded-for-value` | `global-x-forwarded-for-value` |
+| `x-forwarded-port-value` | app, global | `x-forwarded-port-value` | `global-x-forwarded-port-value` |
+| `x-forwarded-proto-value` | app, global | `x-forwarded-proto-value` | `global-x-forwarded-proto-value` |
+| `x-forwarded-ssl` | app, global | `x-forwarded-ssl` | `global-x-forwarded-ssl` |
+
 ## Examples
 
 ### Setting the proxy read timeout for an app

--- a/docs/tasks/dokku_openresty_property.md
+++ b/docs/tasks/dokku_openresty_property.md
@@ -26,6 +26,45 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the openresty property |
 | `state` | string | no | present | present, absent | Desired state of the openresty configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku openresty:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `access-log-format` | app, global | `access-log-format` | `global-access-log-format` |
+| `access-log-path` | app, global | `access-log-path` | `global-access-log-path` |
+| `allowed-letsencrypt-domains-func-base64` | global |  | `global-allowed-letsencrypt-domains-func-base64` |
+| `bind-address-ipv4` | app, global | `bind-address-ipv4` | `global-bind-address-ipv4` |
+| `bind-address-ipv6` | app, global | `bind-address-ipv6` | `global-bind-address-ipv6` |
+| `client-body-timeout` | app, global | `client-body-timeout` | `global-client-body-timeout` |
+| `client-header-timeout` | app, global | `client-header-timeout` | `global-client-header-timeout` |
+| `client-max-body-size` | app, global | `client-max-body-size` | `global-client-max-body-size` |
+| `error-log-path` | app, global | `error-log-path` | `global-error-log-path` |
+| `hsts` | app, global | `hsts` | `global-hsts` |
+| `hsts-include-subdomains` | app, global | `hsts-include-subdomains` | `global-hsts-include-subdomains` |
+| `hsts-max-age` | app, global | `hsts-max-age` | `global-hsts-max-age` |
+| `hsts-preload` | app, global | `hsts-preload` | `global-hsts-preload` |
+| `image` | global |  | `global-image` |
+| `keepalive-timeout` | app, global | `keepalive-timeout` | `global-keepalive-timeout` |
+| `letsencrypt-email` | global |  | `global-letsencrypt-email` |
+| `letsencrypt-server` | global |  | `global-letsencrypt-server` |
+| `lingering-timeout` | app, global | `lingering-timeout` | `global-lingering-timeout` |
+| `log-level` | global |  | `global-log-level` |
+| `proxy-buffer-size` | app, global | `proxy-buffer-size` | `global-proxy-buffer-size` |
+| `proxy-buffering` | app, global | `proxy-buffering` | `global-proxy-buffering` |
+| `proxy-buffers` | app, global | `proxy-buffers` | `global-proxy-buffers` |
+| `proxy-busy-buffers-size` | app, global | `proxy-busy-buffers-size` | `global-proxy-busy-buffers-size` |
+| `proxy-connect-timeout` | app, global | `proxy-connect-timeout` | `global-proxy-connect-timeout` |
+| `proxy-read-timeout` | app, global | `proxy-read-timeout` | `global-proxy-read-timeout` |
+| `proxy-send-timeout` | app, global | `proxy-send-timeout` | `global-proxy-send-timeout` |
+| `send-timeout` | app, global | `send-timeout` | `global-send-timeout` |
+| `underscore-in-headers` | app, global | `underscore-in-headers` | `global-underscore-in-headers` |
+| `x-forwarded-for-value` | app, global | `x-forwarded-for-value` | `global-x-forwarded-for-value` |
+| `x-forwarded-port-value` | app, global | `x-forwarded-port-value` | `global-x-forwarded-port-value` |
+| `x-forwarded-proto-value` | app, global | `x-forwarded-proto-value` | `global-x-forwarded-proto-value` |
+| `x-forwarded-ssl` | app, global | `x-forwarded-ssl` | `global-x-forwarded-ssl` |
+
 ## Examples
 
 ### Setting the proxy read timeout for an app

--- a/docs/tasks/dokku_proxy_property.md
+++ b/docs/tasks/dokku_proxy_property.md
@@ -26,6 +26,16 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the proxy property |
 | `state` | string | no | present | present, absent | Desired state of the proxy configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku proxy:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `proxy-port` | app, global | `proxy-port` | `global-proxy-port` |
+| `proxy-ssl-port` | app, global | `proxy-ssl-port` | `global-proxy-ssl-port` |
+| `type` | app, global | `type` | `global-type` |
+
 ## Examples
 
 ### Setting the proxy type for an app

--- a/docs/tasks/dokku_ps_property.md
+++ b/docs/tasks/dokku_ps_property.md
@@ -26,6 +26,19 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the ps property |
 | `state` | string | no | present | present, absent | Desired state of the ps configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku ps:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `dockerfile-start-cmd` | app | `dockerfile-start-cmd` |  |
+| `procfile-path` | app, global | `procfile-path` | `global-procfile-path` |
+| `restart-policy` | app, global | `restart-policy` | `global-restart-policy` |
+| `skip-deploy` | app, global | `skip-deploy` | `global-skip-deploy` |
+| `start-cmd` | app | `start-cmd` |  |
+| `stop-timeout-seconds` | app, global | `stop-timeout-seconds` | `global-stop-timeout-seconds` |
+
 ## Examples
 
 ### Setting the restart-policy value for an app

--- a/docs/tasks/dokku_registry_property.md
+++ b/docs/tasks/dokku_registry_property.md
@@ -26,6 +26,18 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the registry property |
 | `state` | string | no | present | present, absent | Desired state of the registry configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku registry:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `image-repo` | app | `image-repo` |  |
+| `image-repo-template` | app, global | `image-repo-template` | `global-image-repo-template` |
+| `push-extra-tags` | app, global | `push-extra-tags` | `global-push-extra-tags` |
+| `push-on-release` | app, global | `push-on-release` | `global-push-on-release` |
+| `server` | app, global | `server` | `global-server` |
+
 ## Examples
 
 ### Setting the image repo for an app

--- a/docs/tasks/dokku_scheduler_docker_local_property.md
+++ b/docs/tasks/dokku_scheduler_docker_local_property.md
@@ -25,6 +25,15 @@ Keyed by `app` and `property`. Fields left empty are omitted from the address.
 | `value` | string | no |  |  | Value to set for the scheduler-docker-local property |
 | `state` | string | no | present | present, absent | Desired state of the scheduler-docker-local configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku scheduler-docker-local:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `init-process` | app | `init-process` |  |
+| `parallel-schedule-count` | app | `parallel-schedule-count` |  |
+
 ## Examples
 
 ### Enabling the init process for an app

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -26,6 +26,27 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the scheduler-k3s property |
 | `state` | string | no | present | present, absent | Desired state of the scheduler-k3s configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku scheduler-k3s:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `deploy-timeout` | app, global | `deploy-timeout` | `global-deploy-timeout` |
+| `image-pull-secrets` | app, global | `image-pull-secrets` | `global-image-pull-secrets` |
+| `ingress-class` | global |  | `global-ingress-class` |
+| `kube-context` | global |  | `global-kube-context` |
+| `kubeconfig-path` | global |  | `global-kubeconfig-path` |
+| `kustomize-root-path` | app, global | `kustomize-root-path` | `global-kustomize-root-path` |
+| `letsencrypt-email-prod` | global |  | `global-letsencrypt-email-prod` |
+| `letsencrypt-email-stag` | global |  | `global-letsencrypt-email-stag` |
+| `letsencrypt-server` | app, global | `letsencrypt-server` | `global-letsencrypt-server` |
+| `namespace` | app, global | `namespace` | `global-namespace` |
+| `network-interface` | global |  | `global-network-interface` |
+| `rollback-on-failure` | app, global | `rollback-on-failure` | `global-rollback-on-failure` |
+| `shm-size` | app, global | `shm-size` | `global-shm-size` |
+| `token` (sensitive) | global |  | `global-token` |
+
 ## Examples
 
 ### Setting the deploy timeout for an app

--- a/docs/tasks/dokku_scheduler_property.md
+++ b/docs/tasks/dokku_scheduler_property.md
@@ -26,6 +26,15 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the scheduler property |
 | `state` | string | no | present | present, absent | Desired state of the scheduler configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku scheduler:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `selected` | app, global | `selected` | `global-selected` |
+| `shell` | app, global | `shell` | `global-shell` |
+
 ## Examples
 
 ### Selecting the scheduler for an app

--- a/docs/tasks/dokku_traefik_property.md
+++ b/docs/tasks/dokku_traefik_property.md
@@ -26,6 +26,30 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `value` | string | no |  |  | Value to set for the traefik property |
 | `state` | string | no | present | present, absent | Desired state of the traefik configuration |
 
+## Properties
+
+`property` accepts one of the following, applied with `dokku traefik:set`. A property with no form in a scope is rejected there, matching dokku's own rejection.
+
+| Property | Scopes | Report key (app) | Report key (global) |
+| --- | --- | --- | --- |
+| `api-enabled` | global |  | `global-api-enabled` |
+| `api-entry-point` | global |  | `global-api-entry-point` |
+| `api-entry-point-address` | global |  | `global-api-entry-point-address` |
+| `api-vhost` | global |  | `global-api-vhost` |
+| `basic-auth-password` (sensitive) | global |  | `global-basic-auth-password` |
+| `basic-auth-username` | global |  | `global-basic-auth-username` |
+| `challenge-mode` | global |  | `global-challenge-mode` |
+| `dashboard-enabled` | global |  | `global-dashboard-enabled` |
+| `dns-provider` | global |  | `global-dns-provider` |
+| `http-entry-point` | global |  | `global-http-entry-point` |
+| `https-entry-point` | global |  | `global-https-entry-point` |
+| `image` | global |  | `global-image` |
+| `letsencrypt-email` | global |  | `global-letsencrypt-email` |
+| `letsencrypt-server` | global |  | `global-letsencrypt-server` |
+| `log-level` | global |  | `global-log-level` |
+
+Names starting with `dns-provider-` are also accepted. dokku validates them through `traefik:set` rather than through its report schema, so they cannot be listed above. The plugin does not report them, so they are applied on every run and never converge.
+
 ## Examples
 
 ### Setting the letsencrypt email globally

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -71,10 +71,12 @@ A few conventions to follow:
 - The struct holds the fields the task needs. The only required field is `State`, the desired state;
   everything else is specific to the task.
 - Give every field a `description:"..."` tag. The docs generator reads it (along with `required`,
-  `default`, and `options`) to build the task's Parameters table, so a field without one renders an
-  empty description cell. Add `,omitempty` to the `yaml` tag of optional fields so example YAML stays
-  clean, and use `required:"false"` whenever a field has a `default` (a defaulted field is never
-  actually required).
+  `default`, `options`, and `sensitive`) to build the task's Parameters table, so a field without one
+  renders an empty description cell. Those same tags are what
+  [`docket schema`](task-catalog.md) publishes, so a missing description is a hole in the
+  machine-readable catalog as well as in the docs. Add `,omitempty` to the `yaml` tag of optional
+  fields so example YAML stays clean, and use `required:"false"` whenever a field has a `default`
+  (a defaulted field is never actually required).
 - For a task that performs several atomic changes in one call (such as setting multiple config
   keys), populate `PlanResult.Mutations` with one entry per change, so `plan` can itemize the diff.
 - `DispatchPlan` and `DispatchState` set `DesiredState` on the result automatically.
@@ -222,63 +224,90 @@ func (t ChecksToggleTask) Plan() PlanResult {
 
 ### Property tasks
 
-A property task delegates `Plan()` to `planProperty`, passing the plugin's `:set` subcommand and a
-`PropertyKeys` map. That map is the task's source of truth: it lists every property the task manages
-and, for each, the JSON keys that `dokku <plugin>:report --format json` emits in per-app and global
-scope. An empty string for a scope means the property is not supported there, and `planProperty`
-rejects that scope at plan time. `present` sets the property and requires a `value`; `absent` clears
-it and must not have one - the helper enforces both.
+A property task declares a `PropertyTable` and delegates `Plan()` to `planProperty`. The table is
+the task's single source of truth: the plugin's `:set` subcommand, plus every property the task
+manages and, for each, the JSON keys that `dokku <plugin>:report --format json` emits in per-app and
+global scope. An empty string for a scope means the property is not supported there, and
+`planProperty` rejects that scope at plan time. `present` sets the property and requires a `value`;
+`absent` clears it and must not have one - the helper enforces both.
 
 ```go
 type NginxPropertyTask struct {
-  App      string `required:"false" yaml:"app"`
-  Global   bool   `required:"false" yaml:"global,omitempty"`
-  Property string `required:"true" yaml:"property"`
+  App      string `required:"false" identity:"key" yaml:"app"`
+  Global   bool   `required:"false" identity:"key" yaml:"global,omitempty"`
+  Property string `required:"true" identity:"key" yaml:"property"`
   Value    string `required:"false" yaml:"value,omitempty"`
   State    State  `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
 }
 
 // Maps each property to the report JSON keys per scope. "" means unsupported.
-var nginxPropertyKeys = map[string]PropertyKeys{
-  "client-max-body-size": {PerApp: "client-max-body-size", Global: "global-client-max-body-size"},
-  "proxy-read-timeout":   {PerApp: "proxy-read-timeout", Global: "global-proxy-read-timeout"},
-  // ...
+var nginxPropertyTable = PropertyTable{
+  Subcommand: "nginx:set",
+  Keys: map[string]PropertyKeys{
+    "client-max-body-size": {PerApp: "client-max-body-size", Global: "global-client-max-body-size"},
+    "proxy-read-timeout":   {PerApp: "proxy-read-timeout", Global: "global-proxy-read-timeout"},
+    // ...
+  },
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t NginxPropertyTask) PropertyTable() PropertyTable {
+  return nginxPropertyTable
+}
+
+func (t NginxPropertyTask) Validate() error {
+  return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 func (t NginxPropertyTask) Plan() PlanResult {
-  return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set", nginxPropertyKeys)
+  return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 ```
 
-Keep the `PropertyKeys` map in sync with the plugin's `:report` output - that mapping is how `plan`
-and `apply` detect drift without mutating. Some plugins take a dynamic family of properties whose
-names cannot be enumerated in the map, such as the `dns-provider-<ENV_VAR>` credentials letsencrypt
-and traefik accept. `isDynamicProperty` in `tasks/properties.go` recognizes those so validation
-accepts a name the map has never heard of, and how they plan depends on the plugin:
+The shared helpers take the task rather than a subcommand and a map, so there is no way to reach
+them without declaring the table, and no way to validate against one table while publishing
+another. That matters because the table is not only an implementation detail: it is the real schema
+of the task's otherwise free-form `property` field, and it is what fills the Properties section on
+the task's reference page and the `property_schema` key in
+[`docket schema`](task-catalog.md#property-tasks). The property exporters take the task the same
+way, and `TestEveryPropertyTaskDeclaresPropertyTable` fails the build for a `*_property` task that
+declares no table and is not explicitly exempt.
 
-- The plugin reports the family (letsencrypt on 0.25.0+ emits a row per set property): synthesize
-  the scope keys in `dynamicPropertyKeys` and the property probes like any mapped one. Because the
-  row only exists once the property has a value, an absent row reads as unset. Note the minimum
-  plugin version in `Requirements()`, and mark the synthesized entry `Sensitive` when the value is a
+Keep the table in sync with the plugin's `:report` output - that mapping is how `plan` and `apply`
+detect drift without mutating. Some plugins take a dynamic family of properties whose names cannot
+be enumerated, such as the `dns-provider-<ENV_VAR>` credentials letsencrypt and traefik accept.
+Those are declared in `dynamicPropertyFamilies` in `tasks/properties.go`, which is what lets
+validation accept a name the table has never heard of, and is published to consumers so a linter
+does not reject a legal recipe. How they plan depends on the plugin:
+
+- The plugin reports the family (letsencrypt on 0.25.0+ emits a row per set property): declare it
+  `Probeable`, and the scope keys are synthesized so the property probes like any mapped one.
+  Because the row only exists once the property has a value, an absent row reads as unset. Note the
+  minimum plugin version in `Requirements()`, and mark the family `Sensitive` when the value is a
   credential so the probed value never reaches a drift reason unmasked.
-- The plugin does not report it: the property skips probing and is applied unconditionally, and the
-  task is `ProbePartial` with a caveat naming the family.
+- The plugin does not report it: leave `Probeable` false. The property skips probing and is applied
+  unconditionally, and the task is `ProbePartial` with a caveat naming the family.
 
 ## Regenerating the task docs
 
 The per-task pages under [`docs/tasks/`](tasks/README.md) are generated from each task's `Doc()`,
-`Examples()`, `ExportSupport()`, `ProbeSupport()`, and optional `Requirements()` methods plus its
-struct field tags - they are not hand-edited. Each page carries a Synopsis (from `Doc()`), a
-Requirements section (when the task implements `Requirements()`), Export support and Probe support
-sections, a Parameters table (reflected from the field tags), the examples, and a shared Return
-Values table. After adding or changing a task, regenerate them:
+`Examples()`, `ExportSupport()`, `ProbeSupport()`, optional `Requirements()` and `PropertyTable()`
+methods plus its struct field tags - they are not hand-edited. Each page carries a Synopsis (from
+`Doc()`), a Requirements section (when the task implements `Requirements()`), Export support and
+Probe support sections, an Identity section, a Parameters table (reflected from the field tags), a
+Properties table (for a task with a `PropertyTable()`), the examples, and a shared Return Values
+table. After adding or changing a task, regenerate them:
 
 ```bash
 make docs
 ```
 
 This runs `go generate generate/docs.go`, which writes one `docs/tasks/<task>.md` per registered
-task plus the `docs/tasks/README.md` index. Commit the regenerated files alongside your code.
+task plus the `docs/tasks/README.md` index. Commit the regenerated files alongside your code -
+`TestGeneratedDocsAreCurrent` fails the build if you forget, and prints the diff.
+
+The generator renders those pages from `tasks.Catalog()`, the same description
+[`docket schema`](task-catalog.md) emits, so a declaration you add shows up in both or in neither.
 
 Because the examples are published as-is, they are also tested. `TestAllTaskExamplesValidate`
 (`tasks/main_test.go`) decodes every example offline, applies the field defaults, and runs the
@@ -293,5 +322,6 @@ declare it in the driver's `exampleIntegrationPolicy` rather than leaving the ex
 ## See also
 
 - [Tasks](tasks/README.md) - the generated reference for every task
+- [Task catalog](task-catalog.md) - the same declarations, published for tooling
 - [Task envelope](task-envelope.md) - the cross-cutting keys every task supports
 - [Command reference](command-reference.md) - how `plan` and `apply` consume `Plan()`

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -6,12 +6,20 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/dokku/docket/tasks"
 )
+
+// The per-task reference pages are rendered from tasks.Catalog(), the same
+// machine-readable description `docket schema` emits. The reflection used to
+// live here, which meant the only thing that could be done with docket's
+// knowledge of its own task types was write markdown (#422). Rendering from the
+// catalog instead is what keeps the published JSON and the published markdown
+// describing the same thing.
+//
+// What stays here is presentation: the prose the catalog deliberately does not
+// bake into its `description` field, the table layout, and the section order.
 
 // summarize reduces a task's docblock to a single-line summary for the index:
 // the first line, trimmed to its first sentence.
@@ -24,124 +32,6 @@ func summarize(doc string) string {
 		s = s[:i+1]
 	}
 	return s
-}
-
-// param is one row of a task's Parameters table, derived from a struct field.
-type param struct {
-	Name        string
-	Type        string
-	Required    bool
-	Default     string
-	Choices     string
-	Description string
-}
-
-// displayType maps a Go field type to the doc-facing type name. Named string
-// types such as State render as "string"; slices render as "list" and maps as
-// "dict", mirroring Ansible's type vocabulary. Pointer fields (e.g. an optional
-// *bool) render as their element type so they read as "bool" rather than "*bool".
-func displayType(t reflect.Type) string {
-	if t.Kind() == reflect.Ptr {
-		return displayType(t.Elem())
-	}
-	switch t.Kind() {
-	case reflect.String:
-		return "string"
-	case reflect.Bool:
-		return "bool"
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return "int"
-	case reflect.Slice:
-		return "list"
-	case reflect.Map:
-		return "dict"
-	default:
-		return t.String()
-	}
-}
-
-// yamlName extracts the recipe key for a field from its yaml tag, dropping any
-// ",omitempty"-style suffix. Returns "" when the field is not serialized.
-func yamlName(tag reflect.StructTag, fieldName string) string {
-	name := tag.Get("yaml")
-	if comma := strings.IndexByte(name, ','); comma >= 0 {
-		name = name[:comma]
-	}
-	if name == "-" {
-		return ""
-	}
-	if name == "" {
-		return strings.ToLower(fieldName)
-	}
-	return name
-}
-
-// elementYamlNames returns the recipe keys of the fields of a slice element
-// struct, so a list-of-struct field can describe its item shape inline.
-func elementYamlNames(t reflect.Type) []string {
-	if t.Kind() != reflect.Slice {
-		return nil
-	}
-	el := t.Elem()
-	if el.Kind() != reflect.Struct {
-		return nil
-	}
-	var names []string
-	for i := 0; i < el.NumField(); i++ {
-		f := el.Field(i)
-		if n := yamlName(f.Tag, f.Name); n != "" {
-			names = append(names, n)
-		}
-	}
-	return names
-}
-
-// buildParams reflects over a task struct type and returns its parameters in
-// declaration order.
-func buildParams(rt reflect.Type) []param {
-	var params []param
-	for i := 0; i < rt.NumField(); i++ {
-		field := rt.Field(i)
-		if field.PkgPath != "" { // unexported
-			continue
-		}
-		name := yamlName(field.Tag, field.Name)
-		if name == "" {
-			continue
-		}
-
-		def := field.Tag.Get("default")
-		// A field with a default is effectively optional even if it is
-		// tagged required:"true".
-		required := field.Tag.Get("required") == "true" && def == ""
-
-		desc := field.Tag.Get("description")
-		if items := elementYamlNames(field.Type); len(items) > 0 {
-			desc = strings.TrimSpace(desc)
-			if desc != "" && !strings.HasSuffix(desc, ".") {
-				desc += "."
-			}
-			desc = strings.TrimSpace(desc + " Each item has: " + strings.Join(items, ", ") + ".")
-		}
-		if field.Tag.Get("sensitive") == "true" {
-			desc = strings.TrimSpace(desc + " (sensitive)")
-		}
-
-		choices := ""
-		if opts := field.Tag.Get("options"); opts != "" {
-			choices = strings.Join(strings.Split(opts, ","), ", ")
-		}
-
-		params = append(params, param{
-			Name:        name,
-			Type:        displayType(field.Type),
-			Required:    required,
-			Default:     def,
-			Choices:     choices,
-			Description: desc,
-		})
-	}
-	return params
 }
 
 // escapeCell makes a string safe to embed in a markdown table cell.
@@ -157,44 +47,129 @@ func yesNo(b bool) string {
 	return "no"
 }
 
+// itemFieldNames returns the recipe keys of a list-of-struct field's element,
+// so the Parameters table can describe the item shape inline. Only a list
+// qualifies: a dict's entries are keyed rather than shaped, and its value type
+// is already carried by the type column.
+func itemFieldNames(field tasks.FieldSchema) []string {
+	if field.Type != tasks.TypeList || field.Item == nil || field.Item.Type != tasks.TypeObject {
+		return nil
+	}
+	names := make([]string, 0, len(field.Item.Fields))
+	for _, item := range field.Item.Fields {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+// paramDescription is the Parameters table's description cell. The catalog
+// carries the raw description tag and the facts (Sensitive, Item) separately,
+// so the prose a reader expects is composed here rather than baked into the
+// machine-readable form.
+func paramDescription(field tasks.FieldSchema) string {
+	desc := field.Description
+	if items := itemFieldNames(field); len(items) > 0 {
+		desc = strings.TrimSpace(desc)
+		if desc != "" && !strings.HasSuffix(desc, ".") {
+			desc += "."
+		}
+		desc = strings.TrimSpace(desc + " Each item has: " + strings.Join(items, ", ") + ".")
+	}
+	if field.Sensitive {
+		desc = strings.TrimSpace(desc + " (sensitive)")
+	}
+	return desc
+}
+
 // parametersSection renders the Parameters table for a task. Returns "" when
 // the task has no documented parameters.
-func parametersSection(params []param) string {
-	if len(params) == 0 {
+func parametersSection(fields []tasks.FieldSchema) string {
+	if len(fields) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString("## Parameters\n\n")
 	b.WriteString("| Parameter | Type | Required | Default | Choices | Description |\n")
 	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
-	for _, p := range params {
+	for _, field := range fields {
 		b.WriteString(fmt.Sprintf(
 			"| `%s` | %s | %s | %s | %s | %s |\n",
-			p.Name,
-			p.Type,
-			yesNo(p.Required),
-			escapeCell(p.Default),
-			escapeCell(p.Choices),
-			escapeCell(p.Description),
+			field.Name,
+			field.Type,
+			yesNo(field.Required),
+			escapeCell(field.Default),
+			escapeCell(strings.Join(field.Choices, ", ")),
+			escapeCell(paramDescription(field)),
 		))
 	}
 	return b.String()
 }
 
-// requirementsSection renders the Requirements bullet list for a task that
-// declares non-core plugin dependencies. Returns "" otherwise.
-func requirementsSection(task tasks.Task) string {
-	doc, ok := task.(tasks.RequirementsDocer)
-	if !ok {
+// propertiesSection renders the Properties table for a task that manages a
+// dokku property table: every name its `property` field accepts, the scopes
+// that accept it, and the report keys the drift probe reads. Without it the
+// only way to discover a legal property name is to trigger a validation error.
+func propertiesSection(schema *tasks.PropertySchema) string {
+	if schema == nil || len(schema.Properties) == 0 {
 		return ""
 	}
-	reqs := doc.Requirements()
-	if len(reqs) == 0 {
+
+	var b strings.Builder
+	b.WriteString("## Properties\n\n")
+	b.WriteString(fmt.Sprintf(
+		"`property` accepts one of the following, applied with `dokku %s`. A property with no form in a scope is rejected there, matching dokku's own rejection.\n\n",
+		schema.Subcommand,
+	))
+	b.WriteString("| Property | Scopes | Report key (app) | Report key (global) |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, property := range schema.Properties {
+		name := "`" + property.Name + "`"
+		if property.Sensitive {
+			name += " (sensitive)"
+		}
+		b.WriteString(fmt.Sprintf(
+			"| %s | %s | %s | %s |\n",
+			name,
+			strings.Join(property.Scopes, ", "),
+			codeOrBlank(property.AppReportKey),
+			codeOrBlank(property.GlobalReportKey),
+		))
+	}
+
+	for _, family := range schema.Dynamic {
+		b.WriteString(fmt.Sprintf("\nNames starting with `%s` are also accepted. dokku validates them through `%s` rather than through its report schema, so they cannot be listed above. ",
+			family.Prefix, schema.Subcommand))
+		if family.Probeable {
+			b.WriteString("The plugin reports each one it has been given, so they probe for drift like any listed property.")
+		} else {
+			b.WriteString("The plugin does not report them, so they are applied on every run and never converge.")
+		}
+		if family.Sensitive {
+			b.WriteString(" Their values are treated as secrets and masked.")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// codeOrBlank renders a report key as inline code, or an empty cell when the
+// property has no form in that scope.
+func codeOrBlank(key string) string {
+	if key == "" {
+		return ""
+	}
+	return "`" + key + "`"
+}
+
+// requirementsSection renders the Requirements bullet list for a task that
+// declares non-core plugin dependencies. Returns "" otherwise.
+func requirementsSection(requirements []string) string {
+	if len(requirements) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString("## Requirements\n\n")
-	for _, r := range reqs {
+	for _, r := range requirements {
 		b.WriteString("- " + r + "\n")
 	}
 	return b.String()
@@ -204,9 +179,8 @@ func requirementsSection(task tasks.Task) string {
 // `docket export` can reconstruct the task from a live server. Every task
 // declares this via ExportSupport(); the section is omitted only if a task
 // does not (the export coverage test prevents that in practice).
-func exportSupportSection(task tasks.Task) string {
-	support, ok := tasks.TaskExportSupport(task)
-	if !ok {
+func exportSupportSection(support tasks.ExportSupport) string {
+	if support.Status == "" {
 		return ""
 	}
 	var label string
@@ -233,9 +207,8 @@ func exportSupportSection(task tasks.Task) string {
 // not (the probe coverage test prevents that in practice). A task rendered as
 // "Not supported" here plans as drift on every run, so it never lets
 // `plan --detailed-exitcode` exit 0.
-func probeSupportSection(task tasks.Task) string {
-	support, ok := tasks.TaskProbeSupport(task)
-	if !ok {
+func probeSupportSection(support tasks.ProbeSupport) string {
+	if support.Status == "" {
 		return ""
 	}
 	var label string
@@ -264,18 +237,17 @@ func probeSupportSection(task tasks.Task) string {
 //
 // The address form is explained once in docs/task-envelope.md rather than
 // repeated on 73 pages; what a reader needs here is which fields go into it.
-func identitySection(task tasks.Task) string {
-	keys := tasks.IdentityKeyNames(task)
-	if len(keys) == 0 {
+func identitySection(identity tasks.IdentitySchema) string {
+	if len(identity.Keys) == 0 {
 		return ""
 	}
 
-	line := "Keyed by " + joinCodeNames(keys) + "."
-	if len(keys) > 1 {
+	line := "Keyed by " + joinCodeNames(identity.Keys) + "."
+	if len(identity.Keys) > 1 {
 		line += " Fields left empty are omitted from the address."
 	}
-	for _, collection := range tasks.TaskIdentityCollections(task) {
-		line += fmt.Sprintf(" Manages the whole `%s` collection", collection.YAMLName)
+	for _, collection := range identity.Collections {
+		line += fmt.Sprintf(" Manages the whole `%s` collection", collection.Name)
 		switch collection.Item {
 		case tasks.ItemIdentityMapKey:
 			line += "; entries are identified by their key."
@@ -309,15 +281,14 @@ func joinCodeNames(names []string) string {
 }
 
 // deprecationSection renders the Deprecated admonition for a task that
-// implements DeprecationDocer. The notice sits between the Synopsis and
-// the Requirements/Parameters sections so the reader sees it before
-// scanning the field table.
-func deprecationSection(task tasks.Task) string {
-	msg := tasks.TaskDeprecation(task)
-	if msg == "" {
+// declares one. The notice sits between the Synopsis and the
+// Requirements/Parameters sections so the reader sees it before scanning the
+// field table.
+func deprecationSection(message string) string {
+	if message == "" {
 		return ""
 	}
-	return "> **Deprecated:** " + strings.TrimSpace(msg)
+	return "> **Deprecated:** " + message
 }
 
 // returnValuesSection is the shared Return Values table. Every task returns a
@@ -348,7 +319,7 @@ func returnValuesSection() string {
 
 // examplesSection renders a task's examples under a single Examples header,
 // one H3 subsection per example.
-func examplesSection(taskName string, examples []tasks.Doc) string {
+func examplesSection(examples []tasks.ExampleSchema) string {
 	if len(examples) == 0 {
 		return ""
 	}
@@ -357,46 +328,63 @@ func examplesSection(taskName string, examples []tasks.Doc) string {
 	for _, example := range examples {
 		b.WriteString("### " + example.Name + "\n\n")
 		b.WriteString("```yaml\n")
-		b.WriteString(strings.TrimSpace(example.Codeblock) + "\n")
+		b.WriteString(strings.TrimSpace(example.YAML) + "\n")
 		b.WriteString("```\n\n")
 	}
 	return strings.TrimRight(b.String(), "\n") + "\n"
 }
 
 // renderPage builds the full markdown page for one task.
-func renderPage(taskName string, task tasks.Task, examples []tasks.Doc) string {
-	rt := reflect.TypeOf(task)
-	if rt.Kind() == reflect.Ptr {
-		rt = rt.Elem()
-	}
-
+func renderPage(schema tasks.TaskSchema) string {
 	var sections []string
-	sections = append(sections, "# "+taskName)
-	sections = append(sections, "## Synopsis\n\n"+strings.TrimSpace(task.Doc()))
-	if dep := deprecationSection(task); dep != "" {
+	sections = append(sections, "# "+schema.Type)
+	sections = append(sections, "## Synopsis\n\n"+schema.Synopsis)
+	if dep := deprecationSection(schema.Deprecation); dep != "" {
 		sections = append(sections, dep)
 	}
-	if req := requirementsSection(task); req != "" {
+	if req := requirementsSection(schema.Requirements); req != "" {
 		sections = append(sections, strings.TrimRight(req, "\n"))
 	}
-	if es := exportSupportSection(task); es != "" {
+	if es := exportSupportSection(schema.Export); es != "" {
 		sections = append(sections, es)
 	}
-	if ps := probeSupportSection(task); ps != "" {
+	if ps := probeSupportSection(schema.Probe); ps != "" {
 		sections = append(sections, ps)
 	}
-	if id := identitySection(task); id != "" {
+	if id := identitySection(schema.Identity); id != "" {
 		sections = append(sections, id)
 	}
-	if pt := parametersSection(buildParams(rt)); pt != "" {
+	if pt := parametersSection(schema.Fields); pt != "" {
 		sections = append(sections, strings.TrimRight(pt, "\n"))
 	}
-	if ex := examplesSection(taskName, examples); ex != "" {
+	if props := propertiesSection(schema.PropertySchema); props != "" {
+		sections = append(sections, strings.TrimRight(props, "\n"))
+	}
+	if ex := examplesSection(schema.Examples); ex != "" {
 		sections = append(sections, strings.TrimRight(ex, "\n"))
 	}
 	sections = append(sections, strings.TrimRight(returnValuesSection(), "\n"))
 
 	return strings.Join(sections, "\n\n") + "\n"
+}
+
+// renderIndex builds docs/tasks/README.md: every task with a one-line summary.
+func renderIndex(catalog tasks.TaskCatalog) string {
+	var index strings.Builder
+	index.WriteString("# Tasks\n\n")
+	index.WriteString("Reference for every task type docket can run inside a recipe. Each page lists the task's fields and example usage. These pages are generated from the task definitions with `make docs`.\n\n")
+	index.WriteString("A task marked `(never converges)` cannot read its own state, so it plans as drift on every run. See the Probe support section on its page.\n\n")
+	for _, schema := range catalog.Tasks {
+		suffix := ""
+		if schema.Deprecation != "" {
+			suffix += " (deprecated)"
+		}
+		if schema.Probe.Status == tasks.ProbeUnsupported {
+			suffix += " (never converges)"
+		}
+		index.WriteString(fmt.Sprintf("- [%s](%s.md) - %s%s\n", schema.Type, schema.Type, summarize(schema.Synopsis), suffix))
+	}
+	return index.String()
 }
 
 func main() {
@@ -412,50 +400,24 @@ func main() {
 		}
 	}
 
-	registeredTasks := tasks.RegisteredTasks
-
-	// Sorted names keep the generation order (and console output) stable.
-	names := make([]string, 0, len(registeredTasks))
-	for name := range registeredTasks {
-		names = append(names, name)
+	// The catalog is sorted by task type, which keeps the generation order
+	// (and the console output) stable.
+	catalog, err := tasks.Catalog()
+	if err != nil {
+		log.Fatalf("failed to build the task catalog: %v", err)
 	}
-	sort.Strings(names)
 
-	for _, taskName := range names {
-		fmt.Println(taskName)
-		task := registeredTasks[taskName]
+	for _, schema := range catalog.Tasks {
+		fmt.Println(schema.Type)
 
-		examples, err := task.Examples()
-		if err != nil {
-			log.Fatalf("failed to get examples for task %s: %v", taskName, err)
-		}
-
-		output := renderPage(taskName, task, examples)
-
-		taskDocsFile := filepath.Join(docsFolderName, taskName+".md")
-		if err := os.WriteFile(taskDocsFile, []byte(output), 0644); err != nil {
+		taskDocsFile := filepath.Join(docsFolderName, schema.Type+".md")
+		if err := os.WriteFile(taskDocsFile, []byte(renderPage(schema)), 0644); err != nil {
 			log.Fatalf("failed to write docblock: %v", err)
 		}
 	}
 
-	// Emit an index listing every task with a one-line summary.
-	var index strings.Builder
-	index.WriteString("# Tasks\n\n")
-	index.WriteString("Reference for every task type docket can run inside a recipe. Each page lists the task's fields and example usage. These pages are generated from the task definitions with `make docs`.\n\n")
-	index.WriteString("A task marked `(never converges)` cannot read its own state, so it plans as drift on every run. See the Probe support section on its page.\n\n")
-	for _, name := range names {
-		suffix := ""
-		if tasks.TaskDeprecation(registeredTasks[name]) != "" {
-			suffix += " (deprecated)"
-		}
-		if support, ok := tasks.TaskProbeSupport(registeredTasks[name]); ok && support.Status == tasks.ProbeUnsupported {
-			suffix += " (never converges)"
-		}
-		index.WriteString(fmt.Sprintf("- [%s](%s.md) - %s%s\n", name, name, summarize(registeredTasks[name].Doc()), suffix))
-	}
-
 	indexFile := filepath.Join(docsFolderName, "README.md")
-	if err := os.WriteFile(indexFile, []byte(index.String()), 0644); err != nil {
+	if err := os.WriteFile(indexFile, []byte(renderIndex(catalog)), 0644); err != nil {
 		log.Fatalf("failed to write tasks index: %v", err)
 	}
 }

--- a/generate/docs_test.go
+++ b/generate/docs_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+
+	"github.com/aymanbagabas/go-udiff"
+)
+
+// docsDir is where the generated reference pages live, relative to this
+// package. `go test` runs with the package directory as the working directory,
+// which is the same place `go generate` runs main() from.
+const docsDir = "../docs/tasks"
+
+// TestGeneratedDocsAreCurrent asserts that every committed page under
+// docs/tasks/ is exactly what the generator would write today.
+//
+// The pages are generated but committed, and nothing in CI ran `make docs` and
+// diffed the result, so a task whose fields or declarations changed could ship
+// with a stale reference page indefinitely. This closes that gap in `go test`,
+// without needing a `go generate` step in the workflow.
+//
+// It is also the safety net for rendering the pages from tasks.Catalog()
+// instead of from the generator's own reflection (#422): the refactor is
+// correct exactly insofar as this test passes unchanged.
+func TestGeneratedDocsAreCurrent(t *testing.T) {
+	catalog, err := tasks.Catalog()
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+
+	for _, schema := range catalog.Tasks {
+		path := filepath.Join(docsDir, schema.Type+".md")
+		committed, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v (run make docs)", path, err)
+			continue
+		}
+		assertRendered(t, path, string(committed), renderPage(schema))
+	}
+
+	indexPath := filepath.Join(docsDir, "README.md")
+	committed, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read %s: %v (run make docs)", indexPath, err)
+	}
+	assertRendered(t, indexPath, string(committed), renderIndex(catalog))
+}
+
+// assertRendered compares a committed page against freshly rendered markdown,
+// reporting a unified diff rather than two walls of text.
+func assertRendered(t *testing.T, path, committed, rendered string) {
+	t.Helper()
+	if committed == rendered {
+		return
+	}
+	diff, err := udiff.ToUnified(path, path+" (regenerated)", committed, udiff.Strings(committed, rendered), udiff.DefaultContextLines)
+	if err != nil {
+		t.Errorf("%s is out of date and the diff could not be rendered: %v", path, err)
+		return
+	}
+	t.Errorf("%s is out of date; run make docs\n%s", path, diff)
+}
+
+// TestGeneratedDocsCoverEveryTask asserts that the set of pages on disk is
+// exactly the set of registered tasks. TestGeneratedDocsAreCurrent only looks
+// at pages the registry names, so a task that was removed or renamed would
+// otherwise leave an orphan page behind - the generator never deletes.
+func TestGeneratedDocsCoverEveryTask(t *testing.T) {
+	entries, err := os.ReadDir(docsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", docsDir, err)
+	}
+
+	onDisk := map[string]bool{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".md") || name == "README.md" {
+			continue
+		}
+		onDisk[strings.TrimSuffix(name, ".md")] = true
+	}
+
+	for name := range tasks.RegisteredTasks {
+		if !onDisk[name] {
+			t.Errorf("task %q has no page at %s/%s.md (run make docs)", name, docsDir, name)
+		}
+		delete(onDisk, name)
+	}
+
+	orphans := make([]string, 0, len(onDisk))
+	for name := range onDisk {
+		orphans = append(orphans, name)
+	}
+	sort.Strings(orphans)
+	for _, name := range orphans {
+		t.Errorf("%s/%s.md describes no registered task; delete it", docsDir, name)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -53,6 +53,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"plan": func() (cli.Command, error) {
 			return &commands.PlanCommand{Meta: meta}, nil
 		},
+		"schema": func() (cli.Command, error) {
+			return &commands.SchemaCommand{Meta: meta}, nil
+		},
 		"validate": func() (cli.Command, error) {
 			return &commands.ValidateCommand{Meta: meta}, nil
 		},

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -82,32 +82,40 @@ func (t AppJsonPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// appJsonPropertyKeys maps app-json property names to the JSON keys emitted
+// appJsonPropertyTable maps app-json property names to the JSON keys emitted
 // by `dokku app-json:report --format json` on dokku 0.38.8+.
-var appJsonPropertyKeys = map[string]PropertyKeys{
-	"appjson-path": {PerApp: "appjson-path", Global: "global-appjson-path"},
+var appJsonPropertyTable = PropertyTable{
+	Subcommand: "app-json:set",
+	Keys: map[string]PropertyKeys{
+		"appjson-path": {PerApp: "appjson-path", Global: "global-appjson-path"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t AppJsonPropertyTask) PropertyTable() PropertyTable {
+	return appJsonPropertyTable
 }
 
 // Validate checks the AppJsonPropertyTask's inputs without contacting the server.
 func (t AppJsonPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set", appJsonPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the AppJsonPropertyTask would produce.
 func (t AppJsonPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set", appJsonPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t AppJsonPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "app-json:set", appJsonPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return AppJsonPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t AppJsonPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("app-json:set", appJsonPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return AppJsonPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -90,7 +90,7 @@ func (t AppsPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// appsPropertyKeys maps apps property names to the JSON keys emitted by
+// appsPropertyTable maps apps property names to the JSON keys emitted by
 // `dokku apps:report [<app>|--global] --format json` on dokku 0.38.12+.
 // deploy-source and deploy-source-metadata are per-app only; disable-autocreation
 // is global only - dokku 0.38.12 narrowed apps.GlobalProperties to drop the
@@ -98,32 +98,40 @@ func (t AppsPropertyTask) Execute() TaskOutputState {
 // global value of disable-autocreation. The bare key `global-disable-autocreation`
 // falls out of stripping the `--app-` prefix from dokku's
 // `--app-global-disable-autocreation` report flag.
-var appsPropertyKeys = map[string]PropertyKeys{
-	"deploy-source":          {PerApp: "deploy-source", Global: ""},
-	"deploy-source-metadata": {PerApp: "deploy-source-metadata", Global: ""},
-	"disable-autocreation":   {PerApp: "", Global: "global-disable-autocreation"},
+var appsPropertyTable = PropertyTable{
+	Subcommand: "apps:set",
+	Keys: map[string]PropertyKeys{
+		"deploy-source":          {PerApp: "deploy-source", Global: ""},
+		"deploy-source-metadata": {PerApp: "deploy-source-metadata", Global: ""},
+		"disable-autocreation":   {PerApp: "", Global: "global-disable-autocreation"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t AppsPropertyTask) PropertyTable() PropertyTable {
+	return appsPropertyTable
 }
 
 // Validate checks the AppsPropertyTask's inputs without contacting the server.
 func (t AppsPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "apps:set", appsPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the AppsPropertyTask would produce.
 func (t AppsPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "apps:set", appsPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t AppsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "apps:set", appsPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return AppsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t AppsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("apps:set", appsPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return AppsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -82,33 +82,41 @@ func (t BuilderDockerfilePropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// builderDockerfilePropertyKeys maps builder-dockerfile property names to
+// builderDockerfilePropertyTable maps builder-dockerfile property names to
 // the JSON keys emitted by `dokku builder-dockerfile:report --format json`
 // on dokku 0.38.8+.
-var builderDockerfilePropertyKeys = map[string]PropertyKeys{
-	"dockerfile-path": {PerApp: "dockerfile-path", Global: "global-dockerfile-path"},
+var builderDockerfilePropertyTable = PropertyTable{
+	Subcommand: "builder-dockerfile:set",
+	Keys: map[string]PropertyKeys{
+		"dockerfile-path": {PerApp: "dockerfile-path", Global: "global-dockerfile-path"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuilderDockerfilePropertyTask) PropertyTable() PropertyTable {
+	return builderDockerfilePropertyTable
 }
 
 // Validate checks the BuilderDockerfilePropertyTask's inputs without contacting the server.
 func (t BuilderDockerfilePropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set", builderDockerfilePropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuilderDockerfilePropertyTask would produce.
 func (t BuilderDockerfilePropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set", builderDockerfilePropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuilderDockerfilePropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builder-dockerfile:set", builderDockerfilePropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuilderDockerfilePropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuilderDockerfilePropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builder-dockerfile:set", builderDockerfilePropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuilderDockerfilePropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -82,33 +82,41 @@ func (t BuilderHerokuishPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// builderHerokuishPropertyKeys maps builder-herokuish property names to the
+// builderHerokuishPropertyTable maps builder-herokuish property names to the
 // JSON keys emitted by `dokku builder-herokuish:report --format json` on
 // dokku 0.38.8+.
-var builderHerokuishPropertyKeys = map[string]PropertyKeys{
-	"allowed": {PerApp: "allowed", Global: "global-allowed"},
+var builderHerokuishPropertyTable = PropertyTable{
+	Subcommand: "builder-herokuish:set",
+	Keys: map[string]PropertyKeys{
+		"allowed": {PerApp: "allowed", Global: "global-allowed"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuilderHerokuishPropertyTask) PropertyTable() PropertyTable {
+	return builderHerokuishPropertyTable
 }
 
 // Validate checks the BuilderHerokuishPropertyTask's inputs without contacting the server.
 func (t BuilderHerokuishPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set", builderHerokuishPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuilderHerokuishPropertyTask would produce.
 func (t BuilderHerokuishPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set", builderHerokuishPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuilderHerokuishPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builder-herokuish:set", builderHerokuishPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuilderHerokuishPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuilderHerokuishPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builder-herokuish:set", builderHerokuishPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuilderHerokuishPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -82,33 +82,41 @@ func (t BuilderLambdaPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// builderLambdaPropertyKeys maps builder-lambda property names to the JSON
+// builderLambdaPropertyTable maps builder-lambda property names to the JSON
 // keys emitted by `dokku builder-lambda:report --format json` on dokku
 // 0.38.8+.
-var builderLambdaPropertyKeys = map[string]PropertyKeys{
-	"lambdayml-path": {PerApp: "lambdayml-path", Global: "global-lambdayml-path"},
+var builderLambdaPropertyTable = PropertyTable{
+	Subcommand: "builder-lambda:set",
+	Keys: map[string]PropertyKeys{
+		"lambdayml-path": {PerApp: "lambdayml-path", Global: "global-lambdayml-path"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuilderLambdaPropertyTask) PropertyTable() PropertyTable {
+	return builderLambdaPropertyTable
 }
 
 // Validate checks the BuilderLambdaPropertyTask's inputs without contacting the server.
 func (t BuilderLambdaPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set", builderLambdaPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuilderLambdaPropertyTask would produce.
 func (t BuilderLambdaPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set", builderLambdaPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuilderLambdaPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builder-lambda:set", builderLambdaPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuilderLambdaPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuilderLambdaPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builder-lambda:set", builderLambdaPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuilderLambdaPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -82,33 +82,41 @@ func (t BuilderNixpacksPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// builderNixpacksPropertyKeys maps builder-nixpacks property names to the
+// builderNixpacksPropertyTable maps builder-nixpacks property names to the
 // JSON keys emitted by `dokku builder-nixpacks:report --format json` on
 // dokku 0.38.8+.
-var builderNixpacksPropertyKeys = map[string]PropertyKeys{
-	"nixpackstoml-path": {PerApp: "nixpackstoml-path", Global: "global-nixpackstoml-path"},
+var builderNixpacksPropertyTable = PropertyTable{
+	Subcommand: "builder-nixpacks:set",
+	Keys: map[string]PropertyKeys{
+		"nixpackstoml-path": {PerApp: "nixpackstoml-path", Global: "global-nixpackstoml-path"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuilderNixpacksPropertyTask) PropertyTable() PropertyTable {
+	return builderNixpacksPropertyTable
 }
 
 // Validate checks the BuilderNixpacksPropertyTask's inputs without contacting the server.
 func (t BuilderNixpacksPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set", builderNixpacksPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuilderNixpacksPropertyTask would produce.
 func (t BuilderNixpacksPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set", builderNixpacksPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuilderNixpacksPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builder-nixpacks:set", builderNixpacksPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuilderNixpacksPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuilderNixpacksPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builder-nixpacks:set", builderNixpacksPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuilderNixpacksPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -82,32 +82,40 @@ func (t BuilderPackPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// builderPackPropertyKeys maps builder-pack property names to the JSON keys
+// builderPackPropertyTable maps builder-pack property names to the JSON keys
 // emitted by `dokku builder-pack:report --format json` on dokku 0.38.8+.
-var builderPackPropertyKeys = map[string]PropertyKeys{
-	"projecttoml-path": {PerApp: "projecttoml-path", Global: "global-projecttoml-path"},
+var builderPackPropertyTable = PropertyTable{
+	Subcommand: "builder-pack:set",
+	Keys: map[string]PropertyKeys{
+		"projecttoml-path": {PerApp: "projecttoml-path", Global: "global-projecttoml-path"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuilderPackPropertyTask) PropertyTable() PropertyTable {
+	return builderPackPropertyTable
 }
 
 // Validate checks the BuilderPackPropertyTask's inputs without contacting the server.
 func (t BuilderPackPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set", builderPackPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuilderPackPropertyTask would produce.
 func (t BuilderPackPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set", builderPackPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuilderPackPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builder-pack:set", builderPackPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuilderPackPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuilderPackPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builder-pack:set", builderPackPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuilderPackPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -90,34 +90,42 @@ func (t BuilderPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// builderPropertyKeys maps builder property names to the JSON keys emitted
+// builderPropertyTable maps builder property names to the JSON keys emitted
 // by `dokku builder:report --format json` on dokku 0.38.8+.
-var builderPropertyKeys = map[string]PropertyKeys{
-	"build-dir":    {PerApp: "build-dir", Global: "global-build-dir"},
-	"selected":     {PerApp: "selected", Global: "global-selected"},
-	"skip-cleanup": {PerApp: "skip-cleanup", Global: "global-skip-cleanup"},
+var builderPropertyTable = PropertyTable{
+	Subcommand: "builder:set",
+	Keys: map[string]PropertyKeys{
+		"build-dir":    {PerApp: "build-dir", Global: "global-build-dir"},
+		"selected":     {PerApp: "selected", Global: "global-selected"},
+		"skip-cleanup": {PerApp: "skip-cleanup", Global: "global-skip-cleanup"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuilderPropertyTask) PropertyTable() PropertyTable {
+	return builderPropertyTable
 }
 
 // Validate checks the BuilderPropertyTask's inputs without contacting the server.
 func (t BuilderPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder:set", builderPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuilderPropertyTask would produce.
 func (t BuilderPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set", builderPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuilderPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builder:set", builderPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuilderPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuilderPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builder:set", builderPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuilderPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -82,33 +82,41 @@ func (t BuilderRailpackPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// builderRailpackPropertyKeys maps builder-railpack property names to the
+// builderRailpackPropertyTable maps builder-railpack property names to the
 // JSON keys emitted by `dokku builder-railpack:report --format json` on
 // dokku 0.38.8+.
-var builderRailpackPropertyKeys = map[string]PropertyKeys{
-	"railpackjson-path": {PerApp: "railpackjson-path", Global: "global-railpackjson-path"},
+var builderRailpackPropertyTable = PropertyTable{
+	Subcommand: "builder-railpack:set",
+	Keys: map[string]PropertyKeys{
+		"railpackjson-path": {PerApp: "railpackjson-path", Global: "global-railpackjson-path"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuilderRailpackPropertyTask) PropertyTable() PropertyTable {
+	return builderRailpackPropertyTable
 }
 
 // Validate checks the BuilderRailpackPropertyTask's inputs without contacting the server.
 func (t BuilderRailpackPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set", builderRailpackPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuilderRailpackPropertyTask would produce.
 func (t BuilderRailpackPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set", builderRailpackPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuilderRailpackPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builder-railpack:set", builderRailpackPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuilderRailpackPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuilderRailpackPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builder-railpack:set", builderRailpackPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuilderRailpackPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -82,34 +82,42 @@ func (t BuildpacksPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// buildpacksPropertyKeys maps buildpacks property names to the JSON keys
+// buildpacksPropertyTable maps buildpacks property names to the JSON keys
 // emitted by `dokku buildpacks:report --format json` on dokku 0.38.8+.
 // The buildpacks list (set via `buildpacks:set <app> <buildpack>`) is not a
 // property in the typed-task sense and is not modeled here.
-var buildpacksPropertyKeys = map[string]PropertyKeys{
-	"stack": {PerApp: "stack", Global: "global-stack"},
+var buildpacksPropertyTable = PropertyTable{
+	Subcommand: "buildpacks:set-property",
+	Keys: map[string]PropertyKeys{
+		"stack": {PerApp: "stack", Global: "global-stack"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuildpacksPropertyTask) PropertyTable() PropertyTable {
+	return buildpacksPropertyTable
 }
 
 // Validate checks the BuildpacksPropertyTask's inputs without contacting the server.
 func (t BuildpacksPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property", buildpacksPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuildpacksPropertyTask would produce.
 func (t BuildpacksPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property", buildpacksPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuildpacksPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "buildpacks:set-property", buildpacksPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuildpacksPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuildpacksPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("buildpacks:set-property", buildpacksPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuildpacksPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -82,32 +82,40 @@ func (t BuildsPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// buildsPropertyKeys maps builds property names to the JSON keys emitted by
+// buildsPropertyTable maps builds property names to the JSON keys emitted by
 // `dokku builds:report --format json` on dokku 0.38.8+.
-var buildsPropertyKeys = map[string]PropertyKeys{
-	"retention": {PerApp: "retention", Global: "global-retention"},
+var buildsPropertyTable = PropertyTable{
+	Subcommand: "builds:set",
+	Keys: map[string]PropertyKeys{
+		"retention": {PerApp: "retention", Global: "global-retention"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t BuildsPropertyTask) PropertyTable() PropertyTable {
+	return buildsPropertyTable
 }
 
 // Validate checks the BuildsPropertyTask's inputs without contacting the server.
 func (t BuildsPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builds:set", buildsPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the BuildsPropertyTask would produce.
 func (t BuildsPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builds:set", buildsPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t BuildsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "builds:set", buildsPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return BuildsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t BuildsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("builds:set", buildsPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return BuildsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -82,38 +82,46 @@ func (t CaddyPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// caddyPropertyKeys maps caddy property names to the JSON keys emitted by
+// caddyPropertyTable maps caddy property names to the JSON keys emitted by
 // `dokku caddy:report --format json` on dokku 0.38.8+. All except
 // tls-internal are global-only.
-var caddyPropertyKeys = map[string]PropertyKeys{
-	"image":              {PerApp: "", Global: "global-image"},
-	"letsencrypt-email":  {PerApp: "", Global: "global-letsencrypt-email"},
-	"letsencrypt-server": {PerApp: "", Global: "global-letsencrypt-server"},
-	"log-level":          {PerApp: "", Global: "global-log-level"},
-	"polling-interval":   {PerApp: "", Global: "global-polling-interval"},
-	"tls-internal":       {PerApp: "tls-internal", Global: "global-tls-internal"},
+var caddyPropertyTable = PropertyTable{
+	Subcommand: "caddy:set",
+	Keys: map[string]PropertyKeys{
+		"image":              {PerApp: "", Global: "global-image"},
+		"letsencrypt-email":  {PerApp: "", Global: "global-letsencrypt-email"},
+		"letsencrypt-server": {PerApp: "", Global: "global-letsencrypt-server"},
+		"log-level":          {PerApp: "", Global: "global-log-level"},
+		"polling-interval":   {PerApp: "", Global: "global-polling-interval"},
+		"tls-internal":       {PerApp: "tls-internal", Global: "global-tls-internal"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t CaddyPropertyTask) PropertyTable() PropertyTable {
+	return caddyPropertyTable
 }
 
 // Validate checks the CaddyPropertyTask's inputs without contacting the server.
 func (t CaddyPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set", caddyPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the CaddyPropertyTask would produce.
 func (t CaddyPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set", caddyPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t CaddyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "caddy:set", caddyPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return CaddyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t CaddyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("caddy:set", caddyPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return CaddyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/catalog.go
+++ b/tasks/catalog.go
@@ -1,0 +1,607 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// The catalog is the machine-readable form of everything docket knows about
+// its own task types. It exists because that knowledge used to live only in
+// generate/docs.go - a `package main` binary run by `make docs` - so the only
+// thing that could be done with it was render markdown, and anything else that
+// wanted it had to scrape docs/tasks/*.md or vendor the reflection (#422).
+//
+// Now the reflection lives here and the docs generator renders *from* the
+// catalog, which is what stops the published JSON and the published markdown
+// from ever describing different things.
+//
+// The document describes the recipe surface, not the Go one: every name in it
+// is a key a recipe author types. Go field names and Go type names are
+// deliberately absent - an in-repo caller that wants those still has
+// RegisteredTasks and reflect.
+
+// CatalogVersion is the wire-format version every emitted catalog carries in
+// its `version` field.
+//
+// It is deliberately independent of the --json event stream's version
+// (commands.jsonSchemaVersion): the two are different formats with different
+// consumers, and a breaking change to one must not force the other's consumers
+// to re-branch. Bumps are reserved for breaking changes; adding a key within a
+// major version does not bump.
+const CatalogVersion = 1
+
+// Field and item type names. These are the doc-facing type vocabulary, shared
+// with the Parameters table the generator renders, and they are what the
+// published JSON Schema enumerates.
+const (
+	// TypeString covers Go strings and named string types such as State.
+	TypeString = "string"
+
+	// TypeBool covers bool and *bool.
+	TypeBool = "bool"
+
+	// TypeInt covers every sized integer kind.
+	TypeInt = "int"
+
+	// TypeFloat covers float32 and float64. No task field uses one today.
+	TypeFloat = "float"
+
+	// TypeList is a slice or array field.
+	TypeList = "list"
+
+	// TypeDict is a map field.
+	TypeDict = "dict"
+
+	// TypeObject is a struct element inside a list, such as a PortMapping. It
+	// never appears as a field's own type - a task has no bare struct field.
+	TypeObject = "object"
+
+	// TypeAny is an element with no declared type, as in map[string]any.
+	TypeAny = "any"
+
+	// TypeUnknown is the fallback for a Go kind none of the above covers.
+	// TestCatalogFieldTypesAreKnown fails on it, so adding an exotic field type
+	// to a task is a build failure rather than a leaked Go type name in the
+	// published JSON.
+	TypeUnknown = "unknown"
+)
+
+// Identity roles a field can carry, from its `identity:` struct tag.
+const (
+	// IdentityRoleKey marks a field that decides which resource the task
+	// manages. Declaration order is key order.
+	IdentityRoleKey = "key"
+
+	// IdentityRoleCollection marks a collection the task manages wholesale.
+	IdentityRoleCollection = "collection"
+)
+
+// Scopes a property can be set in.
+const (
+	// PropertyScopeApp means the property has a per-app form, set by naming an
+	// app.
+	PropertyScopeApp = "app"
+
+	// PropertyScopeGlobal means the property has a global form, set with
+	// `global: true`.
+	PropertyScopeGlobal = "global"
+)
+
+// TaskCatalog is the machine-readable description of every registered task
+// type. It is what `docket schema` emits.
+type TaskCatalog struct {
+	// Version is CatalogVersion. Consumers should branch on it so a future
+	// schema change does not silently break them.
+	Version int `json:"version"`
+
+	// Tasks are every registered task type, sorted by Type.
+	Tasks []TaskSchema `json:"tasks"`
+}
+
+// TaskSchema describes one registered task type. The Go field order here is
+// the key order of the emitted JSON.
+type TaskSchema struct {
+	// Type is the registry key - the name a recipe uses to invoke the task,
+	// such as "dokku_apps_property".
+	Type string `json:"type"`
+
+	// Synopsis is the task's Doc(), verbatim.
+	Synopsis string `json:"synopsis"`
+
+	// Deprecation is the notice a deprecated task declares. Absent when the
+	// task is current.
+	Deprecation string `json:"deprecation,omitempty"`
+
+	// Requirements are the non-core dokku plugins the task needs, in declared
+	// order. Absent when the task needs nothing beyond dokku core.
+	Requirements []string `json:"requirements,omitempty"`
+
+	// Export says whether `docket export` can reconstruct the task from a live
+	// server.
+	Export ExportSupport `json:"export"`
+
+	// Probe says how much of its own state the task's Plan() can read back. An
+	// "unsupported" task plans as drift on every run and never converges.
+	Probe ProbeSupport `json:"probe"`
+
+	// Identity is what the task addresses on the server.
+	Identity IdentitySchema `json:"identity"`
+
+	// Fields are the recipe keys the task accepts, in declaration order -
+	// which is the order the reference page lists them in.
+	Fields []FieldSchema `json:"fields"`
+
+	// PropertySchema is present only for a task that manages an enumerable
+	// dokku property table. Its absence on a task that has a `property` field
+	// means the legal names are not enumerable from docket, not that there are
+	// none - see dokku_service_property.
+	PropertySchema *PropertySchema `json:"property_schema,omitempty"`
+
+	// Examples are the task's documented examples, the same ones its reference
+	// page publishes.
+	Examples []ExampleSchema `json:"examples,omitempty"`
+}
+
+// IdentitySchema is what a task addresses, projected from the `identity:"key"`
+// and `identity:"collection"` field tags.
+type IdentitySchema struct {
+	// Keys are the recipe keys of the identity key fields, in declaration
+	// order - the order IdentityAddress renders them in. A key holding its
+	// zero value is omitted from the rendered address, which is what lets the
+	// mutually exclusive app / global pair produce two different addresses.
+	//
+	// Derivable from the fields carrying `"identity": "key"`, and duplicated
+	// here because building a resource address is the main thing a consumer
+	// does with this.
+	Keys []string `json:"keys"`
+
+	// Collections are the collection fields the task manages wholesale.
+	Collections []IdentityCollectionSchema `json:"collections,omitempty"`
+}
+
+// IdentityCollectionSchema is one `identity:"collection"` field.
+type IdentityCollectionSchema struct {
+	// Name is the collection's recipe key.
+	Name string `json:"name"`
+
+	// Item says what identifies one entry: "value", "map_key", or "fields".
+	Item ItemIdentity `json:"item"`
+
+	// ItemKeys are the element struct's own identity key names, in declaration
+	// order. Populated only when Item is "fields".
+	ItemKeys []string `json:"item_keys,omitempty"`
+}
+
+// FieldSchema is one recipe key a task accepts.
+type FieldSchema struct {
+	// Name is the recipe key, from the yaml tag. A field tagged `yaml:"-"` is
+	// absent from the catalog entirely.
+	Name string `json:"name"`
+
+	// Type is the doc-facing type name.
+	Type string `json:"type"`
+
+	// Required mirrors what the loader enforces: `required:"true"` with no
+	// default. A field carrying a default is never actually required, because
+	// defaults.SetDefaults fills it in before the loader's zero-check runs.
+	Required bool `json:"required"`
+
+	// Default is the literal `default:` tag text, to be read according to
+	// Type. It is not pre-parsed, so it cannot diverge from what go-defaults
+	// does with it. Note that go-defaults leaves pointer fields untouched: on
+	// a *bool the tag documents what the task coerces nil to, not a value the
+	// loader writes into the struct.
+	Default string `json:"default,omitempty"`
+
+	// Choices are the `options:` tag values, in tag order. Absent when the
+	// field is not an enum.
+	Choices []string `json:"choices,omitempty"`
+
+	// Description is the raw `description:` tag. Prose the reference page
+	// appends - "(sensitive)", "Each item has: ..." - is derived from
+	// Sensitive and Item rather than baked in here.
+	Description string `json:"description,omitempty"`
+
+	// Sensitive marks a field whose value is a secret. A consumer that echoes
+	// a recipe must mask it.
+	Sensitive bool `json:"sensitive,omitempty"`
+
+	// Identity is "key" or "collection" when the field carries an identity
+	// tag, and absent otherwise.
+	Identity string `json:"identity,omitempty"`
+
+	// Item describes the element shape of a list or dict field. Absent on a
+	// scalar.
+	Item *ItemSchema `json:"item,omitempty"`
+}
+
+// ItemSchema is the element shape of a list or dict field. `list` alone cannot
+// tell a []string from a []PortMapping, which is the gap this closes.
+type ItemSchema struct {
+	// KeyType is the map key's type. Present only on a dict; always "string"
+	// today.
+	KeyType string `json:"key_type,omitempty"`
+
+	// Type is the element's type: a scalar name, "object" when the element is
+	// a struct, or "any" when it is untyped.
+	Type string `json:"type"`
+
+	// Identity is what identifies one entry, for a field tagged
+	// `identity:"collection"`: "value", "map_key", or "fields". Absent on a
+	// collection the task treats as an attribute rather than as the set of
+	// items it manages.
+	Identity ItemIdentity `json:"identity,omitempty"`
+
+	// Keys are the element struct's own identity key names. Present only when
+	// Identity is "fields".
+	Keys []string `json:"keys,omitempty"`
+
+	// Fields are the element struct's own fields, in declaration order.
+	// Present only when Type is "object". An element struct declares the same
+	// tags a task does, so this is where a consumer learns that a
+	// HttpAuthUser's `password` is sensitive.
+	Fields []FieldSchema `json:"fields,omitempty"`
+}
+
+// ExampleSchema is one documented example: the heading its reference page
+// gives it, and the YAML snippet itself.
+type ExampleSchema struct {
+	Name string `json:"name"`
+	YAML string `json:"yaml"`
+}
+
+// PropertySchema is the enumerable property table a *_property task manages -
+// the real schema behind its free-form-looking `property` field.
+type PropertySchema struct {
+	// Plugin is the dokku plugin, for example "apps" or "scheduler-k3s".
+	Plugin string `json:"plugin"`
+
+	// Subcommand is the dokku subcommand a set or unset runs, for example
+	// "apps:set" or "buildpacks:set-property".
+	Subcommand string `json:"subcommand"`
+
+	// Field is the recipe key the table constrains. Always "property".
+	Field string `json:"field"`
+
+	// Properties are the enumerable property names, sorted.
+	Properties []PropertyEntrySchema `json:"properties"`
+
+	// Dynamic are the name families the table cannot enumerate, because dokku
+	// validates them through the set subcommand rather than through its report
+	// schema. A name matching one of these prefixes is legal even though it is
+	// absent from Properties.
+	Dynamic []DynamicPropertySchema `json:"dynamic,omitempty"`
+}
+
+// PropertyEntrySchema is one property name and where it may be used.
+type PropertyEntrySchema struct {
+	// Name is the value a recipe puts in `property:`.
+	Name string `json:"name"`
+
+	// Scopes is a non-empty subset of ["app", "global"], in that order. Using
+	// the property in a scope it does not list is rejected at validate time,
+	// matching dokku's own CLI rejection.
+	Scopes []string `json:"scopes"`
+
+	// AppReportKey and GlobalReportKey are the keys
+	// `dokku <plugin>:report --format json` emits for the property in each
+	// scope. Absent for a scope the property has no form in.
+	AppReportKey    string `json:"app_report_key,omitempty"`
+	GlobalReportKey string `json:"global_report_key,omitempty"`
+
+	// Sensitive marks a property whose value is a secret.
+	Sensitive bool `json:"sensitive,omitempty"`
+}
+
+// DynamicPropertySchema is a family of property names matched by prefix.
+type DynamicPropertySchema struct {
+	// Prefix is what a member's name starts with.
+	Prefix string `json:"prefix"`
+
+	// Probeable is true when the plugin's report surfaces a row per set
+	// member, so docket can read the value back. False means a recipe using
+	// the family reports drift on every run and never converges.
+	Probeable bool `json:"probeable"`
+
+	// Sensitive is true when docket treats members as secrets.
+	Sensitive bool `json:"sensitive,omitempty"`
+}
+
+// PropertyFieldName is the recipe key every property table constrains.
+const PropertyFieldName = "property"
+
+// buildPropertySchema projects a runtime PropertyTable into its published
+// form: names sorted, scopes spelled out rather than left implicit in an empty
+// report key, and the plugin's dynamic families attached.
+func buildPropertySchema(table PropertyTable) PropertySchema {
+	schema := PropertySchema{
+		Plugin:     table.Plugin(),
+		Subcommand: table.Subcommand,
+		Field:      PropertyFieldName,
+		Properties: make([]PropertyEntrySchema, 0, len(table.Keys)),
+	}
+
+	names := make([]string, 0, len(table.Keys))
+	for name := range table.Keys {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		entry := table.Keys[name]
+		property := PropertyEntrySchema{
+			Name:            name,
+			AppReportKey:    entry.PerApp,
+			GlobalReportKey: entry.Global,
+			Sensitive:       entry.Sensitive,
+		}
+		if entry.PerApp != "" {
+			property.Scopes = append(property.Scopes, PropertyScopeApp)
+		}
+		if entry.Global != "" {
+			property.Scopes = append(property.Scopes, PropertyScopeGlobal)
+		}
+		schema.Properties = append(schema.Properties, property)
+	}
+
+	for _, family := range DynamicPropertyFamilies(table.Plugin()) {
+		schema.Dynamic = append(schema.Dynamic, family)
+	}
+	return schema
+}
+
+// Catalog returns the catalog for every registered task, sorted by type key.
+//
+// The error comes from Examples(), which yaml-marshals each example struct.
+// Nothing else here can fail.
+func Catalog() (TaskCatalog, error) {
+	names := make([]string, 0, len(RegisteredTasks))
+	for name := range RegisteredTasks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	catalog := TaskCatalog{Version: CatalogVersion, Tasks: make([]TaskSchema, 0, len(names))}
+	for _, name := range names {
+		schema, err := TaskSchemaOf(name, RegisteredTasks[name])
+		if err != nil {
+			return TaskCatalog{}, err
+		}
+		catalog.Tasks = append(catalog.Tasks, schema)
+	}
+	return catalog, nil
+}
+
+// TaskSchemaOf describes one task. Exported so a caller holding a single
+// prototype does not have to build all of them.
+func TaskSchemaOf(typeKey string, task Task) (TaskSchema, error) {
+	schema := TaskSchema{
+		Type:     typeKey,
+		Synopsis: strings.TrimSpace(task.Doc()),
+		Fields:   buildFields(taskStructOf(task)),
+		Identity: IdentitySchema{Keys: IdentityKeyNames(task)},
+	}
+
+	schema.Deprecation = strings.TrimSpace(TaskDeprecation(task))
+	if doc, ok := task.(RequirementsDocer); ok {
+		schema.Requirements = doc.Requirements()
+	}
+	schema.Export, _ = TaskExportSupport(task)
+	schema.Probe, _ = TaskProbeSupport(task)
+
+	for _, collection := range TaskIdentityCollections(task) {
+		schema.Identity.Collections = append(schema.Identity.Collections, IdentityCollectionSchema{
+			Name:     collection.YAMLName,
+			Item:     collection.Item,
+			ItemKeys: collection.ItemKeys,
+		})
+	}
+
+	if table, ok := TaskPropertyTable(task); ok {
+		propertySchema := buildPropertySchema(table)
+		schema.PropertySchema = &propertySchema
+	}
+
+	examples, err := task.Examples()
+	if err != nil {
+		return TaskSchema{}, fmt.Errorf("examples for task %s: %w", typeKey, err)
+	}
+	for _, example := range examples {
+		schema.Examples = append(schema.Examples, ExampleSchema{
+			Name: example.Name,
+			YAML: strings.TrimSpace(example.Codeblock) + "\n",
+		})
+	}
+
+	return schema, nil
+}
+
+// Encode writes the catalog as an indented JSON document with a trailing
+// newline. This is the byte format `docket schema` emits, so it lives with the
+// catalog rather than with the command.
+//
+// HTML escaping is off: json.Marshal would turn a description mentioning
+// `dokku <plugin>:report` into `<plugin>`, which is unreadable for a
+// document a human also skims.
+func (c TaskCatalog) Encode(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(c)
+}
+
+// taskStructOf dereferences a registered task down to its struct type. The
+// registry stores pointer prototypes.
+func taskStructOf(task Task) reflect.Type {
+	rt := reflect.TypeOf(task)
+	for rt != nil && rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	return rt
+}
+
+// buildFields reflects over a task (or element) struct and returns its recipe
+// keys in declaration order.
+func buildFields(rt reflect.Type) []FieldSchema {
+	if rt == nil || rt.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var fields []FieldSchema
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+		if field.PkgPath != "" { // unexported
+			continue
+		}
+		name := catalogYAMLName(field.Tag, field.Name)
+		if name == "" {
+			continue
+		}
+
+		def := field.Tag.Get("default")
+		schema := FieldSchema{
+			Name: name,
+			Type: catalogFieldType(field.Type),
+			// A field with a default is effectively optional even if it is
+			// tagged required:"true".
+			Required:    field.Tag.Get("required") == "true" && def == "",
+			Default:     def,
+			Description: field.Tag.Get("description"),
+			Sensitive:   field.Tag.Get("sensitive") == "true",
+		}
+		if opts := field.Tag.Get("options"); opts != "" {
+			schema.Choices = strings.Split(opts, ",")
+		}
+		switch field.Tag.Get(identityTag) {
+		case identityTagKey:
+			schema.Identity = IdentityRoleKey
+		case identityTagCollection:
+			schema.Identity = IdentityRoleCollection
+		}
+		schema.Item = buildItem(field.Type, schema.Identity == IdentityRoleCollection)
+
+		fields = append(fields, schema)
+	}
+	return fields
+}
+
+// buildItem describes the element shape of a list or dict field, and returns
+// nil for a scalar. collection says whether the field is tagged
+// `identity:"collection"`, which is what decides whether item identity is
+// reported: an untagged list is an attribute of the resource (storage_mount's
+// `phases` narrows one mount), not the set of items the task manages, so it
+// has no item identity to declare.
+func buildItem(t reflect.Type, collection bool) *ItemSchema {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	var item ItemSchema
+	switch t.Kind() {
+	case reflect.Map:
+		item.KeyType = catalogFieldType(t.Key())
+		item.Type = elementType(t.Elem())
+	case reflect.Slice, reflect.Array:
+		item.Type = elementType(t.Elem())
+	default:
+		return nil
+	}
+
+	if item.Type == TypeObject {
+		item.Fields = buildFields(structElem(t.Elem()))
+	}
+	if collection {
+		item.Identity, item.Keys = collectionItemIdentity(t)
+	}
+	return &item
+}
+
+// elementType names a collection's element type. A struct element is
+// "object" - the shape is then spelled out in ItemSchema.Fields - and an
+// interface element is "any", since map[string]any accepts whatever the
+// recipe supplies.
+func elementType(t reflect.Type) string {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() == reflect.Struct {
+		return TypeObject
+	}
+	if t.Kind() == reflect.Interface {
+		return TypeAny
+	}
+	return catalogFieldType(t)
+}
+
+// structElem returns the struct type behind a collection's element type, or
+// nil when the element is not a struct.
+func structElem(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	return t
+}
+
+// catalogFieldType maps a Go field type to the doc-facing type name. Named
+// string types such as State render as "string"; slices render as "list" and
+// maps as "dict", mirroring Ansible's type vocabulary. Pointer fields (e.g. an
+// optional *bool) render as their element type so they read as "bool" rather
+// than "*bool".
+//
+// The fallback is TypeUnknown rather than the Go type name: a Go identifier
+// has no meaning to a consumer of the recipe surface, and
+// TestCatalogFieldTypesAreKnown fails on it so an exotic new field type is
+// caught at build time instead of shipping.
+func catalogFieldType(t reflect.Type) string {
+	if t.Kind() == reflect.Ptr {
+		return catalogFieldType(t.Elem())
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return TypeString
+	case reflect.Bool:
+		return TypeBool
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return TypeInt
+	case reflect.Float32, reflect.Float64:
+		return TypeFloat
+	case reflect.Slice, reflect.Array:
+		return TypeList
+	case reflect.Map:
+		return TypeDict
+	case reflect.Interface:
+		return TypeAny
+	default:
+		return TypeUnknown
+	}
+}
+
+// catalogYAMLName extracts the recipe key for a field from its yaml tag,
+// dropping any ",omitempty"-style suffix. Returns "" when the field is not
+// serialized, which drops it from the catalog entirely.
+//
+// This is deliberately not yamlFieldName (export.go): that one maps `yaml:"-"`
+// to the lowercased Go field name, because its callers ask "what would this
+// field be called" about a field they already know is exported. Here the
+// question is "is this a key a recipe can set", and the answer for `yaml:"-"`
+// is no.
+func catalogYAMLName(tag reflect.StructTag, fieldName string) string {
+	name := tag.Get("yaml")
+	if comma := strings.IndexByte(name, ','); comma >= 0 {
+		name = name[:comma]
+	}
+	if name == "-" {
+		return ""
+	}
+	if name == "" {
+		return strings.ToLower(fieldName)
+	}
+	return name
+}

--- a/tasks/catalog_test.go
+++ b/tasks/catalog_test.go
@@ -1,0 +1,544 @@
+package tasks
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// catalogFor builds the catalog once for a test, failing fast if it cannot.
+func catalogFor(t *testing.T) TaskCatalog {
+	t.Helper()
+	catalog, err := Catalog()
+	if err != nil {
+		t.Fatalf("Catalog(): %v", err)
+	}
+	return catalog
+}
+
+// schemaFor returns the catalog entry for one task type.
+func schemaFor(t *testing.T, catalog TaskCatalog, typeKey string) TaskSchema {
+	t.Helper()
+	for _, schema := range catalog.Tasks {
+		if schema.Type == typeKey {
+			return schema
+		}
+	}
+	t.Fatalf("catalog has no entry for %q", typeKey)
+	return TaskSchema{}
+}
+
+// fieldFor returns the named field from a list, failing when it is absent.
+func fieldFor(t *testing.T, fields []FieldSchema, name string) FieldSchema {
+	t.Helper()
+	for _, field := range fields {
+		if field.Name == name {
+			return field
+		}
+	}
+	t.Fatalf("no field named %q (have %v)", name, fieldNames(fields))
+	return FieldSchema{}
+}
+
+func fieldNames(fields []FieldSchema) []string {
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		out = append(out, field.Name)
+	}
+	return out
+}
+
+func TestCatalogCoversEveryRegisteredTask(t *testing.T) {
+	catalog := catalogFor(t)
+
+	if catalog.Version != CatalogVersion {
+		t.Errorf("Version = %d; want %d", catalog.Version, CatalogVersion)
+	}
+	if len(catalog.Tasks) != len(RegisteredTasks) {
+		t.Errorf("catalog has %d tasks; registry has %d", len(catalog.Tasks), len(RegisteredTasks))
+	}
+
+	seen := map[string]bool{}
+	for i, schema := range catalog.Tasks {
+		if _, ok := RegisteredTasks[schema.Type]; !ok {
+			t.Errorf("catalog names %q, which is not registered", schema.Type)
+		}
+		if seen[schema.Type] {
+			t.Errorf("catalog lists %q twice", schema.Type)
+		}
+		seen[schema.Type] = true
+		if i > 0 && catalog.Tasks[i-1].Type >= schema.Type {
+			t.Errorf("catalog is not sorted: %q precedes %q", catalog.Tasks[i-1].Type, schema.Type)
+		}
+	}
+}
+
+func TestCatalogEveryTaskHasSynopsisAndFields(t *testing.T) {
+	for _, schema := range catalogFor(t).Tasks {
+		if schema.Synopsis == "" {
+			t.Errorf("task %q has an empty synopsis", schema.Type)
+		}
+		if len(schema.Fields) == 0 {
+			t.Errorf("task %q has no fields", schema.Type)
+		}
+		if len(schema.Identity.Keys) == 0 {
+			t.Errorf("task %q has no identity keys", schema.Type)
+		}
+		for _, field := range schema.Fields {
+			if field.Name == "" {
+				t.Errorf("task %q has a field with no name", schema.Type)
+			}
+		}
+	}
+}
+
+// TestCatalogFieldTypesAreKnown is what makes the catalog's type vocabulary a
+// closed set. The reflection falls back to TypeUnknown rather than to the Go
+// type name, so adding a field of an exotic type to a task fails here instead
+// of leaking `tasks.State`-style Go identifiers into the published JSON.
+func TestCatalogFieldTypesAreKnown(t *testing.T) {
+	fieldTypes := map[string]bool{
+		TypeString: true, TypeBool: true, TypeInt: true, TypeFloat: true,
+		TypeList: true, TypeDict: true, TypeAny: true,
+	}
+	elementTypes := map[string]bool{
+		TypeString: true, TypeBool: true, TypeInt: true, TypeFloat: true,
+		TypeList: true, TypeDict: true, TypeAny: true, TypeObject: true,
+	}
+
+	var check func(t *testing.T, where string, fields []FieldSchema)
+	check = func(t *testing.T, where string, fields []FieldSchema) {
+		for _, field := range fields {
+			at := where + "." + field.Name
+			if !fieldTypes[field.Type] {
+				t.Errorf("%s has type %q, which is not a known field type", at, field.Type)
+			}
+			if field.Item == nil {
+				continue
+			}
+			if !elementTypes[field.Item.Type] {
+				t.Errorf("%s item has type %q, which is not a known element type", at, field.Item.Type)
+			}
+			if field.Item.KeyType != "" && field.Item.KeyType != TypeString {
+				t.Errorf("%s item has key type %q; only %q is expected", at, field.Item.KeyType, TypeString)
+			}
+			check(t, at+"[]", field.Item.Fields)
+		}
+	}
+
+	for _, schema := range catalogFor(t).Tasks {
+		check(t, schema.Type, schema.Fields)
+	}
+}
+
+// TestCatalogRequiredMatchesTags re-derives Required from the struct tags, so
+// the catalog cannot drift from what the loader actually enforces: a field
+// carrying a default is filled in before the zero-check runs, and so is never
+// really required no matter what its required tag says.
+func TestCatalogRequiredMatchesTags(t *testing.T) {
+	catalog := catalogFor(t)
+	for _, schema := range catalog.Tasks {
+		rt := taskStructType(RegisteredTasks[schema.Type])
+		for _, field := range schema.Fields {
+			structField, ok := structFieldByYAMLName(rt, field.Name)
+			if !ok {
+				t.Errorf("%s.%s has no matching struct field", schema.Type, field.Name)
+				continue
+			}
+			def := structField.Tag.Get("default")
+			want := structField.Tag.Get("required") == "true" && def == ""
+			if field.Required != want {
+				t.Errorf("%s.%s Required = %v; want %v", schema.Type, field.Name, field.Required, want)
+			}
+			if field.Default != def {
+				t.Errorf("%s.%s Default = %q; want %q", schema.Type, field.Name, field.Default, def)
+			}
+			if field.Required && field.Default != "" {
+				t.Errorf("%s.%s is required and defaulted, which the loader cannot express", schema.Type, field.Name)
+			}
+		}
+	}
+}
+
+// TestCatalogSensitiveMatchesTags covers the nested case too: a consumer that
+// echoes a recipe has to know that a HttpAuthUser's password is a secret, and
+// that fact lives on the element struct rather than on the task.
+func TestCatalogSensitiveMatchesTags(t *testing.T) {
+	catalog := catalogFor(t)
+
+	var check func(t *testing.T, where string, rt reflect.Type, fields []FieldSchema)
+	check = func(t *testing.T, where string, rt reflect.Type, fields []FieldSchema) {
+		for _, field := range fields {
+			structField, ok := structFieldByYAMLName(rt, field.Name)
+			if !ok {
+				continue
+			}
+			want := structField.Tag.Get("sensitive") == "true"
+			if field.Sensitive != want {
+				t.Errorf("%s.%s Sensitive = %v; want %v", where, field.Name, field.Sensitive, want)
+			}
+			if field.Item != nil && field.Item.Type == TypeObject {
+				check(t, where+"."+field.Name+"[]", structElem(sliceOrMapElem(structField.Type)), field.Item.Fields)
+			}
+		}
+	}
+
+	for _, schema := range catalog.Tasks {
+		check(t, schema.Type, taskStructType(RegisteredTasks[schema.Type]), schema.Fields)
+	}
+
+	// Pin the case the nesting exists for.
+	user := fieldFor(t, schemaFor(t, catalog, "dokku_http_auth_user").Fields, "users")
+	if user.Item == nil {
+		t.Fatal("dokku_http_auth_user.users has no item schema")
+	}
+	for _, name := range []string{"password", "hash"} {
+		if !fieldFor(t, user.Item.Fields, name).Sensitive {
+			t.Errorf("dokku_http_auth_user.users[].%s must be sensitive", name)
+		}
+	}
+}
+
+// TestCatalogIdentityMatchesTaskIdentity checks the catalog against the same
+// helpers the loader and the export filter read. The "every key is a field"
+// half also guards the two yaml-name helpers staying in agreement: a key hidden
+// behind `yaml:"-"` would be in Identity.Keys but absent from Fields.
+func TestCatalogIdentityMatchesTaskIdentity(t *testing.T) {
+	for _, schema := range catalogFor(t).Tasks {
+		task := RegisteredTasks[schema.Type]
+
+		if want := IdentityKeyNames(task); !reflect.DeepEqual(schema.Identity.Keys, want) {
+			t.Errorf("%s Identity.Keys = %v; want %v", schema.Type, schema.Identity.Keys, want)
+		}
+
+		var want []IdentityCollectionSchema
+		for _, collection := range TaskIdentityCollections(task) {
+			want = append(want, IdentityCollectionSchema{
+				Name:     collection.YAMLName,
+				Item:     collection.Item,
+				ItemKeys: collection.ItemKeys,
+			})
+		}
+		if !reflect.DeepEqual(schema.Identity.Collections, want) {
+			t.Errorf("%s Identity.Collections = %+v; want %+v", schema.Type, schema.Identity.Collections, want)
+		}
+
+		names := map[string]bool{}
+		for _, field := range schema.Fields {
+			names[field.Name] = true
+		}
+		for _, key := range schema.Identity.Keys {
+			if !names[key] {
+				t.Errorf("%s identity key %q is not a documented field", schema.Type, key)
+			}
+		}
+	}
+}
+
+func TestCatalogSupportMatchesDeclarations(t *testing.T) {
+	for _, schema := range catalogFor(t).Tasks {
+		task := RegisteredTasks[schema.Type]
+		if want, _ := TaskExportSupport(task); schema.Export != want {
+			t.Errorf("%s Export = %+v; want %+v", schema.Type, schema.Export, want)
+		}
+		if want, _ := TaskProbeSupport(task); schema.Probe != want {
+			t.Errorf("%s Probe = %+v; want %+v", schema.Type, schema.Probe, want)
+		}
+		if want := strings.TrimSpace(TaskDeprecation(task)); schema.Deprecation != want {
+			t.Errorf("%s Deprecation = %q; want %q", schema.Type, schema.Deprecation, want)
+		}
+	}
+}
+
+// TestCatalogFieldShapes pins the shapes a bare type name cannot express: a
+// list of structs, a dict of scalars, a dict of anything, and a *bool whose
+// default documents a runtime coercion rather than a value the loader writes.
+func TestCatalogFieldShapes(t *testing.T) {
+	catalog := catalogFor(t)
+
+	ports := fieldFor(t, schemaFor(t, catalog, "dokku_ports").Fields, "port_mappings")
+	if ports.Type != TypeList || ports.Identity != IdentityRoleCollection {
+		t.Errorf("port_mappings = {type %q, identity %q}; want {list, collection}", ports.Type, ports.Identity)
+	}
+	if ports.Item == nil || ports.Item.Type != TypeObject {
+		t.Fatalf("port_mappings item = %+v; want an object", ports.Item)
+	}
+	if got := fieldNames(ports.Item.Fields); !reflect.DeepEqual(got, []string{"scheme", "host", "container"}) {
+		t.Errorf("port_mappings item fields = %v", got)
+	}
+	if host := fieldFor(t, ports.Item.Fields, "host"); host.Type != TypeInt || host.Identity != IdentityRoleKey {
+		t.Errorf("port_mappings item host = {type %q, identity %q}; want {int, key}", host.Type, host.Identity)
+	}
+	if ports.Item.Identity != ItemIdentityFields {
+		t.Errorf("port_mappings item identity = %q; want %q", ports.Item.Identity, ItemIdentityFields)
+	}
+	if !reflect.DeepEqual(ports.Item.Keys, []string{"scheme", "host"}) {
+		t.Errorf("port_mappings item keys = %v; want [scheme host]", ports.Item.Keys)
+	}
+
+	config := schemaFor(t, catalog, "dokku_config")
+	cfg := fieldFor(t, config.Fields, "config")
+	if cfg.Type != TypeDict || cfg.Item == nil || cfg.Item.KeyType != TypeString || cfg.Item.Type != TypeString {
+		t.Errorf("config = {type %q, item %+v}; want a dict of string", cfg.Type, cfg.Item)
+	}
+	if cfg.Item.Identity != ItemIdentityMapKey {
+		t.Errorf("config item identity = %q; want %q", cfg.Item.Identity, ItemIdentityMapKey)
+	}
+	restart := fieldFor(t, config.Fields, "restart")
+	if restart.Type != TypeBool || restart.Required || restart.Default != "true" {
+		t.Errorf("restart = {type %q, required %v, default %q}; want {bool, false, \"true\"}", restart.Type, restart.Required, restart.Default)
+	}
+
+	values := fieldFor(t, schemaFor(t, catalog, "dokku_scheduler_k3s_chart").Fields, "values")
+	if values.Type != TypeDict || values.Item == nil || values.Item.Type != TypeAny {
+		t.Errorf("values = {type %q, item %+v}; want a dict of any", values.Type, values.Item)
+	}
+
+	scale := fieldFor(t, schemaFor(t, catalog, "dokku_ps_scale").Fields, "scale")
+	if scale.Type != TypeDict || scale.Item == nil || scale.Item.Type != TypeInt {
+		t.Errorf("scale = {type %q, item %+v}; want a dict of int", scale.Type, scale.Item)
+	}
+
+	domains := fieldFor(t, schemaFor(t, catalog, "dokku_domains").Fields, "domains")
+	if domains.Item == nil || domains.Item.Type != TypeString || domains.Item.Identity != ItemIdentityValue {
+		t.Errorf("domains item = %+v; want a string identified by value", domains.Item)
+	}
+
+	// An untagged collection is an attribute of the resource, not the set of
+	// items the task manages, so it declares no item identity.
+	phases := fieldFor(t, schemaFor(t, catalog, "dokku_storage_mount").Fields, "phases")
+	if phases.Identity != "" || phases.Item == nil || phases.Item.Identity != "" {
+		t.Errorf("phases = {identity %q, item %+v}; want no identity", phases.Identity, phases.Item)
+	}
+
+	state := fieldFor(t, config.Fields, "state")
+	if !reflect.DeepEqual(state.Choices, []string{"present", "absent"}) {
+		t.Errorf("state choices = %v; want [present absent]", state.Choices)
+	}
+}
+
+// TestCatalogPropertySchemaMatchesTable checks the published property list
+// against the runtime table each task actually validates and probes with.
+func TestCatalogPropertySchemaMatchesTable(t *testing.T) {
+	for _, schema := range catalogFor(t).Tasks {
+		table, declared := TaskPropertyTable(RegisteredTasks[schema.Type])
+		if !declared {
+			if schema.PropertySchema != nil {
+				t.Errorf("%s publishes a property schema without declaring a table", schema.Type)
+			}
+			continue
+		}
+		if schema.PropertySchema == nil {
+			t.Errorf("%s declares a property table but publishes no property schema", schema.Type)
+			continue
+		}
+
+		published := schema.PropertySchema
+		if published.Plugin != table.Plugin() {
+			t.Errorf("%s plugin = %q; want %q", schema.Type, published.Plugin, table.Plugin())
+		}
+		if published.Subcommand != table.Subcommand {
+			t.Errorf("%s subcommand = %q; want %q", schema.Type, published.Subcommand, table.Subcommand)
+		}
+		if published.Field != PropertyFieldName {
+			t.Errorf("%s property field = %q; want %q", schema.Type, published.Field, PropertyFieldName)
+		}
+
+		var names []string
+		for _, property := range published.Properties {
+			names = append(names, property.Name)
+
+			entry := table.Keys[property.Name]
+			if property.AppReportKey != entry.PerApp || property.GlobalReportKey != entry.Global {
+				t.Errorf("%s[%q] keys = (%q, %q); want (%q, %q)",
+					schema.Type, property.Name, property.AppReportKey, property.GlobalReportKey, entry.PerApp, entry.Global)
+			}
+			if property.Sensitive != entry.Sensitive {
+				t.Errorf("%s[%q] Sensitive = %v; want %v", schema.Type, property.Name, property.Sensitive, entry.Sensitive)
+			}
+
+			var wantScopes []string
+			if entry.PerApp != "" {
+				wantScopes = append(wantScopes, PropertyScopeApp)
+			}
+			if entry.Global != "" {
+				wantScopes = append(wantScopes, PropertyScopeGlobal)
+			}
+			if !reflect.DeepEqual(property.Scopes, wantScopes) {
+				t.Errorf("%s[%q] scopes = %v; want %v", schema.Type, property.Name, property.Scopes, wantScopes)
+			}
+		}
+
+		want := make([]string, 0, len(table.Keys))
+		for name := range table.Keys {
+			want = append(want, name)
+		}
+		sort.Strings(want)
+		if !reflect.DeepEqual(names, want) {
+			t.Errorf("%s properties = %v; want %v", schema.Type, names, want)
+		}
+
+		if !reflect.DeepEqual(published.Dynamic, DynamicPropertyFamilies(table.Plugin())) {
+			t.Errorf("%s dynamic = %+v; want %+v", schema.Type, published.Dynamic, DynamicPropertyFamilies(table.Plugin()))
+		}
+
+		// The table constrains a field that has to exist for the constraint
+		// to mean anything.
+		fieldFor(t, schema.Fields, published.Field)
+	}
+}
+
+// TestCatalogPropertySchemaSpotChecks pins the two ends of the range: a table
+// whose properties are split across scopes, and one with a dynamic family.
+func TestCatalogPropertySchemaSpotChecks(t *testing.T) {
+	catalog := catalogFor(t)
+
+	apps := schemaFor(t, catalog, "dokku_apps_property").PropertySchema
+	if apps == nil {
+		t.Fatal("dokku_apps_property has no property schema")
+	}
+	if apps.Plugin != "apps" || apps.Subcommand != "apps:set" {
+		t.Errorf("apps property schema = {%q, %q}; want {apps, apps:set}", apps.Plugin, apps.Subcommand)
+	}
+	if len(apps.Dynamic) != 0 {
+		t.Errorf("apps has dynamic families %+v; want none", apps.Dynamic)
+	}
+	for _, tc := range []struct {
+		name   string
+		scopes []string
+	}{
+		{"deploy-source", []string{PropertyScopeApp}},
+		{"disable-autocreation", []string{PropertyScopeGlobal}},
+	} {
+		found := false
+		for _, property := range apps.Properties {
+			if property.Name != tc.name {
+				continue
+			}
+			found = true
+			if !reflect.DeepEqual(property.Scopes, tc.scopes) {
+				t.Errorf("apps %q scopes = %v; want %v", tc.name, property.Scopes, tc.scopes)
+			}
+		}
+		if !found {
+			t.Errorf("apps property schema is missing %q", tc.name)
+		}
+	}
+
+	letsencrypt := schemaFor(t, catalog, "dokku_letsencrypt_property").PropertySchema
+	if letsencrypt == nil {
+		t.Fatal("dokku_letsencrypt_property has no property schema")
+	}
+	want := []DynamicPropertySchema{{Prefix: "dns-provider-", Probeable: true, Sensitive: true}}
+	if !reflect.DeepEqual(letsencrypt.Dynamic, want) {
+		t.Errorf("letsencrypt dynamic = %+v; want %+v", letsencrypt.Dynamic, want)
+	}
+
+	// traefik has the same family, but the plugin does not report it, so a
+	// recipe using it never converges - and the catalog has to say so.
+	traefik := schemaFor(t, catalog, "dokku_traefik_property").PropertySchema
+	if traefik == nil {
+		t.Fatal("dokku_traefik_property has no property schema")
+	}
+	if len(traefik.Dynamic) != 1 || traefik.Dynamic[0].Probeable {
+		t.Errorf("traefik dynamic = %+v; want one unprobeable family", traefik.Dynamic)
+	}
+
+	// A free-form property field is not a property table, and must not be
+	// published as an empty one.
+	if service := schemaFor(t, catalog, "dokku_service_property"); service.PropertySchema != nil {
+		t.Errorf("dokku_service_property publishes %+v; its names are not enumerable", service.PropertySchema)
+	}
+}
+
+// TestCatalogEncodeIsStable guards the ordering: RegisteredTasks is a map, and
+// a consumer diffing two catalogs (or a test comparing two runs) needs the
+// bytes to depend only on the code.
+func TestCatalogEncodeIsStable(t *testing.T) {
+	var first, second bytes.Buffer
+	for _, buf := range []*bytes.Buffer{&first, &second} {
+		catalog, err := Catalog()
+		if err != nil {
+			t.Fatalf("Catalog(): %v", err)
+		}
+		if err := catalog.Encode(buf); err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+	}
+	if first.String() != second.String() {
+		t.Error("two catalog builds encoded differently")
+	}
+	if !strings.HasSuffix(first.String(), "\n") {
+		t.Error("encoded catalog does not end with a newline")
+	}
+}
+
+// TestCatalogEncodeDoesNotEscapeHTML keeps a description mentioning a
+// `dokku <plugin>:report` command readable instead of rendering it as
+// <plugin>.
+func TestCatalogEncodeDoesNotEscapeHTML(t *testing.T) {
+	catalog := TaskCatalog{
+		Version: CatalogVersion,
+		Tasks: []TaskSchema{{
+			Type:     "dokku_example",
+			Synopsis: "Reads dokku <plugin>:report & reports drift",
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := catalog.Encode(&buf); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	for _, escape := range []string{`\u003c`, `\u003e`, `\u0026`} {
+		if strings.Contains(buf.String(), escape) {
+			t.Errorf("encoded catalog contains the HTML escape %s:\n%s", escape, buf.String())
+		}
+	}
+	if !strings.Contains(buf.String(), "dokku <plugin>:report & reports drift") {
+		t.Errorf("encoded catalog lost its content:\n%s", buf.String())
+	}
+}
+
+// TestCatalogSkipsUnserializedFields proves the catalog asks "is this a key a
+// recipe can set", not "what would this field be called" - the distinction
+// between catalogYAMLName and yamlFieldName.
+func TestCatalogSkipsUnserializedFields(t *testing.T) {
+	type example struct {
+		App    string `yaml:"app"`
+		Hidden string `yaml:"-"`
+		lower  string //nolint:unused // unexported fields are never recipe keys
+	}
+
+	got := fieldNames(buildFields(reflect.TypeOf(example{})))
+	if !reflect.DeepEqual(got, []string{"app"}) {
+		t.Errorf("fields = %v; want [app]", got)
+	}
+}
+
+// structFieldByYAMLName finds the struct field a recipe key came from.
+func structFieldByYAMLName(rt reflect.Type, name string) (reflect.StructField, bool) {
+	if rt == nil || rt.Kind() != reflect.Struct {
+		return reflect.StructField{}, false
+	}
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+		if field.PkgPath == "" && catalogYAMLName(field.Tag, field.Name) == name {
+			return field, true
+		}
+	}
+	return reflect.StructField{}, false
+}
+
+// sliceOrMapElem returns a collection field's element type.
+func sliceOrMapElem(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return t.Elem()
+	}
+	return t
+}

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -82,32 +82,40 @@ func (t ChecksPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// checksPropertyKeys maps checks property names to the JSON keys emitted by
+// checksPropertyTable maps checks property names to the JSON keys emitted by
 // `dokku checks:report --format json` on dokku 0.38.8+.
-var checksPropertyKeys = map[string]PropertyKeys{
-	"wait-to-retire": {PerApp: "wait-to-retire", Global: "global-wait-to-retire"},
+var checksPropertyTable = PropertyTable{
+	Subcommand: "checks:set",
+	Keys: map[string]PropertyKeys{
+		"wait-to-retire": {PerApp: "wait-to-retire", Global: "global-wait-to-retire"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t ChecksPropertyTask) PropertyTable() PropertyTable {
+	return checksPropertyTable
 }
 
 // Validate checks the ChecksPropertyTask's inputs without contacting the server.
 func (t ChecksPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "checks:set", checksPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the ChecksPropertyTask would produce.
 func (t ChecksPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set", checksPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t ChecksPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "checks:set", checksPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return ChecksPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t ChecksPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("checks:set", checksPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return ChecksPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -82,35 +82,43 @@ func (t CronPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// cronPropertyKeys maps cron property names to the JSON keys emitted by
+// cronPropertyTable maps cron property names to the JSON keys emitted by
 // `dokku cron:report --format json` on dokku 0.38.8+. mailfrom/mailto are
 // global-only.
-var cronPropertyKeys = map[string]PropertyKeys{
-	"maintenance": {PerApp: "maintenance", Global: "global-maintenance"},
-	"mailfrom":    {PerApp: "", Global: "global-mailfrom"},
-	"mailto":      {PerApp: "", Global: "global-mailto"},
+var cronPropertyTable = PropertyTable{
+	Subcommand: "cron:set",
+	Keys: map[string]PropertyKeys{
+		"maintenance": {PerApp: "maintenance", Global: "global-maintenance"},
+		"mailfrom":    {PerApp: "", Global: "global-mailfrom"},
+		"mailto":      {PerApp: "", Global: "global-mailto"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t CronPropertyTask) PropertyTable() PropertyTable {
+	return cronPropertyTable
 }
 
 // Validate checks the CronPropertyTask's inputs without contacting the server.
 func (t CronPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "cron:set", cronPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the CronPropertyTask would produce.
 func (t CronPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set", cronPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t CronPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "cron:set", cronPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return CronPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t CronPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("cron:set", cronPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return CronPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -413,17 +413,17 @@ func (res *ExportResult) processBody(app string, body interface{}, opts ExportOp
 	case SchedulerK3sAutoscalingAuthTask:
 		return res.processSchedulerK3sAutoscalingAuth(app, b, opts)
 	case LetsencryptPropertyTask:
-		return res.processPropertyValue(app, b, b.Property, b.Value, propertyEntry("letsencrypt", b.Property, letsencryptPropertyKeys).Sensitive, opts, func(v string) interface{} {
+		return res.processPropertyValue(app, b, b.Property, b.Value, taskPropertyEntry(b, b.Property).Sensitive, opts, func(v string) interface{} {
 			b.Value = v
 			return b
 		})
 	case SchedulerK3sPropertyTask:
-		return res.processPropertyValue(app, b, b.Property, b.Value, propertyEntry("scheduler-k3s", b.Property, schedulerK3sPropertyKeys).Sensitive, opts, func(v string) interface{} {
+		return res.processPropertyValue(app, b, b.Property, b.Value, taskPropertyEntry(b, b.Property).Sensitive, opts, func(v string) interface{} {
 			b.Value = v
 			return b
 		})
 	case TraefikPropertyTask:
-		return res.processPropertyValue(app, b, b.Property, b.Value, propertyEntry("traefik", b.Property, traefikPropertyKeys).Sensitive, opts, func(v string) interface{} {
+		return res.processPropertyValue(app, b, b.Property, b.Value, taskPropertyEntry(b, b.Property).Sensitive, opts, func(v string) interface{} {
 			b.Value = v
 			return b
 		})

--- a/tasks/export_support.go
+++ b/tasks/export_support.go
@@ -23,9 +23,11 @@ const (
 // ExportSupport describes a task's export behaviour. Status is required;
 // Caveat is a human-readable note explaining a partial or unsupported status
 // (and may be empty for a plainly supported task).
+//
+// The json tags are for the task catalog, which publishes this verbatim.
 type ExportSupport struct {
-	Status ExportStatus
-	Caveat string
+	Status ExportStatus `json:"status"`
+	Caveat string       `json:"caveat,omitempty"`
 }
 
 // ExportDocer is the interface a task implements to declare its export

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -840,7 +840,7 @@ func TestExportGlobalPropertiesReadsGlobalScope(t *testing.T) {
 		"--quiet git:report --global --format json": `{"global-deploy-branch":"main","global-archive-max-files":"100","global-keep-git-dir":""}`,
 	}))()
 
-	bodies, err := exportGlobalProperties("git:set", gitPropertyKeys, func(property, value string) interface{} {
+	bodies, err := exportGlobalProperties(GitPropertyTask{}, func(property, value string) interface{} {
 		return GitPropertyTask{Global: true, Property: property, Value: value}
 	})
 	if err != nil {
@@ -874,7 +874,7 @@ func TestExportLetsencryptDynamicPropertiesFromAppReport(t *testing.T) {
 		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider":"namecheap","dns-provider-NAMECHEAP_API_USER":"deploy-bot","global-dns-provider-NAMECHEAP_API_KEY":"globalkey","computed-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
 	}))()
 
-	bodies, err := exportProperties("web", "letsencrypt:set", letsencryptPropertyKeys, func(app, property, value string) interface{} {
+	bodies, err := exportProperties(LetsencryptPropertyTask{}, "web", func(app, property, value string) interface{} {
 		return LetsencryptPropertyTask{App: app, Property: property, Value: value}
 	})
 	if err != nil {
@@ -903,7 +903,7 @@ func TestExportGlobalLetsencryptDynamicProperties(t *testing.T) {
 		"--quiet letsencrypt:report --global --format json": `{"global-email":"","global-dns-provider":"namecheap","global-dns-provider-NAMECHEAP_API_KEY":"globalkey"}`,
 	}))()
 
-	bodies, err := exportGlobalProperties("letsencrypt:set", letsencryptPropertyKeys, func(property, value string) interface{} {
+	bodies, err := exportGlobalProperties(LetsencryptPropertyTask{}, func(property, value string) interface{} {
 		return LetsencryptPropertyTask{Global: true, Property: property, Value: value}
 	})
 	if err != nil {

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -90,39 +90,47 @@ func (t GitPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// gitPropertyKeys maps git property names to the JSON keys emitted by
+// gitPropertyTable maps git property names to the JSON keys emitted by
 // `dokku git:report --format json` on dokku 0.38.9+. archive-max-files and
 // archive-max-size only surface a global key; rev-env-var and source-image
 // only surface a per-app key.
-var gitPropertyKeys = map[string]PropertyKeys{
-	"archive-max-files": {PerApp: "", Global: "global-archive-max-files"},
-	"archive-max-size":  {PerApp: "", Global: "global-archive-max-size"},
-	"deploy-branch":     {PerApp: "deploy-branch", Global: "global-deploy-branch"},
-	"keep-git-dir":      {PerApp: "keep-git-dir", Global: "global-keep-git-dir"},
-	"rev-env-var":       {PerApp: "rev-env-var", Global: ""},
-	"source-image":      {PerApp: "source-image", Global: ""},
+var gitPropertyTable = PropertyTable{
+	Subcommand: "git:set",
+	Keys: map[string]PropertyKeys{
+		"archive-max-files": {PerApp: "", Global: "global-archive-max-files"},
+		"archive-max-size":  {PerApp: "", Global: "global-archive-max-size"},
+		"deploy-branch":     {PerApp: "deploy-branch", Global: "global-deploy-branch"},
+		"keep-git-dir":      {PerApp: "keep-git-dir", Global: "global-keep-git-dir"},
+		"rev-env-var":       {PerApp: "rev-env-var", Global: ""},
+		"source-image":      {PerApp: "source-image", Global: ""},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t GitPropertyTask) PropertyTable() PropertyTable {
+	return gitPropertyTable
 }
 
 // Validate checks the GitPropertyTask's inputs without contacting the server.
 func (t GitPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "git:set", gitPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the GitPropertyTask would produce.
 func (t GitPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set", gitPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t GitPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "git:set", gitPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return GitPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t GitPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("git:set", gitPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return GitPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -82,37 +82,45 @@ func (t HaproxyPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// haproxyPropertyKeys maps haproxy property names to the JSON keys emitted
+// haproxyPropertyTable maps haproxy property names to the JSON keys emitted
 // by `dokku haproxy:report --format json` on dokku 0.38.8+. All properties
 // are global-only.
-var haproxyPropertyKeys = map[string]PropertyKeys{
-	"image":              {PerApp: "", Global: "global-image"},
-	"letsencrypt-email":  {PerApp: "", Global: "global-letsencrypt-email"},
-	"letsencrypt-server": {PerApp: "", Global: "global-letsencrypt-server"},
-	"log-level":          {PerApp: "", Global: "global-log-level"},
-	"refresh-conf":       {PerApp: "", Global: "global-refresh-conf"},
+var haproxyPropertyTable = PropertyTable{
+	Subcommand: "haproxy:set",
+	Keys: map[string]PropertyKeys{
+		"image":              {PerApp: "", Global: "global-image"},
+		"letsencrypt-email":  {PerApp: "", Global: "global-letsencrypt-email"},
+		"letsencrypt-server": {PerApp: "", Global: "global-letsencrypt-server"},
+		"log-level":          {PerApp: "", Global: "global-log-level"},
+		"refresh-conf":       {PerApp: "", Global: "global-refresh-conf"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t HaproxyPropertyTask) PropertyTable() PropertyTable {
+	return haproxyPropertyTable
 }
 
 // Validate checks the HaproxyPropertyTask's inputs without contacting the server.
 func (t HaproxyPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set", haproxyPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the HaproxyPropertyTask would produce.
 func (t HaproxyPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set", haproxyPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t HaproxyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "haproxy:set", haproxyPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return HaproxyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t HaproxyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("haproxy:set", haproxyPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return HaproxyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -107,40 +107,48 @@ func (t LetsencryptPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// letsencryptPropertyKeys maps letsencrypt property names to the JSON keys
+// letsencryptPropertyTable maps letsencrypt property names to the JSON keys
 // emitted by `dokku letsencrypt:report --format json` on
 // dokku-letsencrypt v0.20.4+. The `dns-provider-*` family takes an arbitrary
 // provider env var name, so it cannot be enumerated here; its keys are
 // synthesized per property by dynamicPropertyKeys, which v0.25.0+ reports.
-var letsencryptPropertyKeys = map[string]PropertyKeys{
-	"dns-provider":        {PerApp: "dns-provider", Global: "global-dns-provider"},
-	"email":               {PerApp: "email", Global: "global-email"},
-	"graceperiod":         {PerApp: "graceperiod", Global: "global-graceperiod"},
-	"lego-args":           {PerApp: "lego-args", Global: "global-lego-args"},
-	"lego-docker-options": {PerApp: "lego-docker-options", Global: "global-lego-docker-options"},
-	"server":              {PerApp: "server", Global: "global-server"},
+var letsencryptPropertyTable = PropertyTable{
+	Subcommand: "letsencrypt:set",
+	Keys: map[string]PropertyKeys{
+		"dns-provider":        {PerApp: "dns-provider", Global: "global-dns-provider"},
+		"email":               {PerApp: "email", Global: "global-email"},
+		"graceperiod":         {PerApp: "graceperiod", Global: "global-graceperiod"},
+		"lego-args":           {PerApp: "lego-args", Global: "global-lego-args"},
+		"lego-docker-options": {PerApp: "lego-docker-options", Global: "global-lego-docker-options"},
+		"server":              {PerApp: "server", Global: "global-server"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t LetsencryptPropertyTask) PropertyTable() PropertyTable {
+	return letsencryptPropertyTable
 }
 
 // Validate checks the LetsencryptPropertyTask's inputs without contacting the server.
 func (t LetsencryptPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set", letsencryptPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the LetsencryptPropertyTask would produce.
 func (t LetsencryptPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set", letsencryptPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t LetsencryptPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "letsencrypt:set", letsencryptPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return LetsencryptPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t LetsencryptPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("letsencrypt:set", letsencryptPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return LetsencryptPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -82,37 +82,45 @@ func (t LogsPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// logsPropertyKeys maps logs property names to the JSON keys emitted by
+// logsPropertyTable maps logs property names to the JSON keys emitted by
 // `dokku logs:report --format json` on dokku 0.38.8+. vector-image and
 // vector-networks are global-only.
-var logsPropertyKeys = map[string]PropertyKeys{
-	"app-label-alias": {PerApp: "app-label-alias", Global: "global-app-label-alias"},
-	"max-size":        {PerApp: "max-size", Global: "global-max-size"},
-	"vector-image":    {PerApp: "", Global: "global-vector-image"},
-	"vector-networks": {PerApp: "", Global: "global-vector-networks"},
-	"vector-sink":     {PerApp: "vector-sink", Global: "global-vector-sink"},
+var logsPropertyTable = PropertyTable{
+	Subcommand: "logs:set",
+	Keys: map[string]PropertyKeys{
+		"app-label-alias": {PerApp: "app-label-alias", Global: "global-app-label-alias"},
+		"max-size":        {PerApp: "max-size", Global: "global-max-size"},
+		"vector-image":    {PerApp: "", Global: "global-vector-image"},
+		"vector-networks": {PerApp: "", Global: "global-vector-networks"},
+		"vector-sink":     {PerApp: "vector-sink", Global: "global-vector-sink"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t LogsPropertyTask) PropertyTable() PropertyTable {
+	return logsPropertyTable
 }
 
 // Validate checks the LogsPropertyTask's inputs without contacting the server.
 func (t LogsPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "logs:set", logsPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the LogsPropertyTask would produce.
 func (t LogsPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set", logsPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t LogsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "logs:set", logsPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return LogsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t LogsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("logs:set", logsPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return LogsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -90,38 +90,46 @@ func (t NetworkPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// networkPropertyKeys maps network property names to the JSON keys emitted
+// networkPropertyTable maps network property names to the JSON keys emitted
 // by `dokku network:report --format json` on dokku 0.38.8+.
 // static-web-listener is per-app only.
-var networkPropertyKeys = map[string]PropertyKeys{
-	"attach-post-create":  {PerApp: "attach-post-create", Global: "global-attach-post-create"},
-	"attach-post-deploy":  {PerApp: "attach-post-deploy", Global: "global-attach-post-deploy"},
-	"bind-all-interfaces": {PerApp: "bind-all-interfaces", Global: "global-bind-all-interfaces"},
-	"initial-network":     {PerApp: "initial-network", Global: "global-initial-network"},
-	"static-web-listener": {PerApp: "static-web-listener", Global: ""},
-	"tld":                 {PerApp: "tld", Global: "global-tld"},
+var networkPropertyTable = PropertyTable{
+	Subcommand: "network:set",
+	Keys: map[string]PropertyKeys{
+		"attach-post-create":  {PerApp: "attach-post-create", Global: "global-attach-post-create"},
+		"attach-post-deploy":  {PerApp: "attach-post-deploy", Global: "global-attach-post-deploy"},
+		"bind-all-interfaces": {PerApp: "bind-all-interfaces", Global: "global-bind-all-interfaces"},
+		"initial-network":     {PerApp: "initial-network", Global: "global-initial-network"},
+		"static-web-listener": {PerApp: "static-web-listener", Global: ""},
+		"tld":                 {PerApp: "tld", Global: "global-tld"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t NetworkPropertyTask) PropertyTable() PropertyTable {
+	return networkPropertyTable
 }
 
 // Validate checks the NetworkPropertyTask's inputs without contacting the server.
 func (t NetworkPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "network:set", networkPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the NetworkPropertyTask would produce.
 func (t NetworkPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set", networkPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t NetworkPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "network:set", networkPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return NetworkPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t NetworkPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("network:set", networkPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return NetworkPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -90,65 +90,73 @@ func (t NginxPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// nginxPropertyKeys maps nginx property names to the JSON keys emitted by
+// nginxPropertyTable maps nginx property names to the JSON keys emitted by
 // `dokku nginx:report --format json` on dokku 0.38.8+. All properties are
 // app+global.
-var nginxPropertyKeys = map[string]PropertyKeys{
-	"access-log-format":       {PerApp: "access-log-format", Global: "global-access-log-format"},
-	"access-log-path":         {PerApp: "access-log-path", Global: "global-access-log-path"},
-	"bind-address-ipv4":       {PerApp: "bind-address-ipv4", Global: "global-bind-address-ipv4"},
-	"bind-address-ipv6":       {PerApp: "bind-address-ipv6", Global: "global-bind-address-ipv6"},
-	"client-body-timeout":     {PerApp: "client-body-timeout", Global: "global-client-body-timeout"},
-	"client-header-timeout":   {PerApp: "client-header-timeout", Global: "global-client-header-timeout"},
-	"client-max-body-size":    {PerApp: "client-max-body-size", Global: "global-client-max-body-size"},
-	"disable-custom-config":   {PerApp: "disable-custom-config", Global: "global-disable-custom-config"},
-	"error-log-path":          {PerApp: "error-log-path", Global: "global-error-log-path"},
-	"hsts":                    {PerApp: "hsts", Global: "global-hsts"},
-	"hsts-include-subdomains": {PerApp: "hsts-include-subdomains", Global: "global-hsts-include-subdomains"},
-	"hsts-max-age":            {PerApp: "hsts-max-age", Global: "global-hsts-max-age"},
-	"hsts-preload":            {PerApp: "hsts-preload", Global: "global-hsts-preload"},
-	"keepalive-timeout":       {PerApp: "keepalive-timeout", Global: "global-keepalive-timeout"},
-	"lingering-timeout":       {PerApp: "lingering-timeout", Global: "global-lingering-timeout"},
-	"nginx-conf-sigil-path":   {PerApp: "nginx-conf-sigil-path", Global: "global-nginx-conf-sigil-path"},
-	"nginx-service-command":   {PerApp: "nginx-service-command", Global: "global-nginx-service-command"},
-	"proxy-buffer-size":       {PerApp: "proxy-buffer-size", Global: "global-proxy-buffer-size"},
-	"proxy-buffering":         {PerApp: "proxy-buffering", Global: "global-proxy-buffering"},
-	"proxy-buffers":           {PerApp: "proxy-buffers", Global: "global-proxy-buffers"},
-	"proxy-busy-buffers-size": {PerApp: "proxy-busy-buffers-size", Global: "global-proxy-busy-buffers-size"},
-	"proxy-connect-timeout":   {PerApp: "proxy-connect-timeout", Global: "global-proxy-connect-timeout"},
-	"proxy-keepalive":         {PerApp: "proxy-keepalive", Global: "global-proxy-keepalive"},
-	"proxy-read-timeout":      {PerApp: "proxy-read-timeout", Global: "global-proxy-read-timeout"},
-	"proxy-send-timeout":      {PerApp: "proxy-send-timeout", Global: "global-proxy-send-timeout"},
-	"send-timeout":            {PerApp: "send-timeout", Global: "global-send-timeout"},
-	"underscore-in-headers":   {PerApp: "underscore-in-headers", Global: "global-underscore-in-headers"},
-	"x-forwarded-for-value":   {PerApp: "x-forwarded-for-value", Global: "global-x-forwarded-for-value"},
-	"x-forwarded-port-value":  {PerApp: "x-forwarded-port-value", Global: "global-x-forwarded-port-value"},
-	"x-forwarded-proto-value": {PerApp: "x-forwarded-proto-value", Global: "global-x-forwarded-proto-value"},
-	"x-forwarded-ssl":         {PerApp: "x-forwarded-ssl", Global: "global-x-forwarded-ssl"},
+var nginxPropertyTable = PropertyTable{
+	Subcommand: "nginx:set",
+	Keys: map[string]PropertyKeys{
+		"access-log-format":       {PerApp: "access-log-format", Global: "global-access-log-format"},
+		"access-log-path":         {PerApp: "access-log-path", Global: "global-access-log-path"},
+		"bind-address-ipv4":       {PerApp: "bind-address-ipv4", Global: "global-bind-address-ipv4"},
+		"bind-address-ipv6":       {PerApp: "bind-address-ipv6", Global: "global-bind-address-ipv6"},
+		"client-body-timeout":     {PerApp: "client-body-timeout", Global: "global-client-body-timeout"},
+		"client-header-timeout":   {PerApp: "client-header-timeout", Global: "global-client-header-timeout"},
+		"client-max-body-size":    {PerApp: "client-max-body-size", Global: "global-client-max-body-size"},
+		"disable-custom-config":   {PerApp: "disable-custom-config", Global: "global-disable-custom-config"},
+		"error-log-path":          {PerApp: "error-log-path", Global: "global-error-log-path"},
+		"hsts":                    {PerApp: "hsts", Global: "global-hsts"},
+		"hsts-include-subdomains": {PerApp: "hsts-include-subdomains", Global: "global-hsts-include-subdomains"},
+		"hsts-max-age":            {PerApp: "hsts-max-age", Global: "global-hsts-max-age"},
+		"hsts-preload":            {PerApp: "hsts-preload", Global: "global-hsts-preload"},
+		"keepalive-timeout":       {PerApp: "keepalive-timeout", Global: "global-keepalive-timeout"},
+		"lingering-timeout":       {PerApp: "lingering-timeout", Global: "global-lingering-timeout"},
+		"nginx-conf-sigil-path":   {PerApp: "nginx-conf-sigil-path", Global: "global-nginx-conf-sigil-path"},
+		"nginx-service-command":   {PerApp: "nginx-service-command", Global: "global-nginx-service-command"},
+		"proxy-buffer-size":       {PerApp: "proxy-buffer-size", Global: "global-proxy-buffer-size"},
+		"proxy-buffering":         {PerApp: "proxy-buffering", Global: "global-proxy-buffering"},
+		"proxy-buffers":           {PerApp: "proxy-buffers", Global: "global-proxy-buffers"},
+		"proxy-busy-buffers-size": {PerApp: "proxy-busy-buffers-size", Global: "global-proxy-busy-buffers-size"},
+		"proxy-connect-timeout":   {PerApp: "proxy-connect-timeout", Global: "global-proxy-connect-timeout"},
+		"proxy-keepalive":         {PerApp: "proxy-keepalive", Global: "global-proxy-keepalive"},
+		"proxy-read-timeout":      {PerApp: "proxy-read-timeout", Global: "global-proxy-read-timeout"},
+		"proxy-send-timeout":      {PerApp: "proxy-send-timeout", Global: "global-proxy-send-timeout"},
+		"send-timeout":            {PerApp: "send-timeout", Global: "global-send-timeout"},
+		"underscore-in-headers":   {PerApp: "underscore-in-headers", Global: "global-underscore-in-headers"},
+		"x-forwarded-for-value":   {PerApp: "x-forwarded-for-value", Global: "global-x-forwarded-for-value"},
+		"x-forwarded-port-value":  {PerApp: "x-forwarded-port-value", Global: "global-x-forwarded-port-value"},
+		"x-forwarded-proto-value": {PerApp: "x-forwarded-proto-value", Global: "global-x-forwarded-proto-value"},
+		"x-forwarded-ssl":         {PerApp: "x-forwarded-ssl", Global: "global-x-forwarded-ssl"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t NginxPropertyTask) PropertyTable() PropertyTable {
+	return nginxPropertyTable
 }
 
 // ExportApp reconstructs the app's explicitly-set nginx properties.
 func (t NginxPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "nginx:set", nginxPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return NginxPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t NginxPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("nginx:set", nginxPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return NginxPropertyTask{Global: true, Property: property, Value: value}
 	})
 }
 
 // Validate checks the NginxPropertyTask's inputs without contacting the server.
 func (t NginxPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set", nginxPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the NginxPropertyTask would produce.
 func (t NginxPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set", nginxPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // init registers the NginxPropertyTask with the task registry

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -90,66 +90,74 @@ func (t OpenrestyPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// openrestyPropertyKeys maps openresty property names to the JSON keys
+// openrestyPropertyTable maps openresty property names to the JSON keys
 // emitted by `dokku openresty:report --format json` on dokku 0.38.9+, which
 // gave openresty a full raw/computed/global split. Every property is
 // app+global except image/letsencrypt-email/letsencrypt-server/log-level/
 // allowed-letsencrypt-domains-func-base64, which remain global-only.
-var openrestyPropertyKeys = map[string]PropertyKeys{
-	"access-log-format":                       {PerApp: "access-log-format", Global: "global-access-log-format"},
-	"access-log-path":                         {PerApp: "access-log-path", Global: "global-access-log-path"},
-	"allowed-letsencrypt-domains-func-base64": {PerApp: "", Global: "global-allowed-letsencrypt-domains-func-base64"},
-	"bind-address-ipv4":                       {PerApp: "bind-address-ipv4", Global: "global-bind-address-ipv4"},
-	"bind-address-ipv6":                       {PerApp: "bind-address-ipv6", Global: "global-bind-address-ipv6"},
-	"client-body-timeout":                     {PerApp: "client-body-timeout", Global: "global-client-body-timeout"},
-	"client-header-timeout":                   {PerApp: "client-header-timeout", Global: "global-client-header-timeout"},
-	"client-max-body-size":                    {PerApp: "client-max-body-size", Global: "global-client-max-body-size"},
-	"error-log-path":                          {PerApp: "error-log-path", Global: "global-error-log-path"},
-	"hsts":                                    {PerApp: "hsts", Global: "global-hsts"},
-	"hsts-include-subdomains":                 {PerApp: "hsts-include-subdomains", Global: "global-hsts-include-subdomains"},
-	"hsts-max-age":                            {PerApp: "hsts-max-age", Global: "global-hsts-max-age"},
-	"hsts-preload":                            {PerApp: "hsts-preload", Global: "global-hsts-preload"},
-	"image":                                   {PerApp: "", Global: "global-image"},
-	"keepalive-timeout":                       {PerApp: "keepalive-timeout", Global: "global-keepalive-timeout"},
-	"letsencrypt-email":                       {PerApp: "", Global: "global-letsencrypt-email"},
-	"letsencrypt-server":                      {PerApp: "", Global: "global-letsencrypt-server"},
-	"lingering-timeout":                       {PerApp: "lingering-timeout", Global: "global-lingering-timeout"},
-	"log-level":                               {PerApp: "", Global: "global-log-level"},
-	"proxy-buffer-size":                       {PerApp: "proxy-buffer-size", Global: "global-proxy-buffer-size"},
-	"proxy-buffering":                         {PerApp: "proxy-buffering", Global: "global-proxy-buffering"},
-	"proxy-buffers":                           {PerApp: "proxy-buffers", Global: "global-proxy-buffers"},
-	"proxy-busy-buffers-size":                 {PerApp: "proxy-busy-buffers-size", Global: "global-proxy-busy-buffers-size"},
-	"proxy-connect-timeout":                   {PerApp: "proxy-connect-timeout", Global: "global-proxy-connect-timeout"},
-	"proxy-read-timeout":                      {PerApp: "proxy-read-timeout", Global: "global-proxy-read-timeout"},
-	"proxy-send-timeout":                      {PerApp: "proxy-send-timeout", Global: "global-proxy-send-timeout"},
-	"send-timeout":                            {PerApp: "send-timeout", Global: "global-send-timeout"},
-	"underscore-in-headers":                   {PerApp: "underscore-in-headers", Global: "global-underscore-in-headers"},
-	"x-forwarded-for-value":                   {PerApp: "x-forwarded-for-value", Global: "global-x-forwarded-for-value"},
-	"x-forwarded-port-value":                  {PerApp: "x-forwarded-port-value", Global: "global-x-forwarded-port-value"},
-	"x-forwarded-proto-value":                 {PerApp: "x-forwarded-proto-value", Global: "global-x-forwarded-proto-value"},
-	"x-forwarded-ssl":                         {PerApp: "x-forwarded-ssl", Global: "global-x-forwarded-ssl"},
+var openrestyPropertyTable = PropertyTable{
+	Subcommand: "openresty:set",
+	Keys: map[string]PropertyKeys{
+		"access-log-format":                       {PerApp: "access-log-format", Global: "global-access-log-format"},
+		"access-log-path":                         {PerApp: "access-log-path", Global: "global-access-log-path"},
+		"allowed-letsencrypt-domains-func-base64": {PerApp: "", Global: "global-allowed-letsencrypt-domains-func-base64"},
+		"bind-address-ipv4":                       {PerApp: "bind-address-ipv4", Global: "global-bind-address-ipv4"},
+		"bind-address-ipv6":                       {PerApp: "bind-address-ipv6", Global: "global-bind-address-ipv6"},
+		"client-body-timeout":                     {PerApp: "client-body-timeout", Global: "global-client-body-timeout"},
+		"client-header-timeout":                   {PerApp: "client-header-timeout", Global: "global-client-header-timeout"},
+		"client-max-body-size":                    {PerApp: "client-max-body-size", Global: "global-client-max-body-size"},
+		"error-log-path":                          {PerApp: "error-log-path", Global: "global-error-log-path"},
+		"hsts":                                    {PerApp: "hsts", Global: "global-hsts"},
+		"hsts-include-subdomains":                 {PerApp: "hsts-include-subdomains", Global: "global-hsts-include-subdomains"},
+		"hsts-max-age":                            {PerApp: "hsts-max-age", Global: "global-hsts-max-age"},
+		"hsts-preload":                            {PerApp: "hsts-preload", Global: "global-hsts-preload"},
+		"image":                                   {PerApp: "", Global: "global-image"},
+		"keepalive-timeout":                       {PerApp: "keepalive-timeout", Global: "global-keepalive-timeout"},
+		"letsencrypt-email":                       {PerApp: "", Global: "global-letsencrypt-email"},
+		"letsencrypt-server":                      {PerApp: "", Global: "global-letsencrypt-server"},
+		"lingering-timeout":                       {PerApp: "lingering-timeout", Global: "global-lingering-timeout"},
+		"log-level":                               {PerApp: "", Global: "global-log-level"},
+		"proxy-buffer-size":                       {PerApp: "proxy-buffer-size", Global: "global-proxy-buffer-size"},
+		"proxy-buffering":                         {PerApp: "proxy-buffering", Global: "global-proxy-buffering"},
+		"proxy-buffers":                           {PerApp: "proxy-buffers", Global: "global-proxy-buffers"},
+		"proxy-busy-buffers-size":                 {PerApp: "proxy-busy-buffers-size", Global: "global-proxy-busy-buffers-size"},
+		"proxy-connect-timeout":                   {PerApp: "proxy-connect-timeout", Global: "global-proxy-connect-timeout"},
+		"proxy-read-timeout":                      {PerApp: "proxy-read-timeout", Global: "global-proxy-read-timeout"},
+		"proxy-send-timeout":                      {PerApp: "proxy-send-timeout", Global: "global-proxy-send-timeout"},
+		"send-timeout":                            {PerApp: "send-timeout", Global: "global-send-timeout"},
+		"underscore-in-headers":                   {PerApp: "underscore-in-headers", Global: "global-underscore-in-headers"},
+		"x-forwarded-for-value":                   {PerApp: "x-forwarded-for-value", Global: "global-x-forwarded-for-value"},
+		"x-forwarded-port-value":                  {PerApp: "x-forwarded-port-value", Global: "global-x-forwarded-port-value"},
+		"x-forwarded-proto-value":                 {PerApp: "x-forwarded-proto-value", Global: "global-x-forwarded-proto-value"},
+		"x-forwarded-ssl":                         {PerApp: "x-forwarded-ssl", Global: "global-x-forwarded-ssl"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t OpenrestyPropertyTask) PropertyTable() PropertyTable {
+	return openrestyPropertyTable
 }
 
 // Validate checks the OpenrestyPropertyTask's inputs without contacting the server.
 func (t OpenrestyPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set", openrestyPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the OpenrestyPropertyTask would produce.
 func (t OpenrestyPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set", openrestyPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t OpenrestyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "openresty:set", openrestyPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return OpenrestyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t OpenrestyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("openresty:set", openrestyPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return OpenrestyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/probe_support.go
+++ b/tasks/probe_support.go
@@ -25,9 +25,11 @@ const (
 // ProbeSupport describes a task's read-state behaviour. Status is required;
 // Caveat is a human-readable note naming what cannot be read (and may be empty
 // for a task that probes everything it manages).
+//
+// The json tags are for the task catalog, which publishes this verbatim.
 type ProbeSupport struct {
-	Status ProbeStatus
-	Caveat string
+	Status ProbeStatus `json:"status"`
+	Caveat string      `json:"caveat,omitempty"`
 }
 
 // ProbeDocer is the interface a task implements to declare whether Plan() can

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -30,6 +30,57 @@ type PropertyKeys struct {
 	Sensitive bool
 }
 
+// PropertyTable is the property schema one *_property task manages: the dokku
+// subcommand a set/unset runs, and the report keys for every property name the
+// task supports.
+//
+// It is the single source of truth for that task. Plan(), Validate(), the two
+// exporters and the machine-readable catalog all read the same value, because
+// the shared helpers below take the task through PropertyTableDocer rather than
+// taking a subcommand and a map as separate arguments. A task therefore cannot
+// declare one table to the catalog and run against another.
+type PropertyTable struct {
+	// Subcommand is the dokku subcommand a set or unset runs, for example
+	// "apps:set" or "buildpacks:set-property".
+	Subcommand string
+
+	// Keys maps each supported property name to the JSON keys
+	// `dokku <plugin>:report --format json` emits for it per scope.
+	Keys map[string]PropertyKeys
+}
+
+// Plugin returns the dokku plugin the table belongs to, derived from the
+// subcommand: "apps:set" -> "apps".
+func (p PropertyTable) Plugin() string {
+	return pluginFromSubcommand(p.Subcommand)
+}
+
+// PropertyTableDocer is implemented by every task that manages a dokku property
+// table.
+//
+// Unlike its siblings (ExportDocer, ProbeDocer) this one is not read only by
+// the docs generator: planProperty, validatePropertyInput and the property
+// exporters take it as their first argument, so a task cannot reach the shared
+// property machinery without declaring the table the catalog publishes.
+//
+// A task whose property names are validated by dokku rather than by docket -
+// dokku_service_property, whose names come from whichever datastore plugin
+// backs the service - deliberately does not implement it. See
+// TestEveryPropertyTaskDeclaresPropertyTable.
+type PropertyTableDocer interface {
+	PropertyTable() PropertyTable
+}
+
+// TaskPropertyTable returns t's property table and whether t declared one.
+// Centralised so the catalog, the docs generator and the coverage test share
+// one read site, mirroring TaskExportSupport and TaskProbeSupport.
+func TaskPropertyTable(t Task) (PropertyTable, bool) {
+	if d, ok := t.(PropertyTableDocer); ok {
+		return d.PropertyTable(), true
+	}
+	return PropertyTable{}, false
+}
+
 // pluginFromSubcommand returns the plugin component of a colon-separated
 // subcommand. For example, "nginx:set" -> "nginx", "buildpacks:set-property" ->
 // "buildpacks", "app-json:set" -> "app-json".
@@ -119,8 +170,10 @@ func getProperty(subcommand, app string, global bool, property string, keys map[
 // A probeable dynamic family cannot be enumerated in keys, so the properties the
 // payload happens to carry are synthesized into it first; without that a set
 // letsencrypt `dns-provider-<KEY>` credential is dropped from the export (#449).
-func exportProperties(app, subcommand string, keys map[string]PropertyKeys, factory func(app, property, value string) interface{}) ([]interface{}, error) {
-	plugin := pluginFromSubcommand(subcommand)
+func exportProperties(task PropertyTableDocer, app string, factory func(app, property, value string) interface{}) ([]interface{}, error) {
+	table := task.PropertyTable()
+	keys := table.Keys
+	plugin := table.Plugin()
 	payload, err := readPropertyReport(plugin, app, false)
 	if err != nil {
 		return nil, err
@@ -159,8 +212,10 @@ func exportProperties(app, subcommand string, keys map[string]PropertyKeys, fact
 // globally-scoped state (for example scheduler-k3s bootstrap keys) is captured
 // instead of silently dropped (#327). Probeable dynamic properties are
 // synthesized into keys the same way exportProperties does it.
-func exportGlobalProperties(subcommand string, keys map[string]PropertyKeys, factory func(property, value string) interface{}) ([]interface{}, error) {
-	plugin := pluginFromSubcommand(subcommand)
+func exportGlobalProperties(task PropertyTableDocer, factory func(property, value string) interface{}) ([]interface{}, error) {
+	table := task.PropertyTable()
+	keys := table.Keys
+	plugin := table.Plugin()
 	payload, err := readPropertyReport(plugin, "", true)
 	if err != nil {
 		return nil, err
@@ -275,46 +330,101 @@ func unknownPropertyWarning(plugin, property string, err error) (PlanWarning, bo
 	}, true
 }
 
-// isDynamicProperty reports whether a (plugin, property) pair represents a
-// dynamic property family whose JSON keys only appear after the property is
-// set. Examples:
-//   - dokku-letsencrypt `dns-provider-*` (arbitrary env var names)
-//   - dokku traefik `dns-provider-*` (same shape, per-provider env vars)
-//
-// Dynamic property names are validated by `:set`, not the report schema, so
-// this is what lets validateProperty accept a name that cannot be enumerated in
-// the key map. It says nothing about whether the property can be probed: a
-// family whose plugin reports its keys is probed through dynamicPropertyKeys,
-// and only the families that helper does not recognize skip the probe.
+// dynamicPropertyFamily is a family of property names a plugin validates
+// through `:set` rather than through its report schema, so the names cannot be
+// enumerated in a PropertyTable.
+type dynamicPropertyFamily struct {
+	// Prefix is what a member's name starts with.
+	Prefix string
+
+	// Probeable is true when the plugin emits a report row per set member, so
+	// the lookup keys can be synthesized from the property name and the member
+	// probes like any mapped property. False means the member is applied
+	// unconditionally and the task never converges for it.
+	Probeable bool
+
+	// Sensitive is true when docket treats members as secrets.
+	Sensitive bool
+}
+
+// dynamicPropertyFamilies is the whole set of dynamic families docket knows
+// about, keyed by plugin. It is a table rather than a switch so the catalog can
+// publish it: a consumer validating a recipe offline has to accept a name that
+// cannot be enumerated, and the only way to know which names those are is to be
+// told the prefix.
 //
 // scheduler-k3s `chart.*.*` used to live here but moved to the dedicated
 // dokku_scheduler_k3s_chart task; SchedulerK3sPropertyTask.Plan rejects
 // chart.* before reaching this helper.
+var dynamicPropertyFamilies = map[string][]dynamicPropertyFamily{
+	// dokku-letsencrypt 0.25.0+ emits a `dns-provider-<KEY>` row for the app
+	// scope and a `global-dns-provider-<KEY>` row for the global one per
+	// property that is set (#449). The values are DNS provider API
+	// credentials, hence Sensitive: planProperty registers the probed value
+	// with the masker before it can reach a `(was %q)` drift reason.
+	"letsencrypt": {{Prefix: "dns-provider-", Probeable: true, Sensitive: true}},
+
+	// traefik's family has the same shape but is still absent from
+	// `traefik:report` (dokku/dokku#8928, tracked for docket in #450), so it
+	// stays on the unprobed path. Its values are credentials too, but
+	// planProperty reads Sensitive off the synthesized key entry, which an
+	// unprobeable family never gets - so they are not masked today (#457).
+	// Left as-is here so this change is a pure refactor; the catalog reports
+	// the flag it actually has rather than the one it should.
+	"traefik": {{Prefix: "dns-provider-"}},
+}
+
+// isDynamicProperty reports whether a (plugin, property) pair belongs to a
+// dynamic property family. This is what lets validateProperty accept a name
+// that cannot be enumerated in the key map. It says nothing about whether the
+// property can be probed - that is the family's Probeable flag, read by
+// dynamicPropertyKeys.
 func isDynamicProperty(plugin, property string) bool {
-	switch plugin {
-	case "letsencrypt", "traefik":
-		return strings.HasPrefix(property, "dns-provider-")
+	_, ok := dynamicPropertyFamilyFor(plugin, property)
+	return ok
+}
+
+// DynamicPropertyFamilies returns the dynamic name families a plugin declares,
+// sorted by prefix, in the form the task catalog publishes. Exported so a
+// consumer validating a recipe offline knows which unenumerable names to
+// accept.
+func DynamicPropertyFamilies(plugin string) []DynamicPropertySchema {
+	families := dynamicPropertyFamilies[plugin]
+	if len(families) == 0 {
+		return nil
 	}
-	return false
+	out := make([]DynamicPropertySchema, 0, len(families))
+	for _, family := range families {
+		out = append(out, DynamicPropertySchema{
+			Prefix:    family.Prefix,
+			Probeable: family.Probeable,
+			Sensitive: family.Sensitive,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Prefix < out[j].Prefix })
+	return out
+}
+
+// dynamicPropertyFamilyFor returns the family a property belongs to, if any.
+func dynamicPropertyFamilyFor(plugin, property string) (dynamicPropertyFamily, bool) {
+	for _, family := range dynamicPropertyFamilies[plugin] {
+		if strings.HasPrefix(property, family.Prefix) {
+			return family, true
+		}
+	}
+	return dynamicPropertyFamily{}, false
 }
 
 // dynamicPropertyKeys returns the report keys for a dynamic property whose
-// plugin surfaces the family in its `:report` payload. dokku-letsencrypt
-// 0.25.0+ emits a `dns-provider-<KEY>` row for the app scope and a
-// `global-dns-provider-<KEY>` row for the global one per property that is set,
-// so the keys can be synthesized from the property name and probed like any
-// mapped property (#449). The values are DNS provider API credentials, hence
-// Sensitive: planProperty registers the probed value with the masker before it
-// can reach a `(was %q)` drift reason.
-//
-// traefik's `dns-provider-*` family has the same shape but is still absent from
-// `traefik:report` (dokku/dokku#8928, tracked for docket in #450), so it stays
-// on the unprobed path.
+// plugin surfaces the family in its `:report` payload, synthesized from the
+// property name. A family the plugin does not report has no keys to synthesize
+// and falls through to the unprobed path.
 func dynamicPropertyKeys(plugin, property string) (PropertyKeys, bool) {
-	if plugin != "letsencrypt" || !isDynamicProperty(plugin, property) {
+	family, ok := dynamicPropertyFamilyFor(plugin, property)
+	if !ok || !family.Probeable {
 		return PropertyKeys{}, false
 	}
-	return PropertyKeys{PerApp: property, Global: "global-" + property, Sensitive: true}, true
+	return PropertyKeys{PerApp: property, Global: "global-" + property, Sensitive: family.Sensitive}, true
 }
 
 // propertyEntry returns the PropertyKeys a plugin uses for one property,
@@ -328,6 +438,14 @@ func propertyEntry(plugin, property string, keys map[string]PropertyKeys) Proper
 	}
 	entry, _ := dynamicPropertyKeys(plugin, property)
 	return entry
+}
+
+// taskPropertyEntry is propertyEntry for a task that carries its own table, so
+// the export path does not have to repeat the plugin name and the map beside
+// the task type it already matched on.
+func taskPropertyEntry(task PropertyTableDocer, property string) PropertyKeys {
+	table := task.PropertyTable()
+	return propertyEntry(table.Plugin(), property, table.Keys)
 }
 
 // withDynamicProperties returns keys plus a synthesized entry for every probeable
@@ -404,14 +522,15 @@ func dynamicPropertiesFromReport(plugin string, payload map[string]string, globa
 // scope, and that a value is supplied only in the state that allows it. Both
 // planProperty and each property task's Validate() call it so plan and
 // validate report the same errors.
-func validatePropertyInput(state State, app string, global bool, property, value, subcommand string, keys map[string]PropertyKeys) error {
+func validatePropertyInput(task PropertyTableDocer, state State, app string, global bool, property, value string) error {
+	table := task.PropertyTable()
 	if !global && app == "" {
 		return errors.New("app is required when global is false")
 	}
 	if global && app != "" {
 		return fmt.Errorf("'app' must not be set when 'global' is set to true")
 	}
-	if err := validateProperty(pluginFromSubcommand(subcommand), property, global, keys); err != nil {
+	if err := validateProperty(table.Plugin(), property, global, table.Keys); err != nil {
 		return err
 	}
 	if state == StatePresent && value == "" {
@@ -423,12 +542,15 @@ func validatePropertyInput(state State, app string, global bool, property, value
 	return nil
 }
 
-func planProperty(state State, app string, global bool, property, value, subcommand string, keys map[string]PropertyKeys) PlanResult {
-	if err := validatePropertyInput(state, app, global, property, value, subcommand, keys); err != nil {
+func planProperty(task PropertyTableDocer, state State, app string, global bool, property, value string) PlanResult {
+	if err := validatePropertyInput(task, state, app, global, property, value); err != nil {
 		return planErr(err)
 	}
 
-	plugin := pluginFromSubcommand(subcommand)
+	table := task.PropertyTable()
+	keys := table.Keys
+	subcommand := table.Subcommand
+	plugin := table.Plugin()
 	target := app
 	if global {
 		target = "--global"

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/dokku/docket/subprocess"
 )
 
+// propertyTableTask is a PropertyTableDocer standing in for a real property
+// task, so a test can drive the shared helpers against a synthetic plugin. A
+// test exercising a real plugin's table passes the task type itself instead.
+type propertyTableTask struct {
+	table PropertyTable
+}
+
+func (p propertyTableTask) PropertyTable() PropertyTable { return p.table }
+
+// fakePropertyTask builds a propertyTableTask from a subcommand and key map.
+func fakePropertyTask(subcommand string, keys map[string]PropertyKeys) propertyTableTask {
+	return propertyTableTask{table: PropertyTable{Subcommand: subcommand, Keys: keys}}
+}
+
 func TestGetPropertyArgsPerApp(t *testing.T) {
 	got := getPropertyArgs("nginx", "myapp", false)
 	want := []string{"--quiet", "nginx:report", "myapp", "--format", "json"}
@@ -37,7 +51,7 @@ func TestPlanPropertyMasksSensitiveDriftValue(t *testing.T) {
 		"--quiet myplugin:report --global --format json": `{"global-secret-prop":"oldsecret"}`,
 	}))()
 
-	res := planProperty(StatePresent, "", true, "secret-prop", "newsecret", "myplugin:set", keys)
+	res := planProperty(fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "secret-prop", "newsecret")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -73,7 +87,7 @@ func TestPlanPropertyAbsentMasksSensitiveOldValue(t *testing.T) {
 
 	// The absent path leaks the current server secret even without a sensitive
 	// recipe value (the value must be empty for absent).
-	res := planProperty(StateAbsent, "", true, "secret-prop", "", "myplugin:set", keys)
+	res := planProperty(fakePropertyTask("myplugin:set", keys), StateAbsent, "", true, "secret-prop", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -93,7 +107,7 @@ func TestPlanPropertyDoesNotMaskBenignDriftValue(t *testing.T) {
 		"--quiet myplugin:report --global --format json": `{"global-timeout":"60s"}`,
 	}))()
 
-	res := planProperty(StatePresent, "", true, "timeout", "90s", "myplugin:set", keys)
+	res := planProperty(fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "timeout", "90s")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -105,10 +119,10 @@ func TestPlanPropertyDoesNotMaskBenignDriftValue(t *testing.T) {
 
 func TestSecretPropertiesAreMarkedSensitive(t *testing.T) {
 	// Guard the marks that close #336 so they are not accidentally dropped.
-	if !traefikPropertyKeys["basic-auth-password"].Sensitive {
+	if !traefikPropertyTable.Keys["basic-auth-password"].Sensitive {
 		t.Error("traefik basic-auth-password must be marked Sensitive")
 	}
-	if !schedulerK3sPropertyKeys["token"].Sensitive {
+	if !schedulerK3sPropertyTable.Keys["token"].Sensitive {
 		t.Error("scheduler-k3s token must be marked Sensitive")
 	}
 }
@@ -280,7 +294,7 @@ func TestPlanPropertyAttachesUnknownKeyWarning(t *testing.T) {
 		"--quiet nginx:report myapp --format json": `{"proxy-read-timeout":"60s"}`,
 	}))()
 
-	res := planProperty(StatePresent, "myapp", false, "hsts", "true", "nginx:set", keys)
+	res := planProperty(fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -307,7 +321,7 @@ func TestPlanPropertyAttachesRejectedProbeWarning(t *testing.T) {
 		return resp, &subprocess.ExecError{Response: resp, Err: errors.New("exit status 1"), Ran: true}
 	})()
 
-	res := planProperty(StatePresent, "myapp", false, "hsts", "true", "nginx:set", keys)
+	res := planProperty(fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -421,7 +435,7 @@ func TestPlanPropertyDynamicLetsencryptInSync(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"token123"}`,
 	}))()
 
-	res := planProperty(StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123", "letsencrypt:set", letsencryptPropertyKeys)
+	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -438,7 +452,7 @@ func TestPlanPropertyDynamicLetsencryptGlobalInSync(t *testing.T) {
 		"--quiet letsencrypt:report --global --format json": `{"global-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
 	}))()
 
-	res := planProperty(StatePresent, "", true, "dns-provider-NAMECHEAP_API_USER", "deploy-bot", "letsencrypt:set", letsencryptPropertyKeys)
+	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "", true, "dns-provider-NAMECHEAP_API_USER", "deploy-bot")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -458,7 +472,7 @@ func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"oldtoken"}`,
 	}))()
 
-	res := planProperty(StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "newtoken", "letsencrypt:set", letsencryptPropertyKeys)
+	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "newtoken")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -486,7 +500,7 @@ func TestPlanPropertyDynamicLetsencryptMissingRowPlansCreate(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
 	}))()
 
-	res := planProperty(StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123", "letsencrypt:set", letsencryptPropertyKeys)
+	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -506,7 +520,7 @@ func TestPlanPropertyDynamicLetsencryptAbsentMissingRowIsInSync(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
 	}))()
 
-	res := planProperty(StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "", "letsencrypt:set", letsencryptPropertyKeys)
+	res := planProperty(LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -523,7 +537,7 @@ func TestPlanPropertyDynamicLetsencryptAbsentPlansDestroy(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"livetoken"}`,
 	}))()
 
-	res := planProperty(StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "", "letsencrypt:set", letsencryptPropertyKeys)
+	res := planProperty(LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -545,7 +559,7 @@ func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
 		return subprocess.ExecCommandResponse{}, nil
 	})()
 
-	res := planProperty(StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "token123", "traefik:set", traefikPropertyKeys)
+	res := planProperty(TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}

--- a/tasks/property_coverage_test.go
+++ b/tasks/property_coverage_test.go
@@ -1,0 +1,257 @@
+package tasks
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// propertyTasksWithoutTable names the tasks that look like property tasks but
+// have no enumerable table, with the reason. Being on this list is a statement
+// that docket cannot know the legal property names, not that the task was
+// overlooked.
+var propertyTasksWithoutTable = map[string]string{
+	"dokku_service_property": "the legal names come from whichever datastore plugin backs the service, and no plugin exposes a report that enumerates them",
+}
+
+// TestEveryPropertyTaskDeclaresPropertyTable asserts that every task whose type
+// key ends in _property either declares its table or is explicitly exempt.
+//
+// The shared helpers already take a PropertyTableDocer, so a task cannot reach
+// planProperty or validatePropertyInput without a table; this catches the other
+// direction - a new property task that hand-rolls its Plan() and so publishes
+// nothing to the catalog, which is how dokku_service_property came to be the
+// odd one out. Checking the allowlist in both directions keeps it from rotting
+// once such a task grows a real table.
+func TestEveryPropertyTaskDeclaresPropertyTable(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		if !strings.HasSuffix(name, "_property") {
+			continue
+		}
+		_, declared := TaskPropertyTable(task)
+		reason, exempt := propertyTasksWithoutTable[name]
+
+		switch {
+		case declared && exempt:
+			t.Errorf("task %q declares a property table but is listed as exempt (%q); drop it from propertyTasksWithoutTable", name, reason)
+		case !declared && !exempt:
+			t.Errorf("task %q does not implement PropertyTableDocer (add a PropertyTable() declaration, or explain the exemption in propertyTasksWithoutTable)", name)
+		}
+	}
+
+	for name := range propertyTasksWithoutTable {
+		if _, ok := RegisteredTasks[name]; !ok {
+			t.Errorf("propertyTasksWithoutTable names %q, which is not a registered task", name)
+		}
+	}
+}
+
+// TestPropertyTablePluginMatchesTaskType asserts that a task's table belongs to
+// the plugin its name claims. This is the one drift the interface cannot
+// prevent: a new property task written by copying an existing one, where the
+// key map got renamed but the subcommand did not.
+func TestPropertyTablePluginMatchesTaskType(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		table, declared := TaskPropertyTable(task)
+		if !declared {
+			continue
+		}
+		want := strings.TrimSuffix(strings.TrimPrefix(name, "dokku_"), "_property")
+		if got := strings.ReplaceAll(table.Plugin(), "-", "_"); got != want {
+			t.Errorf("task %q uses the %q plugin (subcommand %q); want the %q plugin", name, table.Plugin(), table.Subcommand, want)
+		}
+	}
+}
+
+// TestPropertyTableEntriesHaveAScope asserts that no property is unusable. An
+// entry with neither a per-app nor a global report key is rejected in both
+// scopes by validateProperty, so it can never be set at all.
+func TestPropertyTableEntriesHaveAScope(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		table, declared := TaskPropertyTable(task)
+		if !declared {
+			continue
+		}
+		if len(table.Keys) == 0 {
+			t.Errorf("task %q declares an empty property table", name)
+		}
+		for property, entry := range table.Keys {
+			if entry.PerApp == "" && entry.Global == "" {
+				t.Errorf("task %q property %q has no per-app or global form, so it can never be set", name, property)
+			}
+		}
+	}
+}
+
+// TestPropertyTableGlobalKeysRequireAGlobalField asserts that a task with no
+// `global` recipe key declares no globally-scoped property. Such a task passes
+// a literal false for global (dokku_scheduler_docker_local_property), so a
+// global-only entry in its table would be unreachable - and would be published
+// by the catalog as settable when nothing can set it.
+func TestPropertyTableGlobalKeysRequireAGlobalField(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		table, declared := TaskPropertyTable(task)
+		if !declared {
+			continue
+		}
+		if hasGlobalField(task) {
+			continue
+		}
+		for property, entry := range table.Keys {
+			if entry.Global != "" {
+				t.Errorf("task %q has no `global` field but property %q declares the global key %q", name, property, entry.Global)
+			}
+			if entry.PerApp == "" {
+				t.Errorf("task %q has no `global` field, so property %q needs a per-app key", name, property)
+			}
+		}
+	}
+}
+
+// hasGlobalField reports whether a task accepts `global:` in a recipe.
+func hasGlobalField(task Task) bool {
+	rt := taskStructType(task)
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+		if field.PkgPath == "" && catalogYAMLName(field.Tag, field.Name) == "global" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDynamicPropertyFamiliesArePublished asserts the exported view matches the
+// table the validator reads, so a consumer told to accept a prefix is told
+// about every prefix docket itself accepts.
+func TestDynamicPropertyFamiliesArePublished(t *testing.T) {
+	for plugin, families := range dynamicPropertyFamilies {
+		published := DynamicPropertyFamilies(plugin)
+		if len(published) != len(families) {
+			t.Errorf("plugin %q publishes %d families; the table has %d", plugin, len(published), len(families))
+			continue
+		}
+		for _, family := range families {
+			want := DynamicPropertySchema{Prefix: family.Prefix, Probeable: family.Probeable, Sensitive: family.Sensitive}
+			found := false
+			for _, got := range published {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("plugin %q does not publish %+v (published %+v)", plugin, want, published)
+			}
+
+			// A prefix nothing recognises would be published as legal and then
+			// rejected by validateProperty.
+			if !isDynamicProperty(plugin, family.Prefix+"EXAMPLE") {
+				t.Errorf("plugin %q publishes prefix %q but does not accept a name using it", plugin, family.Prefix)
+			}
+		}
+	}
+
+	if got := DynamicPropertyFamilies("apps"); got != nil {
+		t.Errorf("a plugin with no dynamic families published %+v; want nil", got)
+	}
+}
+
+// TestPropertyTablesAreDistinct asserts no two property tasks share a table.
+// Copying a task file and forgetting to rename the table var would otherwise
+// give two tasks the same properties and the same :set subcommand, and every
+// other test here would still pass for one of them.
+func TestPropertyTablesAreDistinct(t *testing.T) {
+	seen := map[string]string{}
+	for name, task := range RegisteredTasks {
+		table, declared := TaskPropertyTable(task)
+		if !declared {
+			continue
+		}
+		if previous, ok := seen[table.Subcommand]; ok {
+			t.Errorf("tasks %q and %q both use subcommand %q", previous, name, table.Subcommand)
+		}
+		seen[table.Subcommand] = name
+	}
+}
+
+// TestPropertyTaskValidatesAgainstItsPublishedTable drives each task's own
+// Validate() against every name its table publishes, and against one it does
+// not. This is the end-to-end version of the invariant the helper signatures
+// enforce structurally: what the catalog says a recipe may write is exactly
+// what the task accepts.
+func TestPropertyTaskValidatesAgainstItsPublishedTable(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		table, declared := TaskPropertyTable(task)
+		if !declared {
+			continue
+		}
+		if _, ok := task.(InputValidator); !ok {
+			t.Errorf("task %q declares a property table but has no Validate()", name)
+			continue
+		}
+
+		// Every name the table publishes must validate in at least one of the
+		// scopes the table says it supports.
+		for property, entry := range table.Keys {
+			global := entry.PerApp == "" && entry.Global != ""
+			instance := newPropertyTaskInstance(t, task, property, global)
+			if instance == nil {
+				continue
+			}
+			if err := instance.Validate(); err != nil {
+				t.Errorf("task %q rejects its own property %q (global=%v): %v", name, property, global, err)
+			}
+		}
+
+		// And a name it does not publish must be rejected, unless a dynamic
+		// family covers it.
+		instance := newPropertyTaskInstance(t, task, "definitely-not-a-real-property", false)
+		if instance == nil {
+			continue
+		}
+		if err := instance.Validate(); err == nil {
+			t.Errorf("task %q accepts a property absent from its table", name)
+		}
+	}
+}
+
+// newPropertyTaskInstance builds a runnable copy of a property task addressing
+// one property, so its Validate() can be driven against its own table. Returns
+// nil for a task whose fields do not fit the shape (none today).
+func newPropertyTaskInstance(t *testing.T, prototype Task, property string, global bool) InputValidator {
+	t.Helper()
+	rt := taskStructType(prototype)
+	value := reflect.New(rt).Elem()
+
+	set := func(name string, v interface{}) bool {
+		for i := 0; i < rt.NumField(); i++ {
+			field := rt.Field(i)
+			if field.PkgPath != "" || catalogYAMLName(field.Tag, field.Name) != name {
+				continue
+			}
+			rv := reflect.ValueOf(v)
+			if !rv.Type().ConvertibleTo(field.Type) {
+				return false
+			}
+			value.Field(i).Set(rv.Convert(field.Type))
+			return true
+		}
+		return false
+	}
+
+	if !set("property", property) || !set("value", "some-value") || !set("state", string(StatePresent)) {
+		return nil
+	}
+	if global {
+		if !set("global", true) {
+			return nil
+		}
+	} else if !set("app", "some-app") {
+		return nil
+	}
+
+	instance, ok := value.Interface().(InputValidator)
+	if !ok {
+		return nil
+	}
+	return instance
+}

--- a/tasks/property_keys_test.go
+++ b/tasks/property_keys_test.go
@@ -13,8 +13,9 @@ type propertyKeysCase struct {
 	global   string
 }
 
-func checkPropertyKeys(t *testing.T, plugin string, keys map[string]PropertyKeys, cases []propertyKeysCase) {
+func checkPropertyKeys(t *testing.T, table PropertyTable, cases []propertyKeysCase) {
 	t.Helper()
+	plugin, keys := table.Plugin(), table.Keys
 	for _, tc := range cases {
 		got, ok := keys[tc.property]
 		if !ok {
@@ -35,9 +36,10 @@ func checkPropertyKeys(t *testing.T, plugin string, keys map[string]PropertyKeys
 
 // checkUnsupportedProperty verifies validateProperty rejects a property not
 // in the plugin's map.
-func checkUnsupportedProperty(t *testing.T, plugin string, keys map[string]PropertyKeys) {
+func checkUnsupportedProperty(t *testing.T, table PropertyTable) {
 	t.Helper()
-	err := validateProperty(plugin, "definitely-not-a-real-property", false, keys)
+	plugin := table.Plugin()
+	err := validateProperty(plugin, "definitely-not-a-real-property", false, table.Keys)
 	if err == nil {
 		t.Errorf("%s: validateProperty should reject unsupported property", plugin)
 		return
@@ -49,8 +51,9 @@ func checkUnsupportedProperty(t *testing.T, plugin string, keys map[string]Prope
 
 // checkScopeMismatch verifies validateProperty returns the right errors when
 // the user asks for a scope the property doesn't support.
-func checkScopeMismatch(t *testing.T, plugin string, keys map[string]PropertyKeys, perAppOnly, globalOnly string) {
+func checkScopeMismatch(t *testing.T, table PropertyTable, perAppOnly, globalOnly string) {
 	t.Helper()
+	plugin, keys := table.Plugin(), table.Keys
 	if perAppOnly != "" {
 		err := validateProperty(plugin, perAppOnly, true, keys)
 		if err == nil || !strings.Contains(err.Error(), "no global form") {
@@ -66,90 +69,90 @@ func checkScopeMismatch(t *testing.T, plugin string, keys map[string]PropertyKey
 }
 
 func TestAppJsonPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "app-json", appJsonPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, appJsonPropertyTable, []propertyKeysCase{
 		{"appjson-path", "appjson-path", "global-appjson-path"},
 	})
-	checkUnsupportedProperty(t, "app-json", appJsonPropertyKeys)
+	checkUnsupportedProperty(t, appJsonPropertyTable)
 }
 
 func TestAppsPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "apps", appsPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, appsPropertyTable, []propertyKeysCase{
 		{"deploy-source", "deploy-source", ""},
 		{"deploy-source-metadata", "deploy-source-metadata", ""},
 		{"disable-autocreation", "", "global-disable-autocreation"},
 	})
-	checkUnsupportedProperty(t, "apps", appsPropertyKeys)
+	checkUnsupportedProperty(t, appsPropertyTable)
 	// deploy-source* are per-app only; disable-autocreation is global only.
-	checkScopeMismatch(t, "apps", appsPropertyKeys, "deploy-source", "disable-autocreation")
+	checkScopeMismatch(t, appsPropertyTable, "deploy-source", "disable-autocreation")
 }
 
 func TestBuilderPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builder", builderPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, builderPropertyTable, []propertyKeysCase{
 		{"build-dir", "build-dir", "global-build-dir"},
 		{"selected", "selected", "global-selected"},
 		{"skip-cleanup", "skip-cleanup", "global-skip-cleanup"},
 	})
-	checkUnsupportedProperty(t, "builder", builderPropertyKeys)
+	checkUnsupportedProperty(t, builderPropertyTable)
 }
 
 func TestBuilderDockerfilePropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builder-dockerfile", builderDockerfilePropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, builderDockerfilePropertyTable, []propertyKeysCase{
 		{"dockerfile-path", "dockerfile-path", "global-dockerfile-path"},
 	})
-	checkUnsupportedProperty(t, "builder-dockerfile", builderDockerfilePropertyKeys)
+	checkUnsupportedProperty(t, builderDockerfilePropertyTable)
 }
 
 func TestBuilderHerokuishPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builder-herokuish", builderHerokuishPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, builderHerokuishPropertyTable, []propertyKeysCase{
 		{"allowed", "allowed", "global-allowed"},
 	})
-	checkUnsupportedProperty(t, "builder-herokuish", builderHerokuishPropertyKeys)
+	checkUnsupportedProperty(t, builderHerokuishPropertyTable)
 }
 
 func TestBuilderLambdaPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builder-lambda", builderLambdaPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, builderLambdaPropertyTable, []propertyKeysCase{
 		{"lambdayml-path", "lambdayml-path", "global-lambdayml-path"},
 	})
-	checkUnsupportedProperty(t, "builder-lambda", builderLambdaPropertyKeys)
+	checkUnsupportedProperty(t, builderLambdaPropertyTable)
 }
 
 func TestBuilderNixpacksPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builder-nixpacks", builderNixpacksPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, builderNixpacksPropertyTable, []propertyKeysCase{
 		{"nixpackstoml-path", "nixpackstoml-path", "global-nixpackstoml-path"},
 	})
-	checkUnsupportedProperty(t, "builder-nixpacks", builderNixpacksPropertyKeys)
+	checkUnsupportedProperty(t, builderNixpacksPropertyTable)
 }
 
 func TestBuilderPackPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builder-pack", builderPackPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, builderPackPropertyTable, []propertyKeysCase{
 		{"projecttoml-path", "projecttoml-path", "global-projecttoml-path"},
 	})
-	checkUnsupportedProperty(t, "builder-pack", builderPackPropertyKeys)
+	checkUnsupportedProperty(t, builderPackPropertyTable)
 }
 
 func TestBuilderRailpackPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builder-railpack", builderRailpackPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, builderRailpackPropertyTable, []propertyKeysCase{
 		{"railpackjson-path", "railpackjson-path", "global-railpackjson-path"},
 	})
-	checkUnsupportedProperty(t, "builder-railpack", builderRailpackPropertyKeys)
+	checkUnsupportedProperty(t, builderRailpackPropertyTable)
 }
 
 func TestBuildpacksPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "buildpacks", buildpacksPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, buildpacksPropertyTable, []propertyKeysCase{
 		{"stack", "stack", "global-stack"},
 	})
-	checkUnsupportedProperty(t, "buildpacks", buildpacksPropertyKeys)
+	checkUnsupportedProperty(t, buildpacksPropertyTable)
 }
 
 func TestBuildsPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "builds", buildsPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, buildsPropertyTable, []propertyKeysCase{
 		{"retention", "retention", "global-retention"},
 	})
-	checkUnsupportedProperty(t, "builds", buildsPropertyKeys)
+	checkUnsupportedProperty(t, buildsPropertyTable)
 }
 
 func TestCaddyPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "caddy", caddyPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, caddyPropertyTable, []propertyKeysCase{
 		{"image", "", "global-image"},
 		{"letsencrypt-email", "", "global-letsencrypt-email"},
 		{"letsencrypt-server", "", "global-letsencrypt-server"},
@@ -157,29 +160,29 @@ func TestCaddyPropertyKeys(t *testing.T) {
 		{"polling-interval", "", "global-polling-interval"},
 		{"tls-internal", "tls-internal", "global-tls-internal"},
 	})
-	checkUnsupportedProperty(t, "caddy", caddyPropertyKeys)
-	checkScopeMismatch(t, "caddy", caddyPropertyKeys, "", "image")
+	checkUnsupportedProperty(t, caddyPropertyTable)
+	checkScopeMismatch(t, caddyPropertyTable, "", "image")
 }
 
 func TestChecksPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "checks", checksPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, checksPropertyTable, []propertyKeysCase{
 		{"wait-to-retire", "wait-to-retire", "global-wait-to-retire"},
 	})
-	checkUnsupportedProperty(t, "checks", checksPropertyKeys)
+	checkUnsupportedProperty(t, checksPropertyTable)
 }
 
 func TestCronPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "cron", cronPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, cronPropertyTable, []propertyKeysCase{
 		{"maintenance", "maintenance", "global-maintenance"},
 		{"mailfrom", "", "global-mailfrom"},
 		{"mailto", "", "global-mailto"},
 	})
-	checkUnsupportedProperty(t, "cron", cronPropertyKeys)
-	checkScopeMismatch(t, "cron", cronPropertyKeys, "", "mailto")
+	checkUnsupportedProperty(t, cronPropertyTable)
+	checkScopeMismatch(t, cronPropertyTable, "", "mailto")
 }
 
 func TestGitPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "git", gitPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, gitPropertyTable, []propertyKeysCase{
 		{"archive-max-files", "", "global-archive-max-files"},
 		{"archive-max-size", "", "global-archive-max-size"},
 		{"deploy-branch", "deploy-branch", "global-deploy-branch"},
@@ -187,25 +190,25 @@ func TestGitPropertyKeys(t *testing.T) {
 		{"rev-env-var", "rev-env-var", ""},
 		{"source-image", "source-image", ""},
 	})
-	checkUnsupportedProperty(t, "git", gitPropertyKeys)
+	checkUnsupportedProperty(t, gitPropertyTable)
 	// archive-max-files is global-only; rev-env-var is per-app-only.
-	checkScopeMismatch(t, "git", gitPropertyKeys, "rev-env-var", "archive-max-files")
+	checkScopeMismatch(t, gitPropertyTable, "rev-env-var", "archive-max-files")
 }
 
 func TestHaproxyPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "haproxy", haproxyPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, haproxyPropertyTable, []propertyKeysCase{
 		{"image", "", "global-image"},
 		{"letsencrypt-email", "", "global-letsencrypt-email"},
 		{"letsencrypt-server", "", "global-letsencrypt-server"},
 		{"log-level", "", "global-log-level"},
 		{"refresh-conf", "", "global-refresh-conf"},
 	})
-	checkUnsupportedProperty(t, "haproxy", haproxyPropertyKeys)
-	checkScopeMismatch(t, "haproxy", haproxyPropertyKeys, "", "image")
+	checkUnsupportedProperty(t, haproxyPropertyTable)
+	checkScopeMismatch(t, haproxyPropertyTable, "", "image")
 }
 
 func TestLetsencryptPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "letsencrypt", letsencryptPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, letsencryptPropertyTable, []propertyKeysCase{
 		{"dns-provider", "dns-provider", "global-dns-provider"},
 		{"email", "email", "global-email"},
 		{"graceperiod", "graceperiod", "global-graceperiod"},
@@ -213,27 +216,27 @@ func TestLetsencryptPropertyKeys(t *testing.T) {
 		{"lego-docker-options", "lego-docker-options", "global-lego-docker-options"},
 		{"server", "server", "global-server"},
 	})
-	checkUnsupportedProperty(t, "letsencrypt", letsencryptPropertyKeys)
+	checkUnsupportedProperty(t, letsencryptPropertyTable)
 	// dns-provider-* are dynamic and should bypass map validation.
-	if err := validateProperty("letsencrypt", "dns-provider-X", false, letsencryptPropertyKeys); err != nil {
+	if err := validateProperty("letsencrypt", "dns-provider-X", false, letsencryptPropertyTable.Keys); err != nil {
 		t.Errorf("dynamic property should pass validation, got %v", err)
 	}
 }
 
 func TestLogsPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "logs", logsPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, logsPropertyTable, []propertyKeysCase{
 		{"app-label-alias", "app-label-alias", "global-app-label-alias"},
 		{"max-size", "max-size", "global-max-size"},
 		{"vector-image", "", "global-vector-image"},
 		{"vector-networks", "", "global-vector-networks"},
 		{"vector-sink", "vector-sink", "global-vector-sink"},
 	})
-	checkUnsupportedProperty(t, "logs", logsPropertyKeys)
-	checkScopeMismatch(t, "logs", logsPropertyKeys, "", "vector-image")
+	checkUnsupportedProperty(t, logsPropertyTable)
+	checkScopeMismatch(t, logsPropertyTable, "", "vector-image")
 }
 
 func TestNetworkPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "network", networkPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, networkPropertyTable, []propertyKeysCase{
 		{"attach-post-create", "attach-post-create", "global-attach-post-create"},
 		{"attach-post-deploy", "attach-post-deploy", "global-attach-post-deploy"},
 		{"bind-all-interfaces", "bind-all-interfaces", "global-bind-all-interfaces"},
@@ -241,12 +244,12 @@ func TestNetworkPropertyKeys(t *testing.T) {
 		{"static-web-listener", "static-web-listener", ""},
 		{"tld", "tld", "global-tld"},
 	})
-	checkUnsupportedProperty(t, "network", networkPropertyKeys)
-	checkScopeMismatch(t, "network", networkPropertyKeys, "static-web-listener", "")
+	checkUnsupportedProperty(t, networkPropertyTable)
+	checkScopeMismatch(t, networkPropertyTable, "static-web-listener", "")
 }
 
 func TestNginxPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "nginx", nginxPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, nginxPropertyTable, []propertyKeysCase{
 		{"access-log-format", "access-log-format", "global-access-log-format"},
 		{"access-log-path", "access-log-path", "global-access-log-path"},
 		{"bind-address-ipv4", "bind-address-ipv4", "global-bind-address-ipv4"},
@@ -279,11 +282,11 @@ func TestNginxPropertyKeys(t *testing.T) {
 		{"x-forwarded-proto-value", "x-forwarded-proto-value", "global-x-forwarded-proto-value"},
 		{"x-forwarded-ssl", "x-forwarded-ssl", "global-x-forwarded-ssl"},
 	})
-	checkUnsupportedProperty(t, "nginx", nginxPropertyKeys)
+	checkUnsupportedProperty(t, nginxPropertyTable)
 }
 
 func TestOpenrestyPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "openresty", openrestyPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, openrestyPropertyTable, []propertyKeysCase{
 		{"access-log-format", "access-log-format", "global-access-log-format"},
 		{"access-log-path", "access-log-path", "global-access-log-path"},
 		{"allowed-letsencrypt-domains-func-base64", "", "global-allowed-letsencrypt-domains-func-base64"},
@@ -317,21 +320,21 @@ func TestOpenrestyPropertyKeys(t *testing.T) {
 		{"x-forwarded-proto-value", "x-forwarded-proto-value", "global-x-forwarded-proto-value"},
 		{"x-forwarded-ssl", "x-forwarded-ssl", "global-x-forwarded-ssl"},
 	})
-	checkUnsupportedProperty(t, "openresty", openrestyPropertyKeys)
-	checkScopeMismatch(t, "openresty", openrestyPropertyKeys, "", "image")
+	checkUnsupportedProperty(t, openrestyPropertyTable)
+	checkScopeMismatch(t, openrestyPropertyTable, "", "image")
 }
 
 func TestProxyPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "proxy", proxyPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, proxyPropertyTable, []propertyKeysCase{
 		{"type", "type", "global-type"},
 		{"proxy-port", "proxy-port", "global-proxy-port"},
 		{"proxy-ssl-port", "proxy-ssl-port", "global-proxy-ssl-port"},
 	})
-	checkUnsupportedProperty(t, "proxy", proxyPropertyKeys)
+	checkUnsupportedProperty(t, proxyPropertyTable)
 }
 
 func TestPsPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "ps", psPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, psPropertyTable, []propertyKeysCase{
 		{"dockerfile-start-cmd", "dockerfile-start-cmd", ""},
 		{"procfile-path", "procfile-path", "global-procfile-path"},
 		{"restart-policy", "restart-policy", "global-restart-policy"},
@@ -339,40 +342,40 @@ func TestPsPropertyKeys(t *testing.T) {
 		{"start-cmd", "start-cmd", ""},
 		{"stop-timeout-seconds", "stop-timeout-seconds", "global-stop-timeout-seconds"},
 	})
-	checkUnsupportedProperty(t, "ps", psPropertyKeys)
-	checkScopeMismatch(t, "ps", psPropertyKeys, "dockerfile-start-cmd", "")
+	checkUnsupportedProperty(t, psPropertyTable)
+	checkScopeMismatch(t, psPropertyTable, "dockerfile-start-cmd", "")
 }
 
 func TestRegistryPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "registry", registryPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, registryPropertyTable, []propertyKeysCase{
 		{"image-repo", "image-repo", ""},
 		{"image-repo-template", "image-repo-template", "global-image-repo-template"},
 		{"push-extra-tags", "push-extra-tags", "global-push-extra-tags"},
 		{"push-on-release", "push-on-release", "global-push-on-release"},
 		{"server", "server", "global-server"},
 	})
-	checkUnsupportedProperty(t, "registry", registryPropertyKeys)
-	checkScopeMismatch(t, "registry", registryPropertyKeys, "image-repo", "")
+	checkUnsupportedProperty(t, registryPropertyTable)
+	checkScopeMismatch(t, registryPropertyTable, "image-repo", "")
 }
 
 func TestSchedulerPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "scheduler", schedulerPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, schedulerPropertyTable, []propertyKeysCase{
 		{"selected", "selected", "global-selected"},
 		{"shell", "shell", "global-shell"},
 	})
-	checkUnsupportedProperty(t, "scheduler", schedulerPropertyKeys)
+	checkUnsupportedProperty(t, schedulerPropertyTable)
 }
 
 func TestSchedulerDockerLocalPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "scheduler-docker-local", schedulerDockerLocalPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, schedulerDockerLocalPropertyTable, []propertyKeysCase{
 		{"init-process", "init-process", ""},
 		{"parallel-schedule-count", "parallel-schedule-count", ""},
 	})
-	checkUnsupportedProperty(t, "scheduler-docker-local", schedulerDockerLocalPropertyKeys)
+	checkUnsupportedProperty(t, schedulerDockerLocalPropertyTable)
 }
 
 func TestSchedulerK3sPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "scheduler-k3s", schedulerK3sPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, schedulerK3sPropertyTable, []propertyKeysCase{
 		{"deploy-timeout", "deploy-timeout", "global-deploy-timeout"},
 		{"image-pull-secrets", "image-pull-secrets", "global-image-pull-secrets"},
 		{"ingress-class", "", "global-ingress-class"},
@@ -388,18 +391,18 @@ func TestSchedulerK3sPropertyKeys(t *testing.T) {
 		{"shm-size", "shm-size", "global-shm-size"},
 		{"token", "", "global-token"},
 	})
-	checkUnsupportedProperty(t, "scheduler-k3s", schedulerK3sPropertyKeys)
-	checkScopeMismatch(t, "scheduler-k3s", schedulerK3sPropertyKeys, "", "token")
+	checkUnsupportedProperty(t, schedulerK3sPropertyTable)
+	checkScopeMismatch(t, schedulerK3sPropertyTable, "", "token")
 	// chart.* properties used to be dynamic; they are now rejected by
 	// SchedulerK3sPropertyTask.Plan and routed to dokku_scheduler_k3s_chart,
 	// so validateProperty against the property-keys map should fail.
-	if err := validateProperty("scheduler-k3s", "chart.traefik.replicas", false, schedulerK3sPropertyKeys); err == nil {
+	if err := validateProperty("scheduler-k3s", "chart.traefik.replicas", false, schedulerK3sPropertyTable.Keys); err == nil {
 		t.Error("expected chart.* to be rejected by the property map (no longer dynamic)")
 	}
 }
 
 func TestTraefikPropertyKeys(t *testing.T) {
-	checkPropertyKeys(t, "traefik", traefikPropertyKeys, []propertyKeysCase{
+	checkPropertyKeys(t, traefikPropertyTable, []propertyKeysCase{
 		{"api-enabled", "", "global-api-enabled"},
 		{"api-entry-point", "", "global-api-entry-point"},
 		{"api-entry-point-address", "", "global-api-entry-point-address"},
@@ -416,10 +419,10 @@ func TestTraefikPropertyKeys(t *testing.T) {
 		{"letsencrypt-server", "", "global-letsencrypt-server"},
 		{"log-level", "", "global-log-level"},
 	})
-	checkUnsupportedProperty(t, "traefik", traefikPropertyKeys)
-	checkScopeMismatch(t, "traefik", traefikPropertyKeys, "", "image")
+	checkUnsupportedProperty(t, traefikPropertyTable)
+	checkScopeMismatch(t, traefikPropertyTable, "", "image")
 	// dns-provider-* are dynamic and should bypass map validation.
-	if err := validateProperty("traefik", "dns-provider-CLOUDFLARE_API_TOKEN", true, traefikPropertyKeys); err != nil {
+	if err := validateProperty("traefik", "dns-provider-CLOUDFLARE_API_TOKEN", true, traefikPropertyTable.Keys); err != nil {
 		t.Errorf("dynamic property should pass validation, got %v", err)
 	}
 }

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -90,35 +90,43 @@ func (t ProxyPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// proxyPropertyKeys maps proxy property names to the JSON keys emitted by
+// proxyPropertyTable maps proxy property names to the JSON keys emitted by
 // `dokku proxy:report --format json` on dokku 0.38.8+. `disabled`/`enabled`
 // are managed via proxy:enable/proxy:disable through ProxyTogglePropertyTask.
-var proxyPropertyKeys = map[string]PropertyKeys{
-	"type":           {PerApp: "type", Global: "global-type"},
-	"proxy-port":     {PerApp: "proxy-port", Global: "global-proxy-port"},
-	"proxy-ssl-port": {PerApp: "proxy-ssl-port", Global: "global-proxy-ssl-port"},
+var proxyPropertyTable = PropertyTable{
+	Subcommand: "proxy:set",
+	Keys: map[string]PropertyKeys{
+		"type":           {PerApp: "type", Global: "global-type"},
+		"proxy-port":     {PerApp: "proxy-port", Global: "global-proxy-port"},
+		"proxy-ssl-port": {PerApp: "proxy-ssl-port", Global: "global-proxy-ssl-port"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t ProxyPropertyTask) PropertyTable() PropertyTable {
+	return proxyPropertyTable
 }
 
 // Validate checks the ProxyPropertyTask's inputs without contacting the server.
 func (t ProxyPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "proxy:set", proxyPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the ProxyPropertyTask would produce.
 func (t ProxyPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "proxy:set", proxyPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t ProxyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "proxy:set", proxyPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return ProxyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t ProxyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("proxy:set", proxyPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return ProxyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -82,39 +82,47 @@ func (t PsPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// psPropertyKeys maps ps property names to the JSON keys emitted by
+// psPropertyTable maps ps property names to the JSON keys emitted by
 // `dokku ps:report --format json` on dokku 0.38.9+. dockerfile-start-cmd and
 // start-cmd are per-app only; everything else (including restart-policy as of
 // 0.38.9) is app+global.
-var psPropertyKeys = map[string]PropertyKeys{
-	"dockerfile-start-cmd": {PerApp: "dockerfile-start-cmd", Global: ""},
-	"procfile-path":        {PerApp: "procfile-path", Global: "global-procfile-path"},
-	"restart-policy":       {PerApp: "restart-policy", Global: "global-restart-policy"},
-	"skip-deploy":          {PerApp: "skip-deploy", Global: "global-skip-deploy"},
-	"start-cmd":            {PerApp: "start-cmd", Global: ""},
-	"stop-timeout-seconds": {PerApp: "stop-timeout-seconds", Global: "global-stop-timeout-seconds"},
+var psPropertyTable = PropertyTable{
+	Subcommand: "ps:set",
+	Keys: map[string]PropertyKeys{
+		"dockerfile-start-cmd": {PerApp: "dockerfile-start-cmd", Global: ""},
+		"procfile-path":        {PerApp: "procfile-path", Global: "global-procfile-path"},
+		"restart-policy":       {PerApp: "restart-policy", Global: "global-restart-policy"},
+		"skip-deploy":          {PerApp: "skip-deploy", Global: "global-skip-deploy"},
+		"start-cmd":            {PerApp: "start-cmd", Global: ""},
+		"stop-timeout-seconds": {PerApp: "stop-timeout-seconds", Global: "global-stop-timeout-seconds"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t PsPropertyTask) PropertyTable() PropertyTable {
+	return psPropertyTable
 }
 
 // Validate checks the PsPropertyTask's inputs without contacting the server.
 func (t PsPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "ps:set", psPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the PsPropertyTask would produce.
 func (t PsPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "ps:set", psPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t PsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "ps:set", psPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return PsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t PsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("ps:set", psPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return PsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -90,37 +90,45 @@ func (t RegistryPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// registryPropertyKeys maps registry property names to the JSON keys
+// registryPropertyTable maps registry property names to the JSON keys
 // emitted by `dokku registry:report --format json` on dokku 0.38.8+.
 // image-repo is per-app only; tag-version is read-only (managed by build).
-var registryPropertyKeys = map[string]PropertyKeys{
-	"image-repo":          {PerApp: "image-repo", Global: ""},
-	"image-repo-template": {PerApp: "image-repo-template", Global: "global-image-repo-template"},
-	"push-extra-tags":     {PerApp: "push-extra-tags", Global: "global-push-extra-tags"},
-	"push-on-release":     {PerApp: "push-on-release", Global: "global-push-on-release"},
-	"server":              {PerApp: "server", Global: "global-server"},
+var registryPropertyTable = PropertyTable{
+	Subcommand: "registry:set",
+	Keys: map[string]PropertyKeys{
+		"image-repo":          {PerApp: "image-repo", Global: ""},
+		"image-repo-template": {PerApp: "image-repo-template", Global: "global-image-repo-template"},
+		"push-extra-tags":     {PerApp: "push-extra-tags", Global: "global-push-extra-tags"},
+		"push-on-release":     {PerApp: "push-on-release", Global: "global-push-on-release"},
+		"server":              {PerApp: "server", Global: "global-server"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t RegistryPropertyTask) PropertyTable() PropertyTable {
+	return registryPropertyTable
 }
 
 // Validate checks the RegistryPropertyTask's inputs without contacting the server.
 func (t RegistryPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "registry:set", registryPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the RegistryPropertyTask would produce.
 func (t RegistryPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set", registryPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t RegistryPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "registry:set", registryPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return RegistryPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t RegistryPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("registry:set", registryPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return RegistryPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -79,28 +79,36 @@ func (t SchedulerDockerLocalPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// schedulerDockerLocalPropertyKeys maps scheduler-docker-local property
+// schedulerDockerLocalPropertyTable maps scheduler-docker-local property
 // names to the JSON keys emitted by
 // `dokku scheduler-docker-local:report --format json` on dokku 0.38.8+.
 // The task struct has no Global field today; map entries set Global="".
-var schedulerDockerLocalPropertyKeys = map[string]PropertyKeys{
-	"init-process":            {PerApp: "init-process", Global: ""},
-	"parallel-schedule-count": {PerApp: "parallel-schedule-count", Global: ""},
+var schedulerDockerLocalPropertyTable = PropertyTable{
+	Subcommand: "scheduler-docker-local:set",
+	Keys: map[string]PropertyKeys{
+		"init-process":            {PerApp: "init-process", Global: ""},
+		"parallel-schedule-count": {PerApp: "parallel-schedule-count", Global: ""},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t SchedulerDockerLocalPropertyTask) PropertyTable() PropertyTable {
+	return schedulerDockerLocalPropertyTable
 }
 
 // Validate checks the SchedulerDockerLocalPropertyTask's inputs without contacting the server.
 func (t SchedulerDockerLocalPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set", schedulerDockerLocalPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, false, t.Property, t.Value)
 }
 
 // Plan reports the drift the SchedulerDockerLocalPropertyTask would produce.
 func (t SchedulerDockerLocalPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set", schedulerDockerLocalPropertyKeys)
+	return planProperty(t, t.State, t.App, false, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t SchedulerDockerLocalPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "scheduler-docker-local:set", schedulerDockerLocalPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return SchedulerDockerLocalPropertyTask{App: app, Property: property, Value: value}
 	})
 }

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -95,35 +95,47 @@ func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// schedulerK3sPropertyKeys maps scheduler-k3s property names to the JSON
+// schedulerK3sPropertyTable maps scheduler-k3s property names to the JSON
 // keys emitted by `dokku scheduler-k3s:report --format json` on dokku
 // 0.38.8+. The `chart.*.*` family is intentionally absent: chart value
 // overrides are managed by dokku_scheduler_k3s_chart through dokku's
 // dedicated scheduler-k3s:charts:set surface, and Plan() rejects any
 // chart.* property before reaching this map.
-var schedulerK3sPropertyKeys = map[string]PropertyKeys{
-	"deploy-timeout":         {PerApp: "deploy-timeout", Global: "global-deploy-timeout"},
-	"image-pull-secrets":     {PerApp: "image-pull-secrets", Global: "global-image-pull-secrets"},
-	"ingress-class":          {PerApp: "", Global: "global-ingress-class"},
-	"kube-context":           {PerApp: "", Global: "global-kube-context"},
-	"kubeconfig-path":        {PerApp: "", Global: "global-kubeconfig-path"},
-	"kustomize-root-path":    {PerApp: "kustomize-root-path", Global: "global-kustomize-root-path"},
-	"letsencrypt-email-prod": {PerApp: "", Global: "global-letsencrypt-email-prod"},
-	"letsencrypt-email-stag": {PerApp: "", Global: "global-letsencrypt-email-stag"},
-	"letsencrypt-server":     {PerApp: "letsencrypt-server", Global: "global-letsencrypt-server"},
-	"namespace":              {PerApp: "namespace", Global: "global-namespace"},
-	"network-interface":      {PerApp: "", Global: "global-network-interface"},
-	"rollback-on-failure":    {PerApp: "rollback-on-failure", Global: "global-rollback-on-failure"},
-	"shm-size":               {PerApp: "shm-size", Global: "global-shm-size"},
-	"token":                  {PerApp: "", Global: "global-token", Sensitive: true},
+var schedulerK3sPropertyTable = PropertyTable{
+	Subcommand: "scheduler-k3s:set",
+	Keys: map[string]PropertyKeys{
+		"deploy-timeout":         {PerApp: "deploy-timeout", Global: "global-deploy-timeout"},
+		"image-pull-secrets":     {PerApp: "image-pull-secrets", Global: "global-image-pull-secrets"},
+		"ingress-class":          {PerApp: "", Global: "global-ingress-class"},
+		"kube-context":           {PerApp: "", Global: "global-kube-context"},
+		"kubeconfig-path":        {PerApp: "", Global: "global-kubeconfig-path"},
+		"kustomize-root-path":    {PerApp: "kustomize-root-path", Global: "global-kustomize-root-path"},
+		"letsencrypt-email-prod": {PerApp: "", Global: "global-letsencrypt-email-prod"},
+		"letsencrypt-email-stag": {PerApp: "", Global: "global-letsencrypt-email-stag"},
+		"letsencrypt-server":     {PerApp: "letsencrypt-server", Global: "global-letsencrypt-server"},
+		"namespace":              {PerApp: "namespace", Global: "global-namespace"},
+		"network-interface":      {PerApp: "", Global: "global-network-interface"},
+		"rollback-on-failure":    {PerApp: "rollback-on-failure", Global: "global-rollback-on-failure"},
+		"shm-size":               {PerApp: "shm-size", Global: "global-shm-size"},
+		"token":                  {PerApp: "", Global: "global-token", Sensitive: true},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t SchedulerK3sPropertyTask) PropertyTable() PropertyTable {
+	return schedulerK3sPropertyTable
 }
 
 // Validate checks the SchedulerK3sPropertyTask's inputs without contacting the server.
 func (t SchedulerK3sPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set", schedulerK3sPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the SchedulerK3sPropertyTask would produce.
+//
+// The chart.* guard lives here rather than in Validate(), so `docket validate`
+// rejects the same recipe for the generic "unsupported property" reason
+// instead of naming the replacement task (#458).
 func (t SchedulerK3sPropertyTask) Plan() PlanResult {
 	if strings.HasPrefix(t.Property, "chart.") {
 		return PlanResult{
@@ -131,19 +143,19 @@ func (t SchedulerK3sPropertyTask) Plan() PlanResult {
 			Error:  fmt.Errorf("chart.* properties are managed by dokku_scheduler_k3s_chart; the scheduler-k3s:set path for chart values is deprecated in dokku"),
 		}
 	}
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set", schedulerK3sPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t SchedulerK3sPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "scheduler-k3s:set", schedulerK3sPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return SchedulerK3sPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t SchedulerK3sPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("scheduler-k3s:set", schedulerK3sPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return SchedulerK3sPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -82,33 +82,41 @@ func (t SchedulerPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// schedulerPropertyKeys maps scheduler property names to the JSON keys
+// schedulerPropertyTable maps scheduler property names to the JSON keys
 // emitted by `dokku scheduler:report --format json` on dokku 0.38.8+.
-var schedulerPropertyKeys = map[string]PropertyKeys{
-	"selected": {PerApp: "selected", Global: "global-selected"},
-	"shell":    {PerApp: "shell", Global: "global-shell"},
+var schedulerPropertyTable = PropertyTable{
+	Subcommand: "scheduler:set",
+	Keys: map[string]PropertyKeys{
+		"selected": {PerApp: "selected", Global: "global-selected"},
+		"shell":    {PerApp: "shell", Global: "global-shell"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t SchedulerPropertyTask) PropertyTable() PropertyTable {
+	return schedulerPropertyTable
 }
 
 // Validate checks the SchedulerPropertyTask's inputs without contacting the server.
 func (t SchedulerPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set", schedulerPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the SchedulerPropertyTask would produce.
 func (t SchedulerPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set", schedulerPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t SchedulerPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "scheduler:set", schedulerPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return SchedulerPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t SchedulerPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("scheduler:set", schedulerPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return SchedulerPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -82,48 +82,56 @@ func (t TraefikPropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// traefikPropertyKeys maps traefik property names to the JSON keys emitted
+// traefikPropertyTable maps traefik property names to the JSON keys emitted
 // by `dokku traefik:report --format json` on dokku 0.38.8+. All properties
 // are global-only. The `dns-provider-*` family is dynamic and handled by
 // isDynamicProperty without a map entry.
-var traefikPropertyKeys = map[string]PropertyKeys{
-	"api-enabled":             {PerApp: "", Global: "global-api-enabled"},
-	"api-entry-point":         {PerApp: "", Global: "global-api-entry-point"},
-	"api-entry-point-address": {PerApp: "", Global: "global-api-entry-point-address"},
-	"api-vhost":               {PerApp: "", Global: "global-api-vhost"},
-	"basic-auth-password":     {PerApp: "", Global: "global-basic-auth-password", Sensitive: true},
-	"basic-auth-username":     {PerApp: "", Global: "global-basic-auth-username"},
-	"challenge-mode":          {PerApp: "", Global: "global-challenge-mode"},
-	"dashboard-enabled":       {PerApp: "", Global: "global-dashboard-enabled"},
-	"dns-provider":            {PerApp: "", Global: "global-dns-provider"},
-	"http-entry-point":        {PerApp: "", Global: "global-http-entry-point"},
-	"https-entry-point":       {PerApp: "", Global: "global-https-entry-point"},
-	"image":                   {PerApp: "", Global: "global-image"},
-	"letsencrypt-email":       {PerApp: "", Global: "global-letsencrypt-email"},
-	"letsencrypt-server":      {PerApp: "", Global: "global-letsencrypt-server"},
-	"log-level":               {PerApp: "", Global: "global-log-level"},
+var traefikPropertyTable = PropertyTable{
+	Subcommand: "traefik:set",
+	Keys: map[string]PropertyKeys{
+		"api-enabled":             {PerApp: "", Global: "global-api-enabled"},
+		"api-entry-point":         {PerApp: "", Global: "global-api-entry-point"},
+		"api-entry-point-address": {PerApp: "", Global: "global-api-entry-point-address"},
+		"api-vhost":               {PerApp: "", Global: "global-api-vhost"},
+		"basic-auth-password":     {PerApp: "", Global: "global-basic-auth-password", Sensitive: true},
+		"basic-auth-username":     {PerApp: "", Global: "global-basic-auth-username"},
+		"challenge-mode":          {PerApp: "", Global: "global-challenge-mode"},
+		"dashboard-enabled":       {PerApp: "", Global: "global-dashboard-enabled"},
+		"dns-provider":            {PerApp: "", Global: "global-dns-provider"},
+		"http-entry-point":        {PerApp: "", Global: "global-http-entry-point"},
+		"https-entry-point":       {PerApp: "", Global: "global-https-entry-point"},
+		"image":                   {PerApp: "", Global: "global-image"},
+		"letsencrypt-email":       {PerApp: "", Global: "global-letsencrypt-email"},
+		"letsencrypt-server":      {PerApp: "", Global: "global-letsencrypt-server"},
+		"log-level":               {PerApp: "", Global: "global-log-level"},
+	},
+}
+
+// PropertyTable returns the property schema this task manages.
+func (t TraefikPropertyTask) PropertyTable() PropertyTable {
+	return traefikPropertyTable
 }
 
 // Validate checks the TraefikPropertyTask's inputs without contacting the server.
 func (t TraefikPropertyTask) Validate() error {
-	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set", traefikPropertyKeys)
+	return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // Plan reports the drift the TraefikPropertyTask would produce.
 func (t TraefikPropertyTask) Plan() PlanResult {
-	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set", traefikPropertyKeys)
+	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
 func (t TraefikPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(app, "traefik:set", traefikPropertyKeys, func(app, property, value string) interface{} {
+	return exportProperties(t, app, func(app, property, value string) interface{} {
 		return TraefikPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
 func (t TraefikPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties("traefik:set", traefikPropertyKeys, func(property, value string) interface{} {
+	return exportGlobalProperties(t, func(property, value string) interface{} {
 		return TraefikPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tests/bats/schema.bats
+++ b/tests/bats/schema.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# docket schema is offline by contract - no subprocess, no server, no recipe -
+# so nothing here calls require_dokku.
+
+setup() {
+  docket_build
+}
+
+@test "docket schema emits a parseable catalog" {
+  run "$(docket_bin)" schema
+  assert_success
+  echo "$output" | jq -e . >/dev/null || fail "output is not valid JSON"
+  echo "$output" | jq -e '.version == 1' >/dev/null || fail "expected version 1"
+  echo "$output" | jq -e '(.tasks | length) > 0' >/dev/null || fail "expected at least one task"
+}
+
+@test "docket schema describes every task with a synopsis and fields" {
+  run "$(docket_bin)" schema
+  assert_success
+  echo "$output" |
+    jq -e 'all(.tasks[]; (.type | length > 0) and (.synopsis | length > 0) and (.fields | length > 0))' >/dev/null ||
+    fail "a task is missing its type, synopsis, or fields"
+  echo "$output" |
+    jq -e 'all(.tasks[]; (.export.status | IN("supported", "partial", "unsupported")))' >/dev/null ||
+    fail "a task has an unexpected export status"
+  echo "$output" |
+    jq -e 'all(.tasks[]; (.probe.status | IN("supported", "partial", "unsupported")))' >/dev/null ||
+    fail "a task has an unexpected probe status"
+}
+
+@test "docket schema lists tasks sorted by type" {
+  run "$(docket_bin)" schema
+  assert_success
+  echo "$output" | jq -e '[.tasks[].type] == ([.tasks[].type] | sort)' >/dev/null ||
+    fail "tasks are not sorted by type"
+}
+
+@test "docket schema describes a collection field's element shape" {
+  run "$(docket_bin)" schema
+  assert_success
+
+  # `list` alone cannot tell a list of strings from a list of structured
+  # entries, which is the gap the item schema closes.
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_ports") | .fields[] | select(.name == "port_mappings")
+           | .type == "list" and .item.type == "object"
+             and ([.item.fields[].name] == ["scheme", "host", "container"])' >/dev/null ||
+    fail "dokku_ports port_mappings does not describe its item shape"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_config") | .fields[] | select(.name == "config")
+           | .type == "dict" and .item.key_type == "string" and .item.type == "string"' >/dev/null ||
+    fail "dokku_config config does not describe its value type"
+}
+
+@test "docket schema marks sensitive fields" {
+  run "$(docket_bin)" schema
+  assert_success
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_git_from_image") | .fields[] | select(.name == "image") | .sensitive == true' >/dev/null ||
+    fail "dokku_git_from_image image is not marked sensitive"
+}
+
+@test "docket schema publishes a property task's supported property names" {
+  run "$(docket_bin)" schema
+  assert_success
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_apps_property") | .property_schema
+           | .plugin == "apps" and .subcommand == "apps:set" and .field == "property"' >/dev/null ||
+    fail "dokku_apps_property does not publish its property table"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_apps_property") | .property_schema.properties[]
+           | select(.name == "disable-autocreation") | .scopes == ["global"]' >/dev/null ||
+    fail "disable-autocreation is not published as global-only"
+}
+
+@test "docket schema publishes property name families it cannot enumerate" {
+  run "$(docket_bin)" schema
+  assert_success
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_letsencrypt_property") | .property_schema.dynamic[]
+           | select(.prefix == "dns-provider-") | .probeable == true and .sensitive == true' >/dev/null ||
+    fail "letsencrypt does not publish its dns-provider- family"
+}
+
+@test "docket schema omits a property schema when the names are not enumerable" {
+  run "$(docket_bin)" schema
+  assert_success
+
+  # dokku_service_property takes a property field, but the legal names come
+  # from whichever datastore plugin backs the service. Publishing an empty
+  # table would read as "no properties" rather than "docket cannot know".
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_service_property") | has("property_schema") | not' >/dev/null ||
+    fail "dokku_service_property should not publish a property schema"
+}
+
+@test "docket schema carries each task's documented examples" {
+  run "$(docket_bin)" schema
+  assert_success
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_app") | .examples | length > 0' >/dev/null ||
+    fail "dokku_app publishes no examples"
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_app") | .examples[0].yaml | test("dokku_app:")' >/dev/null ||
+    fail "dokku_app example does not name the task type"
+}
+
+@test "docket schema output is byte-stable across runs" {
+  "$(docket_bin)" schema >"$BATS_TEST_TMPDIR/first.json"
+  "$(docket_bin)" schema >"$BATS_TEST_TMPDIR/second.json"
+  run diff "$BATS_TEST_TMPDIR/first.json" "$BATS_TEST_TMPDIR/second.json"
+  assert_success
+}
+
+@test "docket schema --output writes the catalog to a file" {
+  run "$(docket_bin)" schema --output "$BATS_TEST_TMPDIR/catalog.json"
+  assert_success
+  assert_output ""
+  jq -e . "$BATS_TEST_TMPDIR/catalog.json" >/dev/null || fail "the written file is not valid JSON"
+}
+
+@test "docket schema rejects a positional argument" {
+  run "$(docket_bin)" schema dokku_app
+  assert_failure
+  assert_output --partial "takes no arguments"
+}


### PR DESCRIPTION
docket knew the full shape of every task type it registers, but that knowledge could only ever become markdown, so anything that was not a reader had to scrape `docs/tasks/*.md` or reimplement the reflection. `docket schema` now prints it as one JSON document: every task type with its recipe keys, their types, defaults, choices and descriptions, which values are secrets, what resource the task addresses, whether it can be exported and probed, and its documented examples. A property task additionally publishes the set of property names it accepts and the scopes each one is legal in, which until now could only be discovered by triggering a validation error, and that same set is rendered on its reference page. The reference pages are generated from the catalog rather than from a second reflection, so the two cannot disagree, and a test now fails the build when a committed page is stale.

The document has a published JSON Schema and is validated against it in CI, the same contract the three JSON-lines streams already have. It is not a committed file: the answer depends only on which binary is running, so there is nothing to go stale, and two runs of one binary emit byte-identical bytes so catalogs can be diffed across versions. The immediate consumer is #407, which needs the catalog in a form the docs generator does not own; editor tooling and recipe linters want the same thing.

The first `make docs` after the refactor changed exactly the 28 property pages and nothing else, which is what establishes that rendering the pages from the catalog is faithful; `TestGeneratedDocsAreCurrent` keeps it that way permanently.

Three things surfaced along the way and are deliberately left alone, since fixing them here would mean changing behaviour in a change that otherwise does not: traefik `dns-provider-*` credentials are not masked (#457), `docket validate` reports a less helpful message than `plan` for a scheduler-k3s `chart.*` property (#458), and narrowing the catalog to named task types (#459).

Closes #422
