### PR TITLE
fix: exit 1 when a play when: errors under --list-tasks

### DIFF
--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -33,22 +33,37 @@ type listTasksOptions struct {
 // Predicates that reference `.registered.<name>` produce an [unknown]
 // marker since their truth value cannot be determined statically. All
 // other false predicates produce a [skipped] marker.
+//
+// A predicate that *errors* is treated differently depending on where it
+// sits. A play-level when: is evaluated against exactly the context the
+// apply / plan loops build for it, so an error here is the same error
+// they would hit: the listing still renders in full, and the exit code
+// is 1. A task-level when: sees a reduced context (no result, no
+// registered, no failed_task), so an error there may be an artifact of
+// listing offline rather than a broken predicate - it renders [when?]
+// and leaves the exit code alone. See evaluateListWhen.
 func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
+	// playWhenError records that at least one play predicate failed to
+	// evaluate. The walk is not short-circuited - every remaining play is
+	// still listed, and the failure is carried by the exit code once the
+	// listing is complete, matching the way the plan loop finishes before
+	// returning 1.
+	playWhenError := false
 	for _, play := range opts.plays {
 		if play.IsFileLevel() {
 			continue
 		}
-		playWhenSkipped := false
 		if play.HasWhen() {
 			playCtx := buildEnvelopeExprContext(buildPlayWhenContext(opts.context, opts.fileLevelKeys, opts.userSet))
 			ok, err := tasks.EvalBool(play.WhenProgram(), playCtx)
 			if err != nil {
+				playWhenError = true
 				if opts.jsonOut {
 					emitListJSON(ui, map[string]interface{}{
-						"type":      "play_skipped",
-						"play":      play.Name,
-						"when":      play.When,
-						"reason":    fmt.Sprintf("when error: %v", err),
+						"type":   "play_skipped",
+						"play":   play.Name,
+						"when":   play.When,
+						"reason": fmt.Sprintf("when error: %v", err),
 					})
 				} else {
 					ui.Output(fmt.Sprintf("==> Play: %s  (when error: %v)", play.Name, err))
@@ -56,7 +71,6 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 				continue
 			}
 			if !ok {
-				playWhenSkipped = true
 				if opts.jsonOut {
 					emitListJSON(ui, map[string]interface{}{
 						"type":   "play_skipped",
@@ -70,7 +84,6 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 				continue
 			}
 		}
-		_ = playWhenSkipped
 
 		if !opts.jsonOut {
 			ui.Output(fmt.Sprintf("==> Play: %s", play.Name))
@@ -83,6 +96,9 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 			renderListEnvelope(ui, play.Name, play.Tasks.GetEnvelope(name), idx, "", 0, playExprCtx, opts.jsonOut)
 			idx++
 		}
+	}
+	if playWhenError {
+		return 1
 	}
 	return 0
 }
@@ -217,6 +233,12 @@ func renderListEnvelope(
 // predicate references `.registered.<name>` (we can't decide without
 // running prior tasks); "when_error" when the predicate compiles but
 // errors at evaluation time against the inputs context.
+//
+// "when_error" is a marker only - it does not fail the listing the way a
+// play-level when: error does. The context here is missing `result` and
+// `failed_task`, so a predicate that is valid at run time can error when
+// evaluated offline: a rescue child written the documented way,
+// `when: 'failed_task.Stderr contains "..."'`, is `nil.Stderr` here.
 func evaluateListWhen(env *tasks.TaskEnvelope, playExprCtx map[string]interface{}) string {
 	if !env.HasWhen() {
 		return ""

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -377,6 +377,119 @@ func TestApplyStartAtTaskUnknownErrors(t *testing.T) {
 	}
 }
 
+// playWhenErrorTasks is the recipe the play-level when:-error tests
+// share: one play whose predicate errors, followed by one that lists
+// normally.
+//
+// `[][0] == 1` compiles and then errors at evaluation (index out of
+// range). That distinction is the whole point - a predicate that fails
+// to *compile* is rejected at load, long before renderListTasks runs,
+// and tests/bats/plays.bats already covers that through validate.
+const playWhenErrorTasks = `---
+- name: broken
+  when: '[][0] == 1'
+  tasks:
+    - name: never listed
+      dokku_stub: { key: a }
+
+- name: fine
+  tasks:
+    - name: listed
+      dokku_stub: { key: a }
+`
+
+// TestListTasksPlayWhenErrorExitsOne pins that a play whose when:
+// predicate errors fails the listing. A play-level when: is evaluated
+// against exactly the context the apply / plan loops build for it
+// (buildPlayWhenContext, called identically at commands/plan.go), so an
+// error here is the same error plan reports as fatal - reporting success
+// would let a --list-tasks CI gate pass a recipe that cannot run.
+//
+// The rest of the listing still renders: the walk is not short-circuited,
+// only the exit code carries the failure.
+func TestListTasksPlayWhenErrorExitsOne(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, playWhenErrorTasks)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "==> Play: broken  (when error:") {
+		t.Errorf("expected the broken play's header to name the evaluation error; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "never listed") {
+		t.Errorf("the erroring play's tasks must not be listed; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "==> Play: fine") || !strings.Contains(stdout, "[0] listed") {
+		t.Errorf("a later play should still be listed after the error; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksPlayWhenErrorJSONExitsOne is the same case under --json,
+// and pins the half that a wrapper sees: the exit code is 1 but stdout
+// still carries the complete stream. That is the exception to the
+// "non-zero exit means the failure detail is on stderr" rule in
+// docs/json-output.md, which holds only for load-time failures.
+//
+// It also exercises the `when error: <err>` form of play_skipped.reason.
+// The schema has always documented both forms; only `when: <src>` was
+// reachable from a test before this.
+func TestListTasksPlayWhenErrorJSONExitsOne(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, playWhenErrorTasks)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks", "--json")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+
+	if !strings.Contains(stdout, `"type":"play_skipped"`) {
+		t.Errorf("expected a play_skipped event; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"reason":"when error:`) {
+		t.Errorf("expected the play_skipped reason to carry the when error: form; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"listed"`) {
+		t.Errorf("a non-zero exit must still emit the rest of the stream; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksTaskWhenErrorDoesNotAffectExit pins the deliberate
+// asymmetry with the two tests above: a *task*-level when: that errors
+// renders [when?] and leaves the exit code at 0.
+//
+// The task context here is missing `result` and `failed_task`, so an
+// error can be an artifact of listing offline rather than a broken
+// predicate - a rescue child written the way docs/task-envelope.md
+// documents, `when: 'failed_task.Stderr contains "..."'`, evaluates
+// nil.Stderr and errors here while being valid at run time. #462 tracks
+// rendering that case as [unknown] instead; either way it must not fail
+// the listing.
+func TestListTasksTaskWhenErrorDoesNotAffectExit(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: broken predicate
+      when: '[][0] == 1'
+      dokku_stub: { key: a }
+    - name: plain
+      dokku_stub: { key: b }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[when?]   broken predicate") {
+		t.Errorf("expected the [when?] marker on the erroring task; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "plain") {
+		t.Errorf("the rest of the play should still be listed; got:\n%s", stdout)
+	}
+}
+
 // TestApplyStartAtTaskSkipsEarlier confirms the executor renders
 // [skipped] for tasks before the target and runs the matched task plus
 // successors. The stub fixtures track which tasks actually execute.

--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -152,7 +152,9 @@ docket's view of the result to evaluate.
 | `validate` | No problems | At least one problem, or the recipe could not be read | - |
 
 `--list-tasks` returns before any task runs, so it is unaffected by `--detailed-exitcode` and exits
-`0` or `1`.
+`0` or `1`. It exits `1` for a recipe it could not load, and for a play `when:` that fails to
+evaluate - that predicate is resolved against the same context a run uses, so the failure is one the
+run would hit too.
 
 ### Correlating tasks across runs
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -277,7 +277,8 @@ recipe" is the same outcome either way. Pass `--detailed-exitcode` when the call
 `0` means nothing changed, `2` means at least one task changed, and `1` still means an error. Errors
 win over changes, matching `plan`. An error swallowed by
 [`ignore_errors`](task-envelope.md#ignore_errors-continue-past-a-failure) is not an error for this
-purpose. `--list-tasks` returns before any task runs, so it is unaffected.
+purpose. `--list-tasks` returns before any task runs, so it never exits `2`; it exits `1` when the
+recipe cannot be loaded or a play `when:` fails to evaluate, and `0` otherwise.
 
 | Flag | Effect |
 |------|--------|
@@ -340,7 +341,27 @@ $ docket apply --list-tasks
 
 A `when:` that is false against the inputs renders as `[skipped]`. A `when:` that references
 `.registered.<name>` cannot be decided without running earlier tasks, so it renders as `[unknown]`
-rather than guessing.
+rather than guessing. A task `when:` that fails to evaluate renders as `[when?]` and does not change
+the exit code: the listing evaluates it without the `result` and `failed_task` values a real run
+would supply, so an error there can be an artifact of listing offline rather than a broken
+predicate.
+
+A play-level `when:` is different, because it is resolved against exactly the context `apply` and
+`plan` build for it. One that fails to evaluate is the same failure a run would hit, so the play's
+header carries the error, its tasks are left unlisted, and the command exits `1`:
+
+```text
+$ docket plan --list-tasks
+==> Play: broken  (when error: cannot fetch tag from <nil> (1:9)
+ | release.tag == "v1"
+ | ........^)
+==> Play: api
+[0] dokku apps:create api
+$ echo $?
+1
+```
+
+Every other play still lists - the failure is carried by the exit code, not by stopping the walk.
 
 A task whose type is deprecated is marked `(deprecated)`. A task whose type cannot read its own
 state is marked `(never converges)`, and one that can read only part of it is marked

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -197,6 +197,11 @@ emitter starts, so it produces **no JSON on stdout** and a human-readable messag
 non-zero exit with empty stdout as a failure whose detail is on stderr, or run
 `docket validate --json` first to get the same problems as structured events.
 
+Do not read that the other way round: a non-zero exit does not imply empty stdout.
+`--list-tasks --json` exits `1` when a play `when:` fails to evaluate, and the stream is complete -
+the failure is a `play_skipped` event whose `reason` carries the `when error: <err>` form, followed
+by every remaining play's tasks.
+
 ## See also
 
 - [Command reference](command-reference.md) - the `--json` and `--detailed-exitcode` flags

--- a/tests/bats/plays.bats
+++ b/tests/bats/plays.bats
@@ -242,6 +242,33 @@ EOF
   assert_output --partial "play when expression compile error"
 }
 
+@test "plays: play-level when: that errors fails --list-tasks" {
+  # The compile-error case above is caught by validate. This is the other
+  # half: a predicate that compiles and then errors at evaluation. A play
+  # when: is resolved against the same context plan uses, so --list-tasks
+  # reaches the same verdict plan does and exits non-zero rather than
+  # reporting a listing a run could never produce. The second play still
+  # lists - the failure is carried by the exit code, not by stopping the
+  # walk. Offline: --list-tasks never contacts a server.
+  write_tasks_file <<EOF
+---
+- name: broken
+  when: '[][0] == 1'
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+- name: fine
+  tasks:
+    - name: listed
+      dokku_app:
+        app: docket-test-noop-2
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
+  assert_failure
+  assert_output --partial "==> Play: broken  (when error:"
+  assert_output --partial "[0] listed"
+}
+
 @test "plays: unknown play-level key reported by validate" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
A play-level `when:` is resolved against exactly the context the apply and plan loops build for it, so a predicate that errors while listing is the same error a run would hit and the same one `plan` already reports as fatal. `--list-tasks` reported it and exited `0`, which let it pass a recipe that cannot run. The listing still renders every remaining play; only the exit code changes. A task-level `when:` error keeps rendering `[when?]` at exit `0`, because that context is missing `result` and `failed_task` and can flag a predicate that is valid at run time - #462 tracks rendering that case as `[unknown]` instead. This replaces the dead `playWhenSkipped` variable, which was assigned and discarded without ever being read.

Note that this is a behaviour change for callers treating `--list-tasks` as always-succeeds: a recipe whose play predicate errors now exits non-zero, which is the verdict `plan` already returns for the same recipe.

Fixes #429
