### PR TITLE
fix: mask traefik dns-provider credentials

### DIFF
--- a/docs/task-catalog.md
+++ b/docs/task-catalog.md
@@ -179,6 +179,10 @@ consumer does not reject a legal recipe:
 `probeable: false` means docket cannot read those values back, so a recipe using that family
 reports drift on every run and never converges.
 
+`sensitive: true` means the members hold secrets: docket masks them in the command echo and lifts
+them into an input on export. It is independent of `probeable` - a credential docket cannot read
+back is still masked on the way out.
+
 **An absent `property_schema` on a task that has a `property` field means the legal names are not
 enumerable from docket, not that there are none.** `dokku_service_property` is the case: its names
 come from whichever datastore plugin backs the service, and no plugin exposes a report that lists

--- a/docs/tasks/dokku_traefik_property.md
+++ b/docs/tasks/dokku_traefik_property.md
@@ -48,7 +48,7 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `letsencrypt-server` | global |  | `global-letsencrypt-server` |
 | `log-level` | global |  | `global-log-level` |
 
-Names starting with `dns-provider-` are also accepted. dokku validates them through `traefik:set` rather than through its report schema, so they cannot be listed above. The plugin does not report them, so they are applied on every run and never converge.
+Names starting with `dns-provider-` are also accepted. dokku validates them through `traefik:set` rather than through its report schema, so they cannot be listed above. The plugin does not report them, so they are applied on every run and never converge. Their values are treated as secrets and masked.
 
 ## Examples
 

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -283,10 +283,15 @@ does not reject a legal recipe. How they plan depends on the plugin:
 - The plugin reports the family (letsencrypt on 0.25.0+ emits a row per set property): declare it
   `Probeable`, and the scope keys are synthesized so the property probes like any mapped one.
   Because the row only exists once the property has a value, an absent row reads as unset. Note the
-  minimum plugin version in `Requirements()`, and mark the family `Sensitive` when the value is a
-  credential so the probed value never reaches a drift reason unmasked.
+  minimum plugin version in `Requirements()`.
 - The plugin does not report it: leave `Probeable` false. The property skips probing and is applied
   unconditionally, and the task is `ProbePartial` with a caveat naming the family.
