### PR TITLE
feat: add a --task filter to docket schema

### DIFF
--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -635,11 +635,11 @@ func userSetKeys(flags *flag.FlagSet, varsFileKeys map[string]bool, arguments ma
 	return out
 }
 
-// nearestInputName returns the registered input name with the lowest
-// Levenshtein distance to candidate, but only if that distance is at most
-// 2. Empty string means "no useful suggestion". Mirrors the behaviour of
-// tasks.nearestTaskName so unknown-input messages stay consistent across
-// the validator and the input loader.
+// nearestInputName returns the name from names with the lowest Levenshtein
+// distance to candidate, but only if that distance is at most 2. Empty string
+// means "no useful suggestion". Mirrors the behaviour of
+// tasks.nearestEnvelopeOrTaskKey so did-you-mean messages stay consistent
+// across the validator, the input loader, and `schema --task`.
 func nearestInputName(candidate string, names []string) string {
 	best := ""
 	bestDist := 3

--- a/commands/schema_command.go
+++ b/commands/schema_command.go
@@ -26,12 +26,14 @@ import (
 // answer depends only on which docket binary is running, which is why the
 // catalog is not a committed file - it cannot go stale.
 //
-// The whole catalog is the only thing it emits today; narrowing it to named
-// task types is #459, which `jq` covers in the meantime.
+// --task narrows it to named task types (#459). The document keeps its shape -
+// a version and a tasks array - so a consumer parses one format either way and
+// the published JSON Schema covers both.
 type SchemaCommand struct {
 	command.Meta
 
-	output string
+	output    string
+	taskTypes []string
 }
 
 func (c *SchemaCommand) Name() string {
@@ -49,11 +51,12 @@ func (c *SchemaCommand) Help() string {
 func (c *SchemaCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Print the catalog to stdout":     fmt.Sprintf("%s %s", appName, c.Name()),
-		"Write the catalog to a file":     fmt.Sprintf("%s %s --output catalog.json", appName, c.Name()),
-		"List every task type":            fmt.Sprintf("%s %s | jq -r '.tasks[].type'", appName, c.Name()),
-		"Show one task's fields":          fmt.Sprintf("%s %s | jq '.tasks[] | select(.type==\"dokku_config\") | .fields'", appName, c.Name()),
-		"List a property task's settings": fmt.Sprintf("%s %s | jq -r '.tasks[] | select(.type==\"dokku_nginx_property\") | .property_schema.properties[].name'", appName, c.Name()),
+		"Print the catalog to stdout":          fmt.Sprintf("%s %s", appName, c.Name()),
+		"Write the catalog to a file":          fmt.Sprintf("%s %s --output catalog.json", appName, c.Name()),
+		"List every task type":                 fmt.Sprintf("%s %s | jq -r '.tasks[].type'", appName, c.Name()),
+		"Narrow the catalog to two task types": fmt.Sprintf("%s %s --task dokku_config --task dokku_domains", appName, c.Name()),
+		"Show one task's fields":               fmt.Sprintf("%s %s | jq '.tasks[] | select(.type==\"dokku_config\") | .fields'", appName, c.Name()),
+		"List a property task's settings":      fmt.Sprintf("%s %s | jq -r '.tasks[] | select(.type==\"dokku_nginx_property\") | .property_schema.properties[].name'", appName, c.Name()),
 	}
 }
 
@@ -72,6 +75,7 @@ func (c *SchemaCommand) ParsedArguments(args []string) (map[string]command.Argum
 func (c *SchemaCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.output, "output", "-", "path to write the catalog to; - writes to stdout")
+	f.StringArrayVar(&c.taskTypes, "task", nil, "restrict the catalog to the named task type, e.g. dokku_config (repeatable); the whole catalog is emitted when omitted")
 	return f
 }
 
@@ -80,14 +84,41 @@ func (c *SchemaCommand) AutocompleteFlags() complete.Flags {
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
 			"--output": complete.PredictFiles("*.json"),
+			"--task":   complete.PredictSet(tasks.RegisteredTaskNames()...),
 		},
 	)
+}
+
+// validateTaskTypeFilter checks every --task value against the registry before
+// any work happens, so a typo fails before the catalog is built and, with
+// --output, before anything touches the disk.
+//
+// An unknown type names the closest registered one the same way an unknown task
+// type in a recipe address does (tasks.ParseResourceSelectors). Matching is
+// exact: type keys are case-sensitive at every other lookup, so a case-folded
+// match here would be the only place the vocabulary bent.
+func validateTaskTypeFilter(values []string) error {
+	for _, value := range values {
+		if value == "" {
+			return fmt.Errorf("invalid --task %q: a task type is required", value)
+		}
+		if _, ok := tasks.RegisteredTasks[value]; ok {
+			continue
+		}
+		msg := fmt.Sprintf("unknown task type %q", value)
+		if near := nearestInputName(value, tasks.RegisteredTaskNames()); near != "" {
+			msg += fmt.Sprintf(" (did you mean %q?)", near)
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
 }
 
 // Run builds the catalog and writes it. Exit codes:
 //
 //	0 - catalog written
-//	1 - flag parse error, unexpected positional argument, or IO error
+//	1 - flag parse error, unexpected positional argument, unknown --task type,
+//	    or IO error
 func (c *SchemaCommand) Run(args []string) int {
 	flags := c.FlagSet()
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -97,12 +128,25 @@ func (c *SchemaCommand) Run(args []string) int {
 		return 1
 	}
 	if rest := flags.Args(); len(rest) > 0 {
-		c.Ui.Error(fmt.Sprintf("unexpected argument %q: schema takes no arguments", rest[0]))
+		msg := fmt.Sprintf("unexpected argument %q: schema takes no arguments", rest[0])
+		// A bare task type is the mistake --task invites, so point at the
+		// flag rather than leaving the reader at a dead end.
+		if _, ok := tasks.RegisteredTasks[rest[0]]; ok {
+			msg += fmt.Sprintf("; did you mean --task %s?", rest[0])
+		}
+		c.Ui.Error(msg)
 		c.Ui.Error(command.CommandErrorText(c))
 		return 1
 	}
 
-	catalog, err := tasks.Catalog()
+	// No CommandErrorText here: --help cannot list task types, so pointing at
+	// it would be noise. Same as export's unknown --resource task type.
+	if err := validateTaskTypeFilter(c.taskTypes); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	catalog, err := tasks.CatalogFor(c.taskTypes)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("failed to build the task catalog: %v", err))
 		return 1

--- a/commands/schema_command_test.go
+++ b/commands/schema_command_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/josegonzalez/cli-skeleton/command"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -303,5 +305,207 @@ func TestSchemaCommandReportsAnUnwritableOutput(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "write error") {
 		t.Errorf("stderr = %q; want a write error", stderr)
+	}
+}
+
+// catalogTypeList returns the emitted type keys in document order, so a test
+// can assert both membership and ordering.
+func catalogTypeList(t *testing.T, doc map[string]interface{}) []string {
+	t.Helper()
+	list, ok := doc["tasks"].([]interface{})
+	if !ok {
+		t.Fatalf("catalog has no tasks array: %v", doc["tasks"])
+	}
+	out := make([]string, 0, len(list))
+	for _, entry := range list {
+		task, ok := entry.(map[string]interface{})
+		if !ok {
+			t.Fatalf("task entry is not an object: %v", entry)
+		}
+		name, _ := task["type"].(string)
+		out = append(out, name)
+	}
+	return out
+}
+
+// TestSchemaCommandFiltersToRequestedTaskTypes is the headline of #459: --task
+// narrows the catalog to the named types and nothing else.
+func TestSchemaCommandFiltersToRequestedTaskTypes(t *testing.T) {
+	out, stderr, exit := runSchema(t, "--task", "dokku_config", "--task", "dokku_domains")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", exit, stderr)
+	}
+
+	doc := decodeCatalog(t, out)
+	if version, _ := doc["version"].(float64); int(version) != tasks.CatalogVersion {
+		t.Errorf("version = %v; want %d", doc["version"], tasks.CatalogVersion)
+	}
+	want := []string{"dokku_config", "dokku_domains"}
+	if got := catalogTypeList(t, doc); !reflect.DeepEqual(got, want) {
+		t.Errorf("types = %v; want %v", got, want)
+	}
+}
+
+// TestSchemaCommandFilteredOutputMatchesSchema is the other half of the issue's
+// contract: a narrowed catalog is the same document shape, so the published
+// JSON Schema still covers it and a consumer parses one format either way.
+func TestSchemaCommandFilteredOutputMatchesSchema(t *testing.T) {
+	out, stderr, exit := runSchema(t, "--task", "dokku_config")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", exit, stderr)
+	}
+	assertMatchesSchema(t, taskCatalogSchemaPath, out)
+}
+
+// TestSchemaCommandFilterIgnoresFlagOrder keeps the documented stability
+// contract true for a narrowed run: tasks are sorted by type, so the bytes do
+// not depend on the order the flags were typed.
+func TestSchemaCommandFilterIgnoresFlagOrder(t *testing.T) {
+	forward, _, _ := runSchema(t, "--task", "dokku_config", "--task", "dokku_domains")
+	reverse, _, _ := runSchema(t, "--task", "dokku_domains", "--task", "dokku_config")
+	if forward != reverse {
+		t.Error("reversing the --task flags changed the output")
+	}
+}
+
+// TestSchemaCommandFilterDedupesRepeatedTypes: the document is a set keyed by
+// type, so naming one twice emits it once rather than failing.
+func TestSchemaCommandFilterDedupesRepeatedTypes(t *testing.T) {
+	out, _, exit := runSchema(t, "--task", "dokku_config", "--task", "dokku_config")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if got := catalogTypeList(t, decodeCatalog(t, out)); !reflect.DeepEqual(got, []string{"dokku_config"}) {
+		t.Errorf("types = %v; want [dokku_config]", got)
+	}
+}
+
+// TestSchemaCommandFilteredEntryMatchesFullCatalog pins that --task changes
+// which entries are emitted and nothing about any entry, so it is purely
+// additive for a consumer that already reads the whole catalog.
+func TestSchemaCommandFilteredEntryMatchesFullCatalog(t *testing.T) {
+	narrowed, _, exit := runSchema(t, "--task", "dokku_config")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	full, _, _ := runSchema(t)
+
+	got := catalogTasks(t, decodeCatalog(t, narrowed))["dokku_config"]
+	want := catalogTasks(t, decodeCatalog(t, full))["dokku_config"]
+	if !reflect.DeepEqual(got, want) {
+		t.Error("the narrowed dokku_config entry differs from the full catalog's")
+	}
+}
+
+// TestSchemaCommandRejectsUnknownTaskType: an unknown type exits non-zero and
+// names the closest match, the way an unknown task type in a recipe address
+// already does. Emitting an empty tasks array would read as "docket has no
+// such task", which is exactly the wrong answer for a typo.
+func TestSchemaCommandRejectsUnknownTaskType(t *testing.T) {
+	out, stderr, exit := runSchema(t, "--task", "dokku_confg")
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, `unknown task type "dokku_confg"`) {
+		t.Errorf("stderr = %q; want it to name the unknown type", stderr)
+	}
+	if !strings.Contains(stderr, `did you mean "dokku_config"`) {
+		t.Errorf("stderr = %q; want a did-you-mean hint", stderr)
+	}
+	if out != "" {
+		t.Errorf("wrote %d bytes to stdout; want none", len(out))
+	}
+}
+
+func TestSchemaCommandUnknownTaskTypeWithoutNearMatch(t *testing.T) {
+	_, stderr, exit := runSchema(t, "--task", "nonsense")
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, `unknown task type "nonsense"`) {
+		t.Errorf("stderr = %q; want it to name the unknown type", stderr)
+	}
+	if strings.Contains(stderr, "did you mean") {
+		t.Errorf("stderr = %q; want no hint when nothing is close", stderr)
+	}
+}
+
+func TestSchemaCommandRejectsEmptyTaskType(t *testing.T) {
+	_, stderr, exit := runSchema(t, "--task=")
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, "a task type is required") {
+		t.Errorf("stderr = %q; want the empty-value message", stderr)
+	}
+}
+
+// TestSchemaCommandTaskTypeFilterIsCaseSensitive pins the decision: type keys
+// are case-sensitive at every other lookup, so --task does not case-fold.
+func TestSchemaCommandTaskTypeFilterIsCaseSensitive(t *testing.T) {
+	_, stderr, exit := runSchema(t, "--task", "DOKKU_CONFIG")
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, `unknown task type "DOKKU_CONFIG"`) {
+		t.Errorf("stderr = %q; want the unknown-type message", stderr)
+	}
+}
+
+func TestSchemaCommandFilterWritesToFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.json")
+
+	out, stderr, exit := runSchema(t, "--task", "dokku_config", "--output", path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", exit, stderr)
+	}
+	if out != "" {
+		t.Errorf("--output wrote %d bytes to stdout; want none", len(out))
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	stdout, _, _ := runSchema(t, "--task", "dokku_config")
+	if string(written) != stdout {
+		t.Error("the file and the stream disagree")
+	}
+}
+
+// TestSchemaCommandUnknownTaskTypeWritesNoFile is why the filter is validated
+// before anything is built: a typo must not leave a file behind.
+func TestSchemaCommandUnknownTaskTypeWritesNoFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.json")
+
+	_, _, exit := runSchema(t, "--task", "nonsense", "--output", path)
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("os.Stat(%s) = %v; want the file not to exist", path, err)
+	}
+}
+
+func TestSchemaCommandAutocompletesTaskTypes(t *testing.T) {
+	c := &SchemaCommand{}
+	predictor, ok := c.AutocompleteFlags()["--task"]
+	if !ok || predictor == nil {
+		t.Fatal("--task has no completion predictor")
+	}
+	if got := predictor.Predict(complete.Args{}); !reflect.DeepEqual(got, tasks.RegisteredTaskNames()) {
+		t.Errorf("--task predicts %v; want every registered task type", got)
+	}
+}
+
+// TestSchemaCommandPositionalTaskTypeSuggestsTheFlag: a bare task type is the
+// mistake --task invites, so the rejection points at the flag.
+func TestSchemaCommandPositionalTaskTypeSuggestsTheFlag(t *testing.T) {
+	_, stderr, exit := runSchema(t, "dokku_app")
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, "did you mean --task dokku_app?") {
+		t.Errorf("stderr = %q; want it to point at --task", stderr)
 	}
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -506,6 +506,9 @@ docket schema
 # List every task type.
 docket schema | jq -r '.tasks[].type'
 
