### PR TITLE
fix: list a rescue when: on failed_task as unknown

### DIFF
--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -28,27 +28,30 @@ type listTasksOptions struct {
 // FilterByTags and renders block / rescue / always children indented
 // under their group's line.
 //
-// when: predicates are evaluated against the inputs only - registered
-// values from prior tasks are not available because no task has run.
-// Predicates that reference `.registered.<name>` produce an [unknown]
-// marker since their truth value cannot be determined statically. All
-// other false predicates produce a [skipped] marker.
+// when: predicates are evaluated against the inputs only - values a
+// prior task registers, and the failing block child a rescue branches
+// on, are not available because no task has run. Predicates that
+// reference those produce an [unknown] marker since their truth value
+// cannot be determined statically. All other false predicates produce a
+// [skipped] marker.
 //
-// A predicate that *errors* is treated differently depending on where it
-// sits. A play-level when: is evaluated against exactly the context the
-// apply / plan loops build for it, so an error here is the same error
-// they would hit: the listing still renders in full, and the exit code
-// is 1. A task-level when: sees a reduced context (no result, no
-// registered, no failed_task), so an error there may be an artifact of
-// listing offline rather than a broken predicate - it renders [when?]
-// and leaves the exit code alone. See evaluateListWhen.
+// A predicate that *errors* fails the listing with exit code 1, whether
+// it sits on a play or on a task: with the undecidable references sorted
+// into [unknown] first, what is left is a predicate that errors the same
+// way at run time. A task carries the failure as its [when?] marker; a
+// play carries it in its header, and its tasks are left unlisted.
+//
+// The one exception is reachability. A task under a group that itself
+// rendered [skipped], [unknown] or [when?] is never evaluated by a run,
+// so its own [when?] prints but leaves the exit code alone - the same
+// reason a skipped play's tasks are not walked at all.
 func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
-	// playWhenError records that at least one play predicate failed to
-	// evaluate. The walk is not short-circuited - every remaining play is
+	// whenError records that at least one predicate failed to evaluate.
+	// The walk is not short-circuited - every remaining play and task is
 	// still listed, and the failure is carried by the exit code once the
 	// listing is complete, matching the way the plan loop finishes before
 	// returning 1.
-	playWhenError := false
+	whenError := false
 	for _, play := range opts.plays {
 		if play.IsFileLevel() {
 			continue
@@ -57,7 +60,7 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 			playCtx := buildEnvelopeExprContext(buildPlayWhenContext(opts.context, opts.fileLevelKeys, opts.userSet))
 			ok, err := tasks.EvalBool(play.WhenProgram(), playCtx)
 			if err != nil {
-				playWhenError = true
+				whenError = true
 				if opts.jsonOut {
 					emitListJSON(ui, map[string]interface{}{
 						"type":   "play_skipped",
@@ -89,24 +92,48 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 			ui.Output(fmt.Sprintf("==> Play: %s", play.Name))
 		}
 
-		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(opts.context, play.Inputs, opts.userSet))
+		rc := listRenderContext{
+			ui:          ui,
+			playName:    play.Name,
+			playExprCtx: buildEnvelopeExprContext(tasks.BuildPerPlayContext(opts.context, play.Inputs, opts.userSet)),
+			jsonOut:     opts.jsonOut,
+		}
 
 		idx := 0
 		for _, name := range tasks.FilterByTags(play.Tasks, opts.includes, opts.skips) {
-			renderListEnvelope(ui, play.Name, play.Tasks.GetEnvelope(name), idx, "", 0, playExprCtx, opts.jsonOut)
+			if renderListEnvelope(rc, play.Tasks.GetEnvelope(name), idx, "", 0, true) {
+				whenError = true
+			}
 			idx++
 		}
 	}
-	if playWhenError {
+	if whenError {
 		return 1
 	}
 	return 0
+}
+
+// listRenderContext carries the values renderListEnvelope needs that do
+// not change as it recurses into a group's children: the output sink,
+// the play the walk is inside, the expr context every predicate in that
+// play evaluates against, and the output mode.
+type listRenderContext struct {
+	ui          cli.Ui
+	playName    string
+	playExprCtx map[string]interface{}
+	jsonOut     bool
 }
 
 // renderListEnvelope renders one envelope's line and, for a group,
 // recursively renders its block / rescue / always children indented one
 // level. indent is the leading-space count; phase labels group children
 // (matching the executor's phase decoration).
+//
+// reachable reports whether a run would evaluate this envelope's when:
+// at all - false once an ancestor group's own predicate was skipped or
+// could not be resolved. Returns whether a [when?] was rendered at a
+// reachable position anywhere in this subtree, which is what fails the
+// listing.
 //
 // The displayed label is the envelope name as-is. Before #427 an unnamed task
 // carried a random `task #N <hex>` name, and this function substituted the
@@ -116,16 +143,14 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 // unnamed task after the resource it addresses, so there is nothing to
 // substitute.
 func renderListEnvelope(
-	ui cli.Ui,
-	playName string,
+	rc listRenderContext,
 	env *tasks.TaskEnvelope,
 	index int,
 	phase string,
 	indent int,
-	playExprCtx map[string]interface{},
-	jsonOut bool,
-) {
-	skipMarker := evaluateListWhen(env, playExprCtx)
+	reachable bool,
+) bool {
+	skipMarker := evaluateListWhen(env, rc.playExprCtx, phase)
 	display := env.Name
 	deprecation := ""
 	var probe tasks.ProbeSupport
@@ -134,10 +159,10 @@ func renderListEnvelope(
 		probe, _ = tasks.TaskProbeSupport(env.Task)
 	}
 
-	if jsonOut {
+	if rc.jsonOut {
 		ev := map[string]interface{}{
 			"type":  "list_task",
-			"play":  playName,
+			"play":  rc.playName,
 			"name":  display,
 			"index": index,
 		}
@@ -175,7 +200,7 @@ func renderListEnvelope(
 				ev["loop_item"] = env.LoopItem
 			}
 		}
-		emitListJSON(ui, ev)
+		emitListJSON(rc.ui, ev)
 	} else {
 		var b strings.Builder
 		if indent > 0 {
@@ -211,39 +236,51 @@ func renderListEnvelope(
 		if len(env.Tags) > 0 {
 			b.WriteString(fmt.Sprintf("  [tags=%s]", strings.Join(env.Tags, ",")))
 		}
-		ui.Output(b.String())
+		rc.ui.Output(b.String())
 	}
 
+	whenError := reachable && skipMarker == "when_error"
+
 	if env.IsGroup() {
-		for i, child := range env.Block {
-			renderListEnvelope(ui, playName, child, i, "block", indent+1, playExprCtx, jsonOut)
-		}
-		for i, child := range env.Rescue {
-			renderListEnvelope(ui, playName, child, i, "rescue", indent+1, playExprCtx, jsonOut)
-		}
-		for i, child := range env.Always {
-			renderListEnvelope(ui, playName, child, i, "always", indent+1, playExprCtx, jsonOut)
+		// A group whose own predicate did not resolve true stands between
+		// its children and any run, so their predicates are listed but no
+		// longer count toward the exit code.
+		childReachable := reachable && skipMarker == ""
+		for _, phased := range []struct {
+			name     string
+			children []*tasks.TaskEnvelope
+		}{
+			{"block", env.Block},
+			{"rescue", env.Rescue},
+			{"always", env.Always},
+		} {
+			for i, child := range phased.children {
+				if renderListEnvelope(rc, child, i, phased.name, indent+1, childReachable) {
+					whenError = true
+				}
+			}
 		}
 	}
+	return whenError
 }
 
 // evaluateListWhen returns the marker --list-tasks should print for
-// env's when: predicate. Returns "" when no predicate is present or it
-// evaluates true; "skipped" when it evaluates false; "unknown" when the
-// predicate references `.registered.<name>` (we can't decide without
-// running prior tasks); "when_error" when the predicate compiles but
-// errors at evaluation time against the inputs context.
+// env's when: predicate, where phase is the envelope's position in its
+// parent group ("block", "rescue", "always", or "" at the top level).
+// Returns "" when no predicate is present or it evaluates true;
+// "skipped" when it evaluates false; "unknown" when the predicate
+// references a value only a run can supply; "when_error" when the
+// predicate compiles but errors at evaluation time against the inputs
+// context.
 //
-// "when_error" is a marker only - it does not fail the listing the way a
-// play-level when: error does. The context here is missing `result` and
-// `failed_task`, so a predicate that is valid at run time can error when
-// evaluated offline: a rescue child written the documented way,
-// `when: 'failed_task.Stderr contains "..."'`, is `nil.Stderr` here.
-func evaluateListWhen(env *tasks.TaskEnvelope, playExprCtx map[string]interface{}) string {
+// Once the undecidable references are sorted into "unknown", a
+// "when_error" is a predicate that errors at run time too, so it fails
+// the listing - see renderListTasks for the reachability caveat.
+func evaluateListWhen(env *tasks.TaskEnvelope, playExprCtx map[string]interface{}, phase string) string {
 	if !env.HasWhen() {
 		return ""
 	}
-	if whenReferencesRegistered(env.When) {
+	if whenReferencesRuntimeValue(env.When, runtimeWhenVars(phase)) {
 		return "unknown"
 	}
 	ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env, nil, nil, nil))
@@ -256,13 +293,56 @@ func evaluateListWhen(env *tasks.TaskEnvelope, playExprCtx map[string]interface{
 	return ""
 }
 
-// whenReferencesRegistered does a substring check against the raw expr
-// source for `registered.` references. The check is intentionally
-// conservative: any predicate that mentions `registered` is reported as
-// [unknown] in --list-tasks rather than evaluated against an empty map
-// (which would yield a misleading skip).
-func whenReferencesRegistered(src string) bool {
-	return strings.Contains(src, "registered")
+// registeredOnlyWhenVars and rescueRuntimeWhenVars are the expr
+// identifiers --list-tasks cannot supply but a run can. `registered` is
+// bound wherever a prior task has registered a value. `failed_task` is
+// bound only for a rescue child (commands/apply.go, commands/plan.go):
+// a group nested under rescue: does not pass it down to its own block:
+// children, so anywhere else it is nil at run time too and a predicate
+// that dereferences it is genuinely broken.
+var (
+	registeredOnlyWhenVars = map[string]bool{"registered": true}
+	rescueRuntimeWhenVars  = map[string]bool{"registered": true, "failed_task": true}
+)
+
+// runtimeWhenVars returns the run-time-only identifiers in scope for an
+// envelope sitting in the given group phase.
+func runtimeWhenVars(phase string) map[string]bool {
+	if phase == "rescue" {
+		return rescueRuntimeWhenVars
+	}
+	return registeredOnlyWhenVars
+}
+
+// whenReferencesRuntimeValue reports whether src references any of the
+// named run-time-only values, which makes its truth value undecidable
+// offline. Such a predicate is reported as [unknown] rather than
+// evaluated against a context that does not bind it - evaluating would
+// yield either a misleading skip (`len(registered) > 0`) or a
+// misleading error (`failed_task.Stderr contains "..."`).
+//
+// The check runs against the parsed identifiers so an input named
+// `registered_at`, a string literal "registered", or a field access
+// `x.failed_task` is not mistaken for a reference. A predicate that
+// reaches here has already compiled at load, so the parse failure branch
+// is not reachable through the CLI; it falls back to a substring match,
+// which is never less conservative than matching identifiers.
+func whenReferencesRuntimeValue(src string, runtime map[string]bool) bool {
+	idents, err := tasks.PredicateIdentifiers(src)
+	if err != nil {
+		for name := range runtime {
+			if strings.Contains(src, name) {
+				return true
+			}
+		}
+		return false
+	}
+	for name := range runtime {
+		if idents[name] {
+			return true
+		}
+	}
+	return false
 }
 
 // emitListJSON serialises ev as a single JSON-lines event on the Ui's

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -221,6 +221,60 @@ func TestApplyListTasksWhenRegisteredShowsUnknown(t *testing.T) {
 	}
 }
 
+// TestApplyListTasksRescueWhenFailedTaskShowsUnknown is #462: a rescue
+// child branching on the failing block child, the form
+// docs/task-envelope.md documents, is undecidable offline for the same
+// reason a `.registered.<name>` reference is - the executor binds
+// `failed_task` only once a block child has failed. It renders
+// [unknown], not the [when?] that reports a valid recipe as broken.
+func TestApplyListTasksRescueWhenFailedTaskShowsUnknown(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      block:
+        - name: create
+          dokku_stub: { key: a }
+      rescue:
+        - name: report
+          when: 'failed_task.Stderr contains "already exists"'
+          dokku_stub: { key: b }
+`)
+	stdout, stderr, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[unknown] [rescue] report") {
+		t.Errorf("expected '[unknown] [rescue] report' line; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[when?]") {
+		t.Errorf("a rescue predicate on failed_task must not render [when?]; got:\n%s", stdout)
+	}
+}
+
+// TestApplyListTasksFailedTaskOutsideRescueShowsWhenError is the other
+// half of #462. `failed_task` is bound for a rescue child and nowhere
+// else - not for a top-level task, and not for a block child of a group
+// that is itself a rescue child - so dereferencing it there errors at
+// run time exactly as it does here. That is a broken predicate, so it
+// renders [when?] and fails the listing.
+func TestApplyListTasksFailedTaskOutsideRescueShowsWhenError(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: misplaced
+      when: 'failed_task.Stderr contains "already exists"'
+      dokku_stub: { key: a }
+`)
+	stdout, stderr, exit := runApply(t, path, "--list-tasks")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[when?]   misplaced") {
+		t.Errorf("expected the [when?] marker outside rescue scope; got:\n%s", stdout)
+	}
+}
+
 // TestApplyListTasksGroupRendersChildren pins the block / rescue /
 // always rendering: the group's own name appears once, followed by
 // each child indented with the [block] / [rescue] / [always] phase
@@ -319,9 +373,16 @@ func TestListTasksJSONMatchesSchema(t *testing.T) {
           dokku_stub: { key: a }
       rescue:
         - name: in rescue
+          when: 'failed_task.Stderr contains "already exists"'
           dokku_stub: { key: a }
       always:
         - name: in always
+          dokku_stub: { key: a }
+    - name: unreachable gate
+      when: 'false'
+      block:
+        - name: broken child
+          when: '[][0] == 1'
           dokku_stub: { key: a }
 `)
 
@@ -339,6 +400,7 @@ func TestListTasksJSONMatchesSchema(t *testing.T) {
 		`"loop_index":`,
 		`"skipped":true`,
 		`"unknown":true`,
+		`"when_error":true`,
 		`"deprecated":true`,
 		`"probe":"unsupported"`,
 		`"probe":"partial"`,
@@ -456,18 +518,16 @@ func TestListTasksPlayWhenErrorJSONExitsOne(t *testing.T) {
 	}
 }
 
-// TestListTasksTaskWhenErrorDoesNotAffectExit pins the deliberate
-// asymmetry with the two tests above: a *task*-level when: that errors
-// renders [when?] and leaves the exit code at 0.
+// TestListTasksTaskWhenErrorExitsOne pins that a *task*-level when: that
+// errors fails the listing the same way a play-level one does. #429 left
+// this at 0 because a rescue child branching on `failed_task` errored
+// here while being valid at run time; #462 sorted that case into
+// [unknown], so what reaches evaluation now is a predicate that errors
+// whenever it is reached.
 //
-// The task context here is missing `result` and `failed_task`, so an
-// error can be an artifact of listing offline rather than a broken
-// predicate - a rescue child written the way docs/task-envelope.md
-// documents, `when: 'failed_task.Stderr contains "..."'`, evaluates
-// nil.Stderr and errors here while being valid at run time. #462 tracks
-// rendering that case as [unknown] instead; either way it must not fail
-// the listing.
-func TestListTasksTaskWhenErrorDoesNotAffectExit(t *testing.T) {
+// As with a play, the walk is not short-circuited: the rest of the play
+// still lists and only the exit code carries the failure.
+func TestListTasksTaskWhenErrorExitsOne(t *testing.T) {
 	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
@@ -479,14 +539,87 @@ func TestListTasksTaskWhenErrorDoesNotAffectExit(t *testing.T) {
 `)
 
 	stdout, stderr, exit := runApply(t, path, "--list-tasks")
-	if exit != 0 {
-		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
 	}
 	if !strings.Contains(stdout, "[when?]   broken predicate") {
 		t.Errorf("expected the [when?] marker on the erroring task; got:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "plain") {
 		t.Errorf("the rest of the play should still be listed; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksTaskWhenErrorUnderUnreachableGroupDoesNotAffectExit is the
+// reachability caveat on the test above. A run never evaluates the
+// children of a group whose own predicate resolved false or could not be
+// resolved, so a broken child predicate there still renders [when?] but
+// leaves the exit code alone - the same reason a skipped play's tasks are
+// not walked at all.
+func TestListTasksTaskWhenErrorUnderUnreachableGroupDoesNotAffectExit(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		groupWhen string
+		marker    string
+	}{
+		{"skipped group", `'false'`, "[skipped] gate"},
+		{"unknown group", `'registered.earlier.Changed'`, "[unknown] gate"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer stubReset()
+			path := writeTasksFile(t, `---
+- tasks:
+    - name: gate
+      when: `+tc.groupWhen+`
+      block:
+        - name: broken child
+          when: '[][0] == 1'
+          dokku_stub: { key: a }
+`)
+
+			stdout, stderr, exit := runApply(t, path, "--list-tasks")
+			if exit != 0 {
+				t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+			}
+			if !strings.Contains(stdout, tc.marker) {
+				t.Errorf("expected %q on the group line; got:\n%s", tc.marker, stdout)
+			}
+			if !strings.Contains(stdout, "[when?]   [block] broken child") {
+				t.Errorf("the unreachable child should still render [when?]; got:\n%s", stdout)
+			}
+		})
+	}
+}
+
+// TestWhenReferencesRuntimeValue drives the reference check directly.
+// The identifier walk is what keeps an input named `registered_at`, a
+// quoted "registered", or a field access `x.failed_task` from being
+// mistaken for the run-time values, and `failed_task` counts only in
+// rescue scope. The last case is the substring fallback, which the CLI
+// cannot reach because every recipe predicate has already compiled.
+func TestWhenReferencesRuntimeValue(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		src   string
+		phase string
+		want  bool
+	}{
+		{"registered lookup", `registered.first.Changed`, "", true},
+		{"registered lookup in rescue", `registered.first.Changed`, "rescue", true},
+		{"failed_task in rescue", `failed_task.Stderr contains "x"`, "rescue", true},
+		{"failed_task outside rescue", `failed_task.Stderr contains "x"`, "", false},
+		{"failed_task in block", `failed_task.Stderr contains "x"`, "block", false},
+		{"input named registered_at", `registered_at != ""`, "rescue", false},
+		{"registered as a string literal", `env == "registered"`, "rescue", false},
+		{"failed_task as a field name", `payload.failed_task != nil`, "rescue", false},
+		{"unparseable falls back to substring", `registered ==`, "", true},
+		{"unparseable substring misses", `env ==`, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := whenReferencesRuntimeValue(tc.src, runtimeWhenVars(tc.phase)); got != tc.want {
+				t.Errorf("whenReferencesRuntimeValue(%q, phase %q) = %v, want %v", tc.src, tc.phase, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -278,7 +278,7 @@ recipe" is the same outcome either way. Pass `--detailed-exitcode` when the call
 win over changes, matching `plan`. An error swallowed by
 [`ignore_errors`](task-envelope.md#ignore_errors-continue-past-a-failure) is not an error for this
 purpose. `--list-tasks` returns before any task runs, so it never exits `2`; it exits `1` when the
-recipe cannot be loaded or a play `when:` fails to evaluate, and `0` otherwise.
+recipe cannot be loaded or a `when:` fails to evaluate, and `0` otherwise.
 
 | Flag | Effect |
 |------|--------|
@@ -339,16 +339,29 @@ $ docket apply --list-tasks
 [2] dokku_docker_options[app=api,phase=deploy,option=--memory=512m]
 ```
 
-A `when:` that is false against the inputs renders as `[skipped]`. A `when:` that references
-`.registered.<name>` cannot be decided without running earlier tasks, so it renders as `[unknown]`
-rather than guessing. A task `when:` that fails to evaluate renders as `[when?]` and does not change
-the exit code: the listing evaluates it without the `result` and `failed_task` values a real run
-would supply, so an error there can be an artifact of listing offline rather than a broken
-predicate.
+A `when:` that is false against the inputs renders as `[skipped]`. A `when:` whose truth value
+depends on a value only a run can supply renders as `[unknown]` rather than guessing: one that
+references `.registered.<name>` cannot be decided without running earlier tasks, and a
+[`rescue:`](task-envelope.md#block--rescue--always-structured-error-handling) child that branches on
+`failed_task` cannot be decided without a block child having failed.
 
-A play-level `when:` is different, because it is resolved against exactly the context `apply` and
-`plan` build for it. One that fails to evaluate is the same failure a run would hit, so the play's
-header carries the error, its tasks are left unlisted, and the command exits `1`:
+Everything else is evaluated, and a `when:` that fails to evaluate renders as `[when?]` and exits
+`1`. Once the undecidable references are set aside, a predicate that errors here errors the same way
+at run time - `failed_task` outside a `rescue:` child is `nil` during a real run too, so
+dereferencing it there is a broken predicate, not an artifact of listing offline.
+
+```text
+$ docket apply --list-tasks
+==> Play: api
+[when?]   gated
+[1] dokku apps:create api
+$ echo $?
+1
+```
+
+The walk is never short-circuited - every remaining task and play still lists, and the failure is
+carried by the exit code alone. A play-level `when:` that fails to evaluate is the same, except that
+the play's header carries the error and its tasks are left unlisted:
 
 ```text
 $ docket plan --list-tasks
@@ -361,7 +374,10 @@ $ echo $?
 1
 ```
 
-Every other play still lists - the failure is carried by the exit code, not by stopping the walk.
+The one exception is reachability. A run never evaluates the children of a group whose own `when:`
+rendered `[skipped]`, `[unknown]`, or `[when?]`, so a broken predicate underneath one still prints
+its `[when?]` marker but leaves the exit code alone - the same reason a skipped play's tasks are not
+listed at all.
 
 A task whose type is deprecated is marked `(deprecated)`. A task whose type cannot read its own
 state is marked `(never converges)`, and one that can read only part of it is marked

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -198,9 +198,10 @@ non-zero exit with empty stdout as a failure whose detail is on stderr, or run
 `docket validate --json` first to get the same problems as structured events.
 
 Do not read that the other way round: a non-zero exit does not imply empty stdout.
-`--list-tasks --json` exits `1` when a play `when:` fails to evaluate, and the stream is complete -
-the failure is a `play_skipped` event whose `reason` carries the `when error: <err>` form, followed
-by every remaining play's tasks.
+`--list-tasks --json` exits `1` when a `when:` fails to evaluate, and the stream is complete. For a
+play `when:`, the failure is a `play_skipped` event whose `reason` carries the `when error: <err>`
+form, followed by every remaining play's tasks. For a task `when:`, it is a `list_task` event
+carrying `"when_error": true`, followed by every remaining task.
 
 ## See also
 

--- a/docs/schemas/list-tasks-v1.schema.json
+++ b/docs/schemas/list-tasks-v1.schema.json
@@ -86,12 +86,12 @@
         "unknown": {
           "type": "boolean",
           "const": true,
-          "description": "The task's when: references a registered value, so it cannot be resolved without running."
+          "description": "The task's when: references a value only a run can supply - a registered value, or `failed_task` on a rescue child - so it cannot be resolved without running."
         },
         "when_error": {
           "type": "boolean",
           "const": true,
-          "description": "The task's when: failed to evaluate."
+          "description": "The task's when: failed to evaluate. The predicate errors at run time too, so the command exits 1 unless an ancestor group was itself skipped, unknown, or erroring."
         },
         "when": {
           "type": "string",

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -296,7 +296,10 @@ The rules:
   (`State != DesiredState`), or a `when:` / `failed_when:` predicate that errors at runtime.
 - `rescue:` children run, in order, only when a block child failed. They run with the failing
   child's result bound to `.failed_task`, so a rescue can branch on the cause:
-  `when: 'failed_task.Stderr contains "..."'`.
+  `when: 'failed_task.Stderr contains "..."'`. The binding reaches a rescue child and nothing else -
+  not a block child of a group that is itself a rescue child - so such a predicate belongs directly
+  under `rescue:`. [`--list-tasks`](command-reference.md#inspecting-and-resuming) renders it as
+  `[unknown]`, since offline there is no failing child to inspect.
 - `always:` children run unconditionally after `block:` / `rescue:`, even if a rescue itself errored.
 - The group's own envelope applies to the combined outcome: `register:` saves the post-rescue,
   post-always result, and `ignore_errors: true` on the group swallows any error that remains after

--- a/tasks/predicate.go
+++ b/tasks/predicate.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 
 	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/parser"
 	"github.com/expr-lang/expr/vm"
 )
 
@@ -39,6 +41,44 @@ func CompilePredicate(src string) (*vm.Program, error) {
 	}
 	actual, _ := programCache.LoadOrStore(src, prog)
 	return actual.(*vm.Program), nil
+}
+
+// PredicateIdentifiers returns the set of root identifiers src
+// references. Only the root of a lookup chain counts: `registered.first`
+// yields `registered`, because expr parses the `.first` half as a string
+// property rather than an identifier. A quoted "registered" is a string
+// literal and is likewise absent.
+//
+// Callers use this to tell whether a predicate depends on a value that
+// only exists while a recipe runs, which a substring match over the raw
+// source cannot do without also matching an input named `registered_at`
+// or a field access `x.failed_task`.
+//
+// Returns an error when src does not parse. A predicate reaching a
+// caller has already been through CompilePredicate, so in practice this
+// only fires for sources that never came from a loaded recipe.
+func PredicateIdentifiers(src string) (map[string]bool, error) {
+	tree, err := parser.Parse(src)
+	if err != nil {
+		return nil, err
+	}
+	v := &identifierCollector{names: map[string]bool{}}
+	ast.Walk(&tree.Node, v)
+	return v.names, nil
+}
+
+// identifierCollector is the ast.Visitor PredicateIdentifiers walks the
+// parse tree with, recording every identifier node it passes.
+type identifierCollector struct {
+	names map[string]bool
+}
+
+// Visit records node's value when it is an identifier and ignores every
+// other node type.
+func (c *identifierCollector) Visit(node *ast.Node) {
+	if ident, ok := (*node).(*ast.IdentifierNode); ok {
+		c.names[ident.Value] = true
+	}
 }
 
 // EvalBool runs prog against env and reports the truthiness of the

--- a/tasks/predicate_test.go
+++ b/tasks/predicate_test.go
@@ -330,3 +330,51 @@ func TestAggregateRegisteredEmptyAndSingle(t *testing.T) {
 		t.Errorf("Results[0] should mirror the single iteration; got %+v", got.Results[0])
 	}
 }
+
+// TestPredicateIdentifiers pins that only the root of a lookup chain is
+// reported. The callers that ask which run-time values a predicate
+// depends on rely on that distinction: an input named `registered_at`, a
+// quoted "registered", and a field access `x.failed_task` must not read
+// as references to `registered` / `failed_task`.
+func TestPredicateIdentifiers(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		src     string
+		want    []string
+		notWant []string
+	}{
+		{name: "registered lookup", src: `registered.first.Changed`, want: []string{"registered"}, notWant: []string{"first", "Changed"}},
+		{name: "failed_task lookup", src: `failed_task.Stderr contains "x"`, want: []string{"failed_task"}, notWant: []string{"Stderr", "x"}},
+		{name: "string literal", src: `env == "registered"`, want: []string{"env"}, notWant: []string{"registered"}},
+		{name: "distinct identifier", src: `registered_at != ""`, want: []string{"registered_at"}, notWant: []string{"registered"}},
+		{name: "field access", src: `payload.failed_task != nil`, want: []string{"payload"}, notWant: []string{"failed_task"}},
+		{name: "nested in a call", src: `len(registered) > 0`, want: []string{"registered"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PredicateIdentifiers(tc.src)
+			if err != nil {
+				t.Fatalf("PredicateIdentifiers(%q) err = %v", tc.src, err)
+			}
+			for _, name := range tc.want {
+				if !got[name] {
+					t.Errorf("PredicateIdentifiers(%q) should report %q; got %v", tc.src, name, got)
+				}
+			}
+			for _, name := range tc.notWant {
+				if got[name] {
+					t.Errorf("PredicateIdentifiers(%q) should not report %q; got %v", tc.src, name, got)
+				}
+			}
+		})
+	}
+}
+
+// TestPredicateIdentifiersSyntaxErrorReports covers the branch callers
+// fall back on. A predicate that reached the listing has already been
+// through CompilePredicate, so this is only reachable for sources that
+// never came from a loaded recipe.
+func TestPredicateIdentifiersSyntaxErrorReports(t *testing.T) {
+	if _, err := PredicateIdentifiers("registered =="); err == nil {
+		t.Fatal("expected a parse error, got nil")
+	}
+}

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -257,6 +257,40 @@ EOF
   assert_output --partial "[skipped] gated"
 }
 
+@test "--list-tasks shows [unknown] for a rescue when: on failed_task" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy
+      block:
+        - dokku_app: { app: docket-test-list-1 }
+      rescue:
+        - name: report
+          when: 'failed_task.Stderr contains "already exists"'
+          dokku_app: { app: docket-test-list-1, state: absent }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "[unknown] [rescue] report"
+  refute_output --partial "[when?]"
+}
+
+@test "--list-tasks exits 1 on a task when: that cannot evaluate" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: broken predicate
+      when: '[][0] == 1'
+      dokku_app: { app: docket-test-list-1 }
+    - name: plain
+      dokku_app: { app: docket-test-list-2 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_failure
+  assert_output --partial "[when?]   broken predicate"
+  assert_output --partial "plain"
+}
+
 @test "--list-tasks marks deprecated task types" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
`failed_task` is bound only once a block child has failed, so a rescue predicate branching on it is undecidable offline for the same reason a `registered` reference is, and `--list-tasks` now renders it `[unknown]` instead of reporting a valid recipe as broken. The reference check reads the parsed identifiers rather than the raw source, so an input named `registered_at`, a quoted `"registered"`, or a field access `x.failed_task` no longer forces a false `[unknown]`, and `failed_task` counts only where the executor actually binds it. With that false positive gone, a task `when:` that fails to evaluate now exits 1 like a play one, except under a group whose own predicate was skipped, unknown, or erroring, where a run would never evaluate it.

Fixes #462.