+
+Mark the family `Sensitive` whenever its values are credentials, whichever of those two it is.
+Whether a value is a secret and whether docket can read it back are separate questions, and
+answering the first by asking the second is how traefik's `dns-provider-*` credentials reached argv
+in cleartext (#457). `Sensitive` registers the desired value with the masker before it is echoed;
+on a `Probeable` family it also masks the value read back, so it never reaches a drift reason.
 
 ## Regenerating the task docs
 

--- a/tasks/catalog_test.go
+++ b/tasks/catalog_test.go
@@ -436,14 +436,16 @@ func TestCatalogPropertySchemaSpotChecks(t *testing.T) {
 		t.Errorf("letsencrypt dynamic = %+v; want %+v", letsencrypt.Dynamic, want)
 	}
 
-	// traefik has the same family, but the plugin does not report it, so a
-	// recipe using it never converges - and the catalog has to say so.
+	// traefik holds the same credentials, but the plugin does not report them,
+	// so a recipe using the family never converges - and the catalog has to say
+	// so without implying the values are any less secret (#457).
 	traefik := schemaFor(t, catalog, "dokku_traefik_property").PropertySchema
 	if traefik == nil {
 		t.Fatal("dokku_traefik_property has no property schema")
 	}
-	if len(traefik.Dynamic) != 1 || traefik.Dynamic[0].Probeable {
-		t.Errorf("traefik dynamic = %+v; want one unprobeable family", traefik.Dynamic)
+	want = []DynamicPropertySchema{{Prefix: "dns-provider-", Probeable: false, Sensitive: true}}
+	if !reflect.DeepEqual(traefik.Dynamic, want) {
+		t.Errorf("traefik dynamic = %+v; want %+v", traefik.Dynamic, want)
 	}
 
 	// A free-form property field is not a property table, and must not be

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -343,8 +343,23 @@ type dynamicPropertyFamily struct {
 	// unconditionally and the task never converges for it.
 	Probeable bool
 
-	// Sensitive is true when docket treats members as secrets.
+	// Sensitive is true when docket treats members as secrets. It is
+	// independent of Probeable: whether a value is a credential and whether
+	// docket can read it back are separate questions (#457).
 	Sensitive bool
+}
+
+// keysFor returns the PropertyKeys one member of the family gets. The report
+// keys exist only when the plugin reports the family, so an unprobeable member
+// carries no lookup keys - but it still carries the family's Sensitive mark, so
+// its value is masked on the way out even though it can never be read back.
+func (f dynamicPropertyFamily) keysFor(property string) PropertyKeys {
+	entry := PropertyKeys{Sensitive: f.Sensitive}
+	if f.Probeable {
+		entry.PerApp = property
+		entry.Global = "global-" + property
+	}
+	return entry
 }
 
 // dynamicPropertyFamilies is the whole set of dynamic families docket knows
@@ -360,18 +375,17 @@ var dynamicPropertyFamilies = map[string][]dynamicPropertyFamily{
 	// dokku-letsencrypt 0.25.0+ emits a `dns-provider-<KEY>` row for the app
 	// scope and a `global-dns-provider-<KEY>` row for the global one per
 	// property that is set (#449). The values are DNS provider API
-	// credentials, hence Sensitive: planProperty registers the probed value
-	// with the masker before it can reach a `(was %q)` drift reason.
+	// credentials, hence Sensitive: planProperty registers both the desired
+	// value and, because this family is probed, the value read back before it
+	// can reach a `(was %q)` drift reason.
 	"letsencrypt": {{Prefix: "dns-provider-", Probeable: true, Sensitive: true}},
 
-	// traefik's family has the same shape but is still absent from
+	// traefik's family holds the same credentials but is still absent from
 	// `traefik:report` (dokku/dokku#8928, tracked for docket in #450), so it
-	// stays on the unprobed path. Its values are credentials too, but
-	// planProperty reads Sensitive off the synthesized key entry, which an
-	// unprobeable family never gets - so they are not masked today (#457).
-	// Left as-is here so this change is a pure refactor; the catalog reports
-	// the flag it actually has rather than the one it should.
-	"traefik": {{Prefix: "dns-provider-"}},
+	// stays on the unprobed path. Sensitive is set anyway: there is no probed
+	// value to mask, but the desired one still reaches argv and the plan
+	// mutation line (#457).
+	"traefik": {{Prefix: "dns-provider-", Sensitive: true}},
 }
 
 // isDynamicProperty reports whether a (plugin, property) pair belongs to a
@@ -424,20 +438,25 @@ func dynamicPropertyKeys(plugin, property string) (PropertyKeys, bool) {
 	if !ok || !family.Probeable {
 		return PropertyKeys{}, false
 	}
-	return PropertyKeys{PerApp: property, Global: "global-" + property, Sensitive: family.Sensitive}, true
+	return family.keysFor(property), true
 }
 
 // propertyEntry returns the PropertyKeys a plugin uses for one property,
-// falling back to the synthesized entry when the property belongs to a
-// probeable dynamic family the map cannot enumerate. Reading the map directly
-// instead would report a `dns-provider-<KEY>` credential as non-Sensitive and
-// export it in cleartext (#451).
+// falling back to the family's entry when the property belongs to a dynamic
+// family the map cannot enumerate. Reading the map directly instead would
+// report a `dns-provider-<KEY>` credential as non-Sensitive and export it in
+// cleartext (#451). The fallback goes through the family rather than through
+// dynamicPropertyKeys so a family docket cannot probe still answers the
+// sensitivity question (#457).
 func propertyEntry(plugin, property string, keys map[string]PropertyKeys) PropertyKeys {
 	if entry, ok := keys[property]; ok {
 		return entry
 	}
-	entry, _ := dynamicPropertyKeys(plugin, property)
-	return entry
+	family, ok := dynamicPropertyFamilyFor(plugin, property)
+	if !ok {
+		return PropertyKeys{}
+	}
+	return family.keysFor(property)
 }
 
 // taskPropertyEntry is propertyEntry for a task that carries its own table, so
@@ -559,8 +578,6 @@ func planProperty(task PropertyTableDocer, state State, app string, global bool,
 	// A dynamic property has no static map entry. When its plugin reports the
 	// family, synthesize the entry so the probe path below runs against it; the
 	// families that stay unreported keep falling through to the unprobed path.
-	// This has to happen before the Sensitive read below, which is what
-	// registers a synthesized credential with the masker.
 	keys = withDynamicProperties(plugin, keys, []string{property})
 
 	// A property flagged Sensitive carries a secret value. Register the desired
@@ -568,7 +585,11 @@ func planProperty(task PropertyTableDocer, state State, app string, global bool,
 	// server-probed current value is registered after each probe below, since
 	// it is not known from the recipe (a hand-written recipe never tags it, and
 	// the `(was %q)` drift reason would otherwise leak the live server secret).
-	sensitive := keys[property].Sensitive
+	//
+	// propertyEntry answers this rather than the merged map, because the map
+	// only ever gains an entry for a family docket can probe - reading it
+	// directly would leave an unprobeable credential unmasked (#457).
+	sensitive := propertyEntry(plugin, property, keys).Sensitive
 	if sensitive {
 		subprocess.AddGlobalSensitive(value)
 	}

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -573,6 +573,93 @@ func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
 	}
 }
 
+// TestPlanPropertyDynamicTraefikMasksCredential is the core of #457: the
+// traefik family cannot be probed, but its values are DNS provider credentials
+// all the same, so the desired value must reach the masker before it lands in
+// the command echo or the plan mutation line.
+func TestPlanPropertyDynamicTraefikMasksCredential(t *testing.T) {
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	defer subprocess.SetExecRunner(func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{}, nil
+	})()
+
+	res := planProperty(TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "traefiktoken")
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if !strings.Contains(res.Reason, "(no probe key)") {
+		t.Errorf("reason = %q; want the unprobed reason", res.Reason)
+	}
+	// Commands are masked as they are resolved, so a leak here means the value
+	// was never registered; mutations are masked by the emitter instead.
+	for _, cmd := range res.Commands {
+		if masked := subprocess.MaskString(cmd); strings.Contains(masked, "traefiktoken") {
+			t.Errorf("command leaked the credential: %q -> %q", cmd, masked)
+		}
+	}
+	for _, mutation := range res.Mutations {
+		if masked := subprocess.MaskString(mutation); strings.Contains(masked, "traefiktoken") {
+			t.Errorf("mutation leaked the credential: %q -> %q", mutation, masked)
+		}
+	}
+}
+
+// TestPropertyEntry pins the three arms the export path and planProperty read
+// sensitivity through: a mapped property answers for itself, a probeable
+// dynamic member is synthesized whole, and an unprobeable one carries the
+// family's Sensitive mark with no lookup keys (#457).
+func TestPropertyEntry(t *testing.T) {
+	cases := []struct {
+		name     string
+		plugin   string
+		property string
+		keys     map[string]PropertyKeys
+		want     PropertyKeys
+	}{
+		{
+			name:     "mapped entry wins",
+			plugin:   "traefik",
+			property: "basic-auth-password",
+			keys:     traefikPropertyTable.Keys,
+			want:     PropertyKeys{Global: "global-basic-auth-password", Sensitive: true},
+		},
+		{
+			name:     "probeable dynamic member is synthesized",
+			plugin:   "letsencrypt",
+			property: "dns-provider-NAMECHEAP_API_USER",
+			keys:     letsencryptPropertyTable.Keys,
+			want: PropertyKeys{
+				PerApp:    "dns-provider-NAMECHEAP_API_USER",
+				Global:    "global-dns-provider-NAMECHEAP_API_USER",
+				Sensitive: true,
+			},
+		},
+		{
+			name:     "unprobeable dynamic member is still sensitive",
+			plugin:   "traefik",
+			property: "dns-provider-CLOUDFLARE_API_TOKEN",
+			keys:     traefikPropertyTable.Keys,
+			want:     PropertyKeys{Sensitive: true},
+		},
+		{
+			name:     "unknown property has no entry",
+			plugin:   "traefik",
+			property: "wat",
+			keys:     traefikPropertyTable.Keys,
+			want:     PropertyKeys{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := propertyEntry(tc.plugin, tc.property, tc.keys); got != tc.want {
+				t.Errorf("propertyEntry(%q, %q) = %+v; want %+v", tc.plugin, tc.property, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateProperty(t *testing.T) {
 	keys := map[string]PropertyKeys{
 		"both":       {PerApp: "both", Global: "global-both"},

--- a/tasks/property_coverage_test.go
+++ b/tasks/property_coverage_test.go
@@ -155,6 +155,23 @@ func TestDynamicPropertyFamiliesArePublished(t *testing.T) {
 	}
 }
 
+// TestDynamicFamilySensitivityIsIndependentOfProbing asserts every family's
+// Sensitive mark survives the lookup planProperty and the exporters make.
+// Sensitivity used to be read off an entry only a probeable family ever got, so
+// an unprobeable credential reached argv in cleartext (#457); this fails the
+// build if that coupling comes back.
+func TestDynamicFamilySensitivityIsIndependentOfProbing(t *testing.T) {
+	for plugin, families := range dynamicPropertyFamilies {
+		for _, family := range families {
+			property := family.Prefix + "EXAMPLE"
+			if got := propertyEntry(plugin, property, nil).Sensitive; got != family.Sensitive {
+				t.Errorf("propertyEntry(%q, %q).Sensitive = %v; want %v (probeable: %v)",
+					plugin, property, got, family.Sensitive, family.Probeable)
+			}
+		}
+	}
+}
+
 // TestPropertyTablesAreDistinct asserts no two property tasks share a table.
 // Copying a task file and forgetting to rename the table var would otherwise
 // give two tasks the same properties and the same :set subcommand, and every

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -140,6 +140,31 @@ EOF
   assert_output --partial "***"
 }
 
+@test "docket plan masks a traefik dns-provider credential" {
+  # traefik does not report its dns-provider-* family, so the property takes the
+  # unprobed path and no traefik state is read or written here. The value is a
+  # DNS provider credential all the same and must not reach the mutation line or
+  # the --json commands array (#457).
+  write_tasks_file <<'EOF'
+---
+- tasks:
+    - name: set a traefik dns provider credential
+      dokku_traefik_property:
+        global: true
+        property: dns-provider-CLOUDFLARE_API_TOKEN
+        value: traefiktokenzzz
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  refute_output --partial "traefiktokenzzz"
+  assert_output --partial "***"
+
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --json
+  assert_success
+  refute_output --partial "traefiktokenzzz"
+  assert_output --partial "***"
+}
+
 @test "docket plan output never echoes dokku_config map values" {
   # Create the app first so the dokku_config plan probe succeeds; otherwise
   # the missing-app probe error short-circuits the test before the masking

--- a/tests/bats/schema.bats
+++ b/tests/bats/schema.bats
@@ -86,6 +86,13 @@ setup() {
     jq -e '.tasks[] | select(.type == "dokku_letsencrypt_property") | .property_schema.dynamic[]
            | select(.prefix == "dns-provider-") | .probeable == true and .sensitive == true' >/dev/null ||
     fail "letsencrypt does not publish its dns-provider- family"
+
+  # traefik holds the same credentials but does not report them, so the family
+  # is sensitive without being probeable (#457).
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_traefik_property") | .property_schema.dynamic[]
+           | select(.prefix == "dns-provider-") | .probeable == false and .sensitive == true' >/dev/null ||
+    fail "traefik does not publish its dns-provider- family as sensitive"
 }
 
 @test "docket schema omits a property schema when the names are not enumerable" {


### PR DESCRIPTION
Sensitivity was being inferred from probeability: the flag was read off a key-map entry that only a family dokku reports ever receives, so the traefik `dns-provider-<ENV_VAR>` credentials reached argv in cleartext in the command echo, the plan mutation line, and the `--json` streams. Sensitivity now comes from the family itself, which is a separate question from whether the value can be read back, and `docket schema` publishes the family as sensitive.

Probing the family stays out of scope: #450 still tracks reading these values back once `traefik:report` surfaces them.

Fixes #457