+# Only the task types you name.
+docket schema --task dokku_config --task dokku_domains | jq -r '.tasks[].type'
+
 # What fields does dokku_config take?
 docket schema | jq '.tasks[] | select(.type=="dokku_config") | .fields'
 
@@ -514,14 +517,15 @@ docket schema | jq -r '.tasks[] | select(.type=="dokku_nginx_property") | .prope
 ```
 
 Like `init` and `validate`, `schema` is offline: it opens no subprocess and contacts no server. It
-also reads no recipe, so it takes no `--tasks` and no positional argument. Two runs of the same
-binary emit byte-identical output, which is what makes diffing catalogs across docket versions
-useful.
+also reads no recipe, so it takes no `--tasks` and no positional argument - the `--task` below
+names a task type, not a recipe file. Two runs of the same binary emit byte-identical output,
+which is what makes diffing catalogs across docket versions useful.
 
 | Flag | Effect |
 |------|--------|
-| (default) | Write the catalog to stdout. |
+| (default) | Write the whole catalog to stdout. |
 | `--output <path>` | Write to a path instead; `-` writes to stdout. An existing file is overwritten, since the catalog is wholly derived and holds nothing of yours. |
+| `--task <type>` | Restrict the catalog to the named task type, such as `dokku_config`. Repeatable. The document keeps its shape, a `version` and a `tasks` array, so anything that reads the whole catalog reads a narrowed one unchanged. Tasks stay sorted by `type` whatever order the flags came in, and naming one twice emits it once. An unknown type is an error naming the closest match, not an empty array. |
 
 ## docket version
 

--- a/docs/schemas/task-catalog-v1.schema.json
+++ b/docs/schemas/task-catalog-v1.schema.json
@@ -14,7 +14,7 @@
     "tasks": {
       "type": "array",
       "items": { "$ref": "#/$defs/task" },
-      "description": "Every registered task type, sorted by `type`."
+      "description": "The task types the document describes, sorted by `type`. Every registered task type unless `docket schema --task` narrowed it."
     }
   },
   "$defs": {

--- a/docs/task-catalog.md
+++ b/docs/task-catalog.md
@@ -13,6 +13,7 @@ recipe before it reaches a server.
 ```bash
 docket schema
 docket schema --output catalog.json
+docket schema --task dokku_config --task dokku_domains
 ```
 
 The command is offline: it opens no subprocess and contacts no server. The answer depends only on
@@ -62,6 +63,25 @@ deliberately absent - the catalog describes the recipe surface, not docket's imp
 There is a [JSON Schema](schemas/task-catalog-v1.schema.json) for the whole thing. Unlike the
 [JSON-lines streams](json-output.md), which validate one line at a time, this one validates the
 document as a unit.
+
+### Narrowing the catalog
+
+`--task <type>` restricts the `tasks` array to the types you name, and is repeatable:
+
+```bash
+docket schema --task dokku_config --task dokku_domains | jq -r '.tasks[].type'
+```
+
+The document is unchanged in every other respect: the same `version`, the same `tasks` array, and
+each entry byte-identical to its form in the whole catalog. The published JSON Schema validates a
+narrowed document as it validates a full one, so a consumer parses one format either way and
+nothing has to change for a consumer that never passes the flag.
+
+Types are selected by registry key, matched exactly and case-sensitively, in any order - the array
+still comes back sorted by `type`. Naming one type twice emits it once, since the document is a
+set keyed by type. An unknown type exits non-zero and names the closest registered one, the
+way an unknown task type in a recipe does; it is not an empty `tasks` array, which would read as
+"docket has no such task" rather than "you typed it wrong".
 
 ## Versioning
 
@@ -190,10 +210,12 @@ them.
 
 ## Stability
 
-- Tasks are sorted by `type`; properties by `name`; dynamic families by `prefix`.
+- Tasks are sorted by `type`, including when `--task` narrows the catalog, so the output never
+  depends on the order the flags were given; properties by `name`; dynamic families by `prefix`.
 - Fields, identity keys, requirements and choices keep declaration order, because that order is
   meaningful.
-- Two runs of the same binary produce byte-identical output.
+- Two runs of the same binary produce byte-identical output, for the whole catalog and for any
+  `--task` selection.
 
 ## See also
 

--- a/tasks/catalog.go
+++ b/tasks/catalog.go
@@ -91,14 +91,15 @@ const (
 	PropertyScopeGlobal = "global"
 )
 
-// TaskCatalog is the machine-readable description of every registered task
-// type. It is what `docket schema` emits.
+// TaskCatalog is the machine-readable description of a set of registered task
+// types. It is what `docket schema` emits.
 type TaskCatalog struct {
 	// Version is CatalogVersion. Consumers should branch on it so a future
 	// schema change does not silently break them.
 	Version int `json:"version"`
 
-	// Tasks are every registered task type, sorted by Type.
+	// Tasks are the requested task types - every registered one unless the
+	// caller narrowed the selection - sorted by Type.
 	Tasks []TaskSchema `json:"tasks"`
 }
 
@@ -355,15 +356,43 @@ func buildPropertySchema(table PropertyTable) PropertySchema {
 }
 
 // Catalog returns the catalog for every registered task, sorted by type key.
-//
-// The error comes from Examples(), which yaml-marshals each example struct.
-// Nothing else here can fail.
 func Catalog() (TaskCatalog, error) {
-	names := make([]string, 0, len(RegisteredTasks))
-	for name := range RegisteredTasks {
-		names = append(names, name)
+	return CatalogFor(nil)
+}
+
+// CatalogFor returns the catalog narrowed to typeKeys, sorted by type key. A
+// nil or empty selection means every registered task, so the whole catalog and
+// a narrowed one are the same code path rather than two that can drift.
+//
+// Sorting is by type key whatever order the keys arrived in, which is what lets
+// a narrowed catalog be diffed against a full one and makes two runs of the
+// same selection byte-identical. Duplicates collapse: the document is a set
+// keyed by type, so naming a type twice is not an error.
+//
+// An unregistered key is an error rather than a silently smaller document - a
+// caller asking for a type that does not exist wants to know. Keys are checked
+// in the order given, so the message names the first one the caller wrote, and
+// all of them are checked before any schema is built.
+//
+// The other error comes from Examples(), which yaml-marshals each example
+// struct. Nothing else here can fail.
+func CatalogFor(typeKeys []string) (TaskCatalog, error) {
+	names := RegisteredTaskNames()
+	if len(typeKeys) > 0 {
+		seen := make(map[string]bool, len(typeKeys))
+		names = make([]string, 0, len(typeKeys))
+		for _, key := range typeKeys {
+			if _, ok := RegisteredTasks[key]; !ok {
+				return TaskCatalog{}, fmt.Errorf("unknown task type %q", key)
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			names = append(names, key)
+		}
+		sort.Strings(names)
 	}
-	sort.Strings(names)
 
 	catalog := TaskCatalog{Version: CatalogVersion, Tasks: make([]TaskSchema, 0, len(names))}
 	for _, name := range names {
@@ -374,6 +403,18 @@ func Catalog() (TaskCatalog, error) {
 		catalog.Tasks = append(catalog.Tasks, schema)
 	}
 	return catalog, nil
+}
+
+// RegisteredTaskNames returns every registered task type, sorted. The result is
+// a fresh slice, so a caller may sort, filter or truncate it without disturbing
+// the registry.
+func RegisteredTaskNames() []string {
+	names := make([]string, 0, len(RegisteredTasks))
+	for name := range RegisteredTasks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // TaskSchemaOf describes one task. Exported so a caller holding a single

--- a/tasks/catalog_test.go
+++ b/tasks/catalog_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 )
 
-// catalogFor builds the catalog once for a test, failing fast if it cannot.
-func catalogFor(t *testing.T) TaskCatalog {
+// wholeCatalog builds the unnarrowed catalog once for a test, failing fast if
+// it cannot. Named to keep it clear of CatalogFor, which selects task types.
+func wholeCatalog(t *testing.T) TaskCatalog {
 	t.Helper()
 	catalog, err := Catalog()
 	if err != nil {
@@ -51,7 +52,7 @@ func fieldNames(fields []FieldSchema) []string {
 }
 
 func TestCatalogCoversEveryRegisteredTask(t *testing.T) {
-	catalog := catalogFor(t)
+	catalog := wholeCatalog(t)
 
 	if catalog.Version != CatalogVersion {
 		t.Errorf("Version = %d; want %d", catalog.Version, CatalogVersion)
@@ -76,7 +77,7 @@ func TestCatalogCoversEveryRegisteredTask(t *testing.T) {
 }
 
 func TestCatalogEveryTaskHasSynopsisAndFields(t *testing.T) {
-	for _, schema := range catalogFor(t).Tasks {
+	for _, schema := range wholeCatalog(t).Tasks {
 		if schema.Synopsis == "" {
 			t.Errorf("task %q has an empty synopsis", schema.Type)
 		}
@@ -128,7 +129,7 @@ func TestCatalogFieldTypesAreKnown(t *testing.T) {
 		}
 	}
 
-	for _, schema := range catalogFor(t).Tasks {
+	for _, schema := range wholeCatalog(t).Tasks {
 		check(t, schema.Type, schema.Fields)
 	}
 }
@@ -138,7 +139,7 @@ func TestCatalogFieldTypesAreKnown(t *testing.T) {
 // carrying a default is filled in before the zero-check runs, and so is never
 // really required no matter what its required tag says.
 func TestCatalogRequiredMatchesTags(t *testing.T) {
-	catalog := catalogFor(t)
+	catalog := wholeCatalog(t)
 	for _, schema := range catalog.Tasks {
 		rt := taskStructType(RegisteredTasks[schema.Type])
 		for _, field := range schema.Fields {
@@ -166,7 +167,7 @@ func TestCatalogRequiredMatchesTags(t *testing.T) {
 // echoes a recipe has to know that a HttpAuthUser's password is a secret, and
 // that fact lives on the element struct rather than on the task.
 func TestCatalogSensitiveMatchesTags(t *testing.T) {
-	catalog := catalogFor(t)
+	catalog := wholeCatalog(t)
 
 	var check func(t *testing.T, where string, rt reflect.Type, fields []FieldSchema)
 	check = func(t *testing.T, where string, rt reflect.Type, fields []FieldSchema) {
@@ -206,7 +207,7 @@ func TestCatalogSensitiveMatchesTags(t *testing.T) {
 // half also guards the two yaml-name helpers staying in agreement: a key hidden
 // behind `yaml:"-"` would be in Identity.Keys but absent from Fields.
 func TestCatalogIdentityMatchesTaskIdentity(t *testing.T) {
-	for _, schema := range catalogFor(t).Tasks {
+	for _, schema := range wholeCatalog(t).Tasks {
 		task := RegisteredTasks[schema.Type]
 
 		if want := IdentityKeyNames(task); !reflect.DeepEqual(schema.Identity.Keys, want) {
@@ -238,7 +239,7 @@ func TestCatalogIdentityMatchesTaskIdentity(t *testing.T) {
 }
 
 func TestCatalogSupportMatchesDeclarations(t *testing.T) {
-	for _, schema := range catalogFor(t).Tasks {
+	for _, schema := range wholeCatalog(t).Tasks {
 		task := RegisteredTasks[schema.Type]
 		if want, _ := TaskExportSupport(task); schema.Export != want {
 			t.Errorf("%s Export = %+v; want %+v", schema.Type, schema.Export, want)
@@ -256,7 +257,7 @@ func TestCatalogSupportMatchesDeclarations(t *testing.T) {
 // list of structs, a dict of scalars, a dict of anything, and a *bool whose
 // default documents a runtime coercion rather than a value the loader writes.
 func TestCatalogFieldShapes(t *testing.T) {
-	catalog := catalogFor(t)
+	catalog := wholeCatalog(t)
 
 	ports := fieldFor(t, schemaFor(t, catalog, "dokku_ports").Fields, "port_mappings")
 	if ports.Type != TypeList || ports.Identity != IdentityRoleCollection {
@@ -322,7 +323,7 @@ func TestCatalogFieldShapes(t *testing.T) {
 // TestCatalogPropertySchemaMatchesTable checks the published property list
 // against the runtime table each task actually validates and probes with.
 func TestCatalogPropertySchemaMatchesTable(t *testing.T) {
-	for _, schema := range catalogFor(t).Tasks {
+	for _, schema := range wholeCatalog(t).Tasks {
 		table, declared := TaskPropertyTable(RegisteredTasks[schema.Type])
 		if !declared {
 			if schema.PropertySchema != nil {
@@ -393,7 +394,7 @@ func TestCatalogPropertySchemaMatchesTable(t *testing.T) {
 // TestCatalogPropertySchemaSpotChecks pins the two ends of the range: a table
 // whose properties are split across scopes, and one with a dynamic family.
 func TestCatalogPropertySchemaSpotChecks(t *testing.T) {
-	catalog := catalogFor(t)
+	catalog := wholeCatalog(t)
 
 	apps := schemaFor(t, catalog, "dokku_apps_property").PropertySchema
 	if apps == nil {
@@ -543,4 +544,114 @@ func sliceOrMapElem(t reflect.Type) reflect.Type {
 		return t.Elem()
 	}
 	return t
+}
+
+// catalogTypes returns the type keys a catalog carries, in document order.
+func catalogTypes(catalog TaskCatalog) []string {
+	out := make([]string, 0, len(catalog.Tasks))
+	for _, schema := range catalog.Tasks {
+		out = append(out, schema.Type)
+	}
+	return out
+}
+
+// TestCatalogForSelectsNamedTasks covers the narrowing #459 added: only the
+// named types come back, and they come back sorted whatever order they were
+// asked for, so a selection is byte-stable and diffs against the full catalog.
+func TestCatalogForSelectsNamedTasks(t *testing.T) {
+	catalog, err := CatalogFor([]string{"dokku_domains", "dokku_config"})
+	if err != nil {
+		t.Fatalf("CatalogFor: %v", err)
+	}
+	if catalog.Version != CatalogVersion {
+		t.Errorf("Version = %d; want %d", catalog.Version, CatalogVersion)
+	}
+	want := []string{"dokku_config", "dokku_domains"}
+	if got := catalogTypes(catalog); !reflect.DeepEqual(got, want) {
+		t.Errorf("types = %v; want %v", got, want)
+	}
+}
+
+// TestCatalogForWithNoSelectionMatchesCatalog pins that Catalog() is the same
+// code path, so the whole catalog cannot drift from a narrowed one.
+func TestCatalogForWithNoSelectionMatchesCatalog(t *testing.T) {
+	full := wholeCatalog(t)
+	for _, selection := range [][]string{nil, {}} {
+		catalog, err := CatalogFor(selection)
+		if err != nil {
+			t.Fatalf("CatalogFor(%v): %v", selection, err)
+		}
+		if !reflect.DeepEqual(catalog, full) {
+			t.Errorf("CatalogFor(%v) does not match Catalog()", selection)
+		}
+	}
+}
+
+// TestCatalogForDedupesRepeatedTypes: the document is a set keyed by type, so
+// naming one twice - a shell loop, say - emits it once rather than failing.
+func TestCatalogForDedupesRepeatedTypes(t *testing.T) {
+	catalog, err := CatalogFor([]string{"dokku_config", "dokku_config", "dokku_config"})
+	if err != nil {
+		t.Fatalf("CatalogFor: %v", err)
+	}
+	if got := catalogTypes(catalog); !reflect.DeepEqual(got, []string{"dokku_config"}) {
+		t.Errorf("types = %v; want [dokku_config]", got)
+	}
+}
+
+// TestCatalogForRejectsUnknownType: an unregistered key is an error rather
+// than a silently smaller document, which would look like a complete answer.
+func TestCatalogForRejectsUnknownType(t *testing.T) {
+	catalog, err := CatalogFor([]string{"dokku_config", "dokku_confg"})
+	if err == nil {
+		t.Fatal("expected an error for an unregistered task type")
+	}
+	if !strings.Contains(err.Error(), `unknown task type "dokku_confg"`) {
+		t.Errorf("err = %q; want it to name the unknown type", err)
+	}
+	if !reflect.DeepEqual(catalog, TaskCatalog{}) {
+		t.Errorf("catalog = %+v; want the zero value on error", catalog)
+	}
+}
+
+// TestCatalogForEntriesMatchTheFullCatalog proves narrowing is a projection,
+// not a re-derivation: a consumer reading one task out of a narrowed catalog
+// sees exactly what it would have seen in the whole one.
+func TestCatalogForEntriesMatchTheFullCatalog(t *testing.T) {
+	full := wholeCatalog(t)
+	selection := []string{"dokku_config", "dokku_domains", "dokku_apps_property"}
+	catalog, err := CatalogFor(selection)
+	if err != nil {
+		t.Fatalf("CatalogFor: %v", err)
+	}
+	for _, schema := range catalog.Tasks {
+		if want := schemaFor(t, full, schema.Type); !reflect.DeepEqual(schema, want) {
+			t.Errorf("narrowed entry for %q differs from the full catalog's", schema.Type)
+		}
+	}
+}
+
+// TestRegisteredTaskNamesIsSortedAndComplete guards the helper the catalog,
+// the --task validator and the shell completion all read from.
+func TestRegisteredTaskNamesIsSortedAndComplete(t *testing.T) {
+	names := RegisteredTaskNames()
+	if len(names) != len(RegisteredTasks) {
+		t.Errorf("got %d names; registry has %d", len(names), len(RegisteredTasks))
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("names are not sorted: %v", names)
+	}
+	for _, name := range names {
+		if _, ok := RegisteredTasks[name]; !ok {
+			t.Errorf("name %q is not in the registry", name)
+		}
+	}
+
+	// The result is a copy, so a caller may sort or truncate it in place.
+	if len(names) > 0 {
+		names[0] = "mutated"
+		if again := RegisteredTaskNames(); again[0] == "mutated" {
+			t.Error("RegisteredTaskNames returned a slice aliasing shared state")
+		}
+	}
 }

--- a/tests/bats/completion.bats
+++ b/tests/bats/completion.bats
@@ -72,3 +72,12 @@ setup() {
   assert_output --partial 'tasks.yml'
   refute_output --partial 'notes.txt'
 }
+
+@test "docket schema --task completes registered task types (#459)" {
+  cd "$BATS_TEST_TMPDIR"
+  export COMP_LINE='docket schema --task '
+  run "$(docket_bin)" schema --task
+  assert_success
+  assert_output --partial 'dokku_config'
+  assert_output --partial 'dokku_domains'
+}

--- a/tests/bats/schema.bats
+++ b/tests/bats/schema.bats
@@ -137,3 +137,46 @@ setup() {
   assert_failure
   assert_output --partial "takes no arguments"
 }
+
+@test "docket schema --task narrows the catalog to the named types" {
+  run "$(docket_bin)" schema --task dokku_config --task dokku_domains
+  assert_success
+  echo "$output" | jq -e '.version == 1' >/dev/null || fail "expected version 1"
+  echo "$output" | jq -e '[.tasks[].type] == ["dokku_config", "dokku_domains"]' >/dev/null ||
+    fail "expected only the two named task types"
+}
+
+@test "docket schema --task keeps the document shape" {
+  run "$(docket_bin)" schema --task dokku_config
+  assert_success
+
+  # The narrowed document is the same shape as the whole catalog, so a
+  # consumer parses one format either way and the published JSON Schema
+  # keeps covering it.
+  echo "$output" | jq -e 'has("version") and has("tasks")' >/dev/null ||
+    fail "narrowed output is missing version or tasks"
+  echo "$output" |
+    jq -e 'all(.tasks[]; (.type | length > 0) and (.synopsis | length > 0) and (.fields | length > 0))' >/dev/null ||
+    fail "the narrowed entry is missing its type, synopsis, or fields"
+}
+
+@test "docket schema --task ignores the order the flags are given" {
+  "$(docket_bin)" schema --task dokku_config --task dokku_domains >"$BATS_TEST_TMPDIR/forward.json"
+  "$(docket_bin)" schema --task dokku_domains --task dokku_config >"$BATS_TEST_TMPDIR/reverse.json"
+  run diff "$BATS_TEST_TMPDIR/forward.json" "$BATS_TEST_TMPDIR/reverse.json"
+  assert_success
+}
+
+@test "docket schema --task rejects an unknown task type" {
+  run "$(docket_bin)" schema --task dokku_confg
+  assert_failure
+  assert_output --partial 'did you mean "dokku_config"'
+}
+
+@test "docket schema --task writes a narrowed catalog to a file" {
+  run "$(docket_bin)" schema --task dokku_config --output "$BATS_TEST_TMPDIR/catalog.json"
+  assert_success
+  assert_output ""
+  jq -e '(.tasks | length) == 1' "$BATS_TEST_TMPDIR/catalog.json" >/dev/null ||
+    fail "the written file is not narrowed to one task"
+}


### PR DESCRIPTION
`docket schema` emitted the whole task catalog, which is a large document when the question is about one task. `--task <type>` is repeatable and narrows the `tasks` array to the types named. The document keeps its shape, a `version` and a `tasks` array, so a consumer parses one format either way and the published JSON Schema covers both; each entry is byte-identical to its form in the whole catalog. Tasks stay sorted by `type` whatever order the flags came in, and naming one twice emits it once. An unknown type exits non-zero and names the closest registered one, the way an unknown task type in a recipe address does, rather than emitting an empty array that would read as "docket has no such task".

```console
$ docket schema --task dokku_config --task dokku_domains | jq -r '.tasks[].type'
dokku_config
dokku_domains

$ docket schema --task dokku_confg
 !     unknown task type "dokku_confg" (did you mean "dokku_config"?)
```

Since a bare task type is the mistake the new flag invites, `docket schema dokku_app` now points at `--task` instead of leaving the reader at a dead end. `--task` also completes to the registered task types in the shell.

Fixes #459
