### PR TITLE
fix: report the chart.* rejection from validate too

### DIFF
--- a/docs/schemas/task-catalog-v1.schema.json
+++ b/docs/schemas/task-catalog-v1.schema.json
@@ -208,6 +208,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/dynamic_property" },
           "description": "Name families the table cannot enumerate, because dokku validates them through the set subcommand rather than through its report schema. A name matching one of these prefixes is legal even though it is absent from `properties`."
+        },
+        "rejected": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/rejected_property" },
+          "description": "Name families this task refuses because another task manages them. A name matching one of these prefixes is absent from `properties` for a different reason than a typo is, and reporting it as an unknown name sends the user looking through a list it will never be in."
         }
       }
     },
@@ -253,6 +258,23 @@
         "sensitive": {
           "const": true,
           "description": "Members' values are treated as secrets."
+        }
+      }
+    },
+
+    "rejected_property": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prefix", "replacement", "reason"],
+      "properties": {
+        "prefix": { "type": "string", "description": "What a member's name starts with." },
+        "replacement": {
+          "type": "string",
+          "description": "The task type to write the property against instead. Always a `type` present elsewhere in this catalog."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why this task does not manage the family, phrased as a clause that reads after a semicolon."
         }
       }
     },

--- a/docs/task-catalog.md
+++ b/docs/task-catalog.md
@@ -203,6 +203,19 @@ reports drift on every run and never converges.
 them into an input on export. It is independent of `probeable` - a credential docket cannot read
 back is still masked on the way out.
 
+A name can also be absent from `properties` because another task manages it. That is a different
+answer from "no such property", and the catalog says so rather than leaving a consumer to report an
+unknown name and offer a list it will never be in:
+
+```json
+"rejected": [ { "prefix": "chart.", "replacement": "dokku_scheduler_k3s_chart",
+                "reason": "the scheduler-k3s:set path for chart values is deprecated in dokku" } ]
+```
+
+`replacement` is always a `type` present elsewhere in the same catalog, so a consumer can point the
+user at it directly. `docket validate` rejects a matching name with the same sentence `plan` and
+`apply` do - `<prefix>* properties are managed by <replacement>; <reason>`.
+
 **An absent `property_schema` on a task that has a `property` field means the legal names are not
 enumerable from docket, not that there are none.** `dokku_service_property` is the case: its names
 come from whichever datastore plugin backs the service, and no plugin exposes a report that lists
@@ -211,7 +224,8 @@ them.
 ## Stability
 
 - Tasks are sorted by `type`, including when `--task` narrows the catalog, so the output never
-  depends on the order the flags were given; properties by `name`; dynamic families by `prefix`.
+  depends on the order the flags were given; properties by `name`; dynamic and rejected families by
+  `prefix`.
 - Fields, identity keys, requirements and choices keep declaration order, because that order is
   meaningful.
 - Two runs of the same binary produce byte-identical output, for the whole catalog and for any

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -47,6 +47,8 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | `shm-size` | app, global | `shm-size` | `global-shm-size` |
 | `token` (sensitive) | global |  | `global-token` |
 
+Names starting with `chart.` are rejected here - they are managed by `dokku_scheduler_k3s_chart`, since the scheduler-k3s:set path for chart values is deprecated in dokku.
+
 ## Examples
 
 ### Setting the deploy timeout for an app

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -293,6 +293,36 @@ answering the first by asking the second is how traefik's `dns-provider-*` crede
 in cleartext (#457). `Sensitive` registers the desired value with the masker before it is echoed;
 on a `Probeable` family it also masks the value read back, so it never reaches a drift reason.
 
+The mirror image is a family the task refuses because another task owns it. Declare it under
+`Rejected` rather than guarding inside `Plan()`:
+
+```go
+var schedulerK3sPropertyTable = PropertyTable{
+  Subcommand: "scheduler-k3s:set",
+  Rejected: []RejectedPropertyFamily{
+    {
+      Prefix:      "chart.",
+      Replacement: "dokku_scheduler_k3s_chart",
+      Reason:      "the scheduler-k3s:set path for chart values is deprecated in dokku",
+    },
+  },
+  Keys: map[string]PropertyKeys{ /* ... */ },
+}
+```
+
+A member is rejected with `<prefix>* properties are managed by <replacement>; <reason>`, checked
+before scoping and before the key map. Leaving it out of `Keys` is not enough on its own: the user
+who wrote `chart.traefik.replicas` meant it, and answering with the list of names that *are*
+supported sends them looking for something that will never be on it. All three fields are required,
+and `Replacement` has to name a registered task.
+
+Declaring it on the table rather than in `Plan()` is what keeps the message honest.
+`validatePropertyInput` is the one function `planProperty` and every property task's `Validate()`
+both call, so `plan`, `apply` and `validate` cannot drift apart - which is exactly what happened
+while the `chart.*` guard lived in `Plan()` alone and `docket validate` reported the generic
+unsupported-name error instead (#458). The family is published as `property_schema.rejected` too, so
+a consumer validating a recipe offline can give the same answer.
+
 ## Regenerating the task docs
 
 The per-task pages under [`docs/tasks/`](tasks/README.md) are generated from each task's `Doc()`,

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -149,6 +149,11 @@ func propertiesSection(schema *tasks.PropertySchema) string {
 		}
 		b.WriteString("\n")
 	}
+
+	for _, family := range schema.Rejected {
+		b.WriteString(fmt.Sprintf("\nNames starting with `%s` are rejected here - they are managed by `%s`, since %s.\n",
+			family.Prefix, family.Replacement, family.Reason))
+	}
 	return b.String()
 }
 

--- a/tasks/catalog.go
+++ b/tasks/catalog.go
@@ -276,6 +276,13 @@ type PropertySchema struct {
 	// schema. A name matching one of these prefixes is legal even though it is
 	// absent from Properties.
 	Dynamic []DynamicPropertySchema `json:"dynamic,omitempty"`
+
+	// Rejected are the name families this task refuses because another task
+	// manages them. A name matching one of these prefixes is absent from
+	// Properties for a different reason than a typo is, and a consumer that
+	// reports it as an unknown name sends the user looking through a list it
+	// will never be in.
+	Rejected []RejectedPropertySchema `json:"rejected,omitempty"`
 }
 
 // PropertyEntrySchema is one property name and where it may be used.
@@ -310,6 +317,19 @@ type DynamicPropertySchema struct {
 
 	// Sensitive is true when docket treats members as secrets.
 	Sensitive bool `json:"sensitive,omitempty"`
+}
+
+// RejectedPropertySchema is a family of property names the task refuses,
+// matched by prefix, and the task that manages them instead.
+type RejectedPropertySchema struct {
+	// Prefix is what a member's name starts with.
+	Prefix string `json:"prefix"`
+
+	// Replacement is the task type to write the property against instead.
+	Replacement string `json:"replacement"`
+
+	// Reason says why this task does not manage the family.
+	Reason string `json:"reason"`
 }
 
 // PropertyFieldName is the recipe key every property table constrains.
@@ -351,6 +371,9 @@ func buildPropertySchema(table PropertyTable) PropertySchema {
 
 	for _, family := range DynamicPropertyFamilies(table.Plugin()) {
 		schema.Dynamic = append(schema.Dynamic, family)
+	}
+	for _, family := range RejectedPropertyFamilies(table) {
+		schema.Rejected = append(schema.Rejected, family)
 	}
 	return schema
 }

--- a/tasks/catalog_test.go
+++ b/tasks/catalog_test.go
@@ -385,6 +385,10 @@ func TestCatalogPropertySchemaMatchesTable(t *testing.T) {
 			t.Errorf("%s dynamic = %+v; want %+v", schema.Type, published.Dynamic, DynamicPropertyFamilies(table.Plugin()))
 		}
 
+		if !reflect.DeepEqual(published.Rejected, RejectedPropertyFamilies(table)) {
+			t.Errorf("%s rejected = %+v; want %+v", schema.Type, published.Rejected, RejectedPropertyFamilies(table))
+		}
+
 		// The table constrains a field that has to exist for the constraint
 		// to mean anything.
 		fieldFor(t, schema.Fields, published.Field)
@@ -447,6 +451,37 @@ func TestCatalogPropertySchemaSpotChecks(t *testing.T) {
 	want = []DynamicPropertySchema{{Prefix: "dns-provider-", Probeable: false, Sensitive: true}}
 	if !reflect.DeepEqual(traefik.Dynamic, want) {
 		t.Errorf("traefik dynamic = %+v; want %+v", traefik.Dynamic, want)
+	}
+
+	// scheduler-k3s refuses the chart.* family outright. Publishing it is what
+	// lets a consumer validating a recipe offline answer the way docket does -
+	// with the task that owns the name - instead of reporting it as unknown and
+	// offering a list it will never be in (#458).
+	k3s := schemaFor(t, catalog, "dokku_scheduler_k3s_property").PropertySchema
+	if k3s == nil {
+		t.Fatal("dokku_scheduler_k3s_property has no property schema")
+	}
+	wantRejected := []RejectedPropertySchema{{
+		Prefix:      "chart.",
+		Replacement: "dokku_scheduler_k3s_chart",
+		Reason:      "the scheduler-k3s:set path for chart values is deprecated in dokku",
+	}}
+	if !reflect.DeepEqual(k3s.Rejected, wantRejected) {
+		t.Errorf("scheduler-k3s rejected = %+v; want %+v", k3s.Rejected, wantRejected)
+	}
+	for _, property := range k3s.Properties {
+		if strings.HasPrefix(property.Name, "chart.") {
+			t.Errorf("scheduler-k3s publishes %q as supported and rejected at once", property.Name)
+		}
+	}
+	if _, ok := RegisteredTasks[wantRejected[0].Replacement]; !ok {
+		t.Errorf("scheduler-k3s points at %q, which is not a registered task", wantRejected[0].Replacement)
+	}
+
+	// A table with nothing to refuse omits the key rather than publishing an
+	// empty list, the same way Dynamic does.
+	if len(apps.Rejected) != 0 {
+		t.Errorf("apps has rejected families %+v; want none", apps.Rejected)
 	}
 
 	// A free-form property field is not a property table, and must not be

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -30,6 +30,41 @@ type PropertyKeys struct {
 	Sensitive bool
 }
 
+// RejectedPropertyFamily is a family of property names, matched by prefix, that
+// a task deliberately refuses because another task owns them.
+//
+// It is not the same as a name simply being absent from Keys. An absent name is
+// a typo, and the right answer is the list of names that are supported; a
+// rejected family is a name the user meant, written against the wrong task, and
+// the only useful answer is which task to write it against instead. Offering
+// the supported list there sends the user looking for something that is not on
+// it (#458).
+//
+// Declaring it on the table rather than guarding inside Plan() is what keeps
+// plan, apply and validate on the same message: validatePropertyInput is the
+// one function both paths reach, and it is where the family is checked.
+type RejectedPropertyFamily struct {
+	// Prefix is what a member's name starts with, for example "chart.".
+	Prefix string
+
+	// Replacement is the task type that manages the family instead, for
+	// example "dokku_scheduler_k3s_chart".
+	Replacement string
+
+	// Reason says why this task does not manage it, as a clause that reads
+	// after a semicolon: "the scheduler-k3s:set path for chart values is
+	// deprecated in dokku".
+	Reason string
+}
+
+// err returns the error a member of the family is rejected with. All three
+// fields are required; TestRejectedPropertyFamiliesAreWellFormed fails the
+// build for a family that leaves one empty, so there is nothing to branch on
+// here.
+func (f RejectedPropertyFamily) err() error {
+	return fmt.Errorf("%s* properties are managed by %s; %s", f.Prefix, f.Replacement, f.Reason)
+}
+
 // PropertyTable is the property schema one *_property task manages: the dokku
 // subcommand a set/unset runs, and the report keys for every property name the
 // task supports.
@@ -47,6 +82,22 @@ type PropertyTable struct {
 	// Keys maps each supported property name to the JSON keys
 	// `dokku <plugin>:report --format json` emits for it per scope.
 	Keys map[string]PropertyKeys
+
+	// Rejected are the name families this task refuses outright because
+	// another task manages them. Checked before Keys, so a member is
+	// answered with the task that owns it rather than with the list of
+	// names this one supports.
+	Rejected []RejectedPropertyFamily
+}
+
+// rejectedFamilyFor returns the family that refuses a property, if any.
+func (p PropertyTable) rejectedFamilyFor(property string) (RejectedPropertyFamily, bool) {
+	for _, family := range p.Rejected {
+		if strings.HasPrefix(property, family.Prefix) {
+			return family, true
+		}
+	}
+	return RejectedPropertyFamily{}, false
 }
 
 // Plugin returns the dokku plugin the table belongs to, derived from the
@@ -369,8 +420,9 @@ func (f dynamicPropertyFamily) keysFor(property string) PropertyKeys {
 // told the prefix.
 //
 // scheduler-k3s `chart.*.*` used to live here but moved to the dedicated
-// dokku_scheduler_k3s_chart task; SchedulerK3sPropertyTask.Plan rejects
-// chart.* before reaching this helper.
+// dokku_scheduler_k3s_chart task; it is now a RejectedPropertyFamily on
+// schedulerK3sPropertyTable, so validatePropertyInput turns it away before
+// reaching this helper.
 var dynamicPropertyFamilies = map[string][]dynamicPropertyFamily{
 	// dokku-letsencrypt 0.25.0+ emits a `dns-provider-<KEY>` row for the app
 	// scope and a `global-dns-provider-<KEY>` row for the global one per
@@ -413,6 +465,26 @@ func DynamicPropertyFamilies(plugin string) []DynamicPropertySchema {
 			Prefix:    family.Prefix,
 			Probeable: family.Probeable,
 			Sensitive: family.Sensitive,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Prefix < out[j].Prefix })
+	return out
+}
+
+// RejectedPropertyFamilies returns the name families a table refuses, sorted by
+// prefix, in the form the task catalog publishes. Exported so a consumer
+// validating a recipe offline can answer a rejected name the way docket does -
+// with the task that manages it - instead of reporting it as unknown.
+func RejectedPropertyFamilies(table PropertyTable) []RejectedPropertySchema {
+	if len(table.Rejected) == 0 {
+		return nil
+	}
+	out := make([]RejectedPropertySchema, 0, len(table.Rejected))
+	for _, family := range table.Rejected {
+		out = append(out, RejectedPropertySchema{
+			Prefix:      family.Prefix,
+			Replacement: family.Replacement,
+			Reason:      family.Reason,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Prefix < out[j].Prefix })
@@ -537,12 +609,19 @@ func dynamicPropertiesFromReport(plugin string, payload map[string]string, globa
 // other probe failures are recorded in PlanResult.Reason and the apply still
 // runs, matching pre-probe behavior.
 // validatePropertyInput checks a property task's inputs without probing the
-// server: app/global scoping, that the property is supported for the target
-// scope, and that a value is supplied only in the state that allows it. Both
-// planProperty and each property task's Validate() call it so plan and
-// validate report the same errors.
+// server: that the property is not from a family the table rejects, app/global
+// scoping, that the property is supported for the target scope, and that a
+// value is supplied only in the state that allows it. Both planProperty and
+// each property task's Validate() call it so plan and validate report the same
+// errors.
 func validatePropertyInput(task PropertyTableDocer, state State, app string, global bool, property, value string) error {
 	table := task.PropertyTable()
+	// A rejected family is checked before anything else, including scoping:
+	// the user wrote a name this task will never manage, so naming the task
+	// that does is more use than telling them the app field is missing too.
+	if family, ok := table.rejectedFamilyFor(property); ok {
+		return family.err()
+	}
 	if !global && app == "" {
 		return errors.New("app is required when global is false")
 	}

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -700,6 +700,111 @@ func TestValidateProperty(t *testing.T) {
 	}
 }
 
+// rejectedFamilyTable is a synthetic table that refuses one family, so the
+// shared behaviour can be driven without leaning on scheduler-k3s's real one.
+func rejectedFamilyTable() propertyTableTask {
+	return propertyTableTask{table: PropertyTable{
+		Subcommand: "test:set",
+		Rejected: []RejectedPropertyFamily{
+			{Prefix: "chart.", Replacement: "dokku_other_task", Reason: "another task owns it"},
+		},
+		Keys: map[string]PropertyKeys{
+			"supported": {PerApp: "supported", Global: "global-supported"},
+		},
+	}}
+}
+
+func TestRejectedFamilyFor(t *testing.T) {
+	table := rejectedFamilyTable().table
+	cases := []struct {
+		property string
+		want     bool
+	}{
+		{"chart.traefik.replicas", true},
+		{"chart.", true},
+		{"chartreuse", false},
+		{"supported", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.property, func(t *testing.T) {
+			family, ok := table.rejectedFamilyFor(tc.property)
+			if ok != tc.want {
+				t.Fatalf("rejectedFamilyFor(%q) = %v; want %v", tc.property, ok, tc.want)
+			}
+			if ok && family.Replacement != "dokku_other_task" {
+				t.Errorf("rejectedFamilyFor(%q) replacement = %q; want dokku_other_task", tc.property, family.Replacement)
+			}
+		})
+	}
+}
+
+// TestValidatePropertyInputRejectedFamily pins the ordering inside
+// validatePropertyInput. The rejected family is checked before scoping and
+// before the key map, so a member is always answered with the task that owns
+// it - never with the supported-name list, and never with a scoping error the
+// user would fix only to hit the refusal anyway (#458).
+func TestValidatePropertyInputRejectedFamily(t *testing.T) {
+	task := rejectedFamilyTable()
+	cases := []struct {
+		name     string
+		app      string
+		global   bool
+		property string
+		value    string
+		state    State
+		wantErr  string
+	}{
+		{"member rejected", "some-app", false, "chart.traefik.replicas", "3", StatePresent, "chart.* properties are managed by dokku_other_task; another task owns it"},
+		{"outranks missing app", "", false, "chart.traefik.replicas", "3", StatePresent, "managed by dokku_other_task"},
+		{"outranks app with global", "some-app", true, "chart.traefik.replicas", "3", StatePresent, "managed by dokku_other_task"},
+		{"outranks missing value", "some-app", false, "chart.traefik.replicas", "", StatePresent, "managed by dokku_other_task"},
+		{"near miss falls through", "some-app", false, "chartreuse", "3", StatePresent, "unsupported property"},
+		{"supported name unaffected", "some-app", false, "supported", "3", StatePresent, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePropertyInput(task, tc.state, tc.app, tc.global, tc.property, tc.value)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("got error %v; want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("got nil error; want substring %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("got error %q; want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestRejectedPropertyFamiliesSorted checks the catalog projection: the
+// published order is by prefix regardless of declaration order, so two runs of
+// the same binary agree and a reordered declaration is not a wire change.
+func TestRejectedPropertyFamiliesSorted(t *testing.T) {
+	table := PropertyTable{
+		Subcommand: "test:set",
+		Rejected: []RejectedPropertyFamily{
+			{Prefix: "zeta.", Replacement: "dokku_zeta", Reason: "z"},
+			{Prefix: "alpha.", Replacement: "dokku_alpha", Reason: "a"},
+		},
+	}
+	got := RejectedPropertyFamilies(table)
+	want := []RejectedPropertySchema{
+		{Prefix: "alpha.", Replacement: "dokku_alpha", Reason: "a"},
+		{Prefix: "zeta.", Replacement: "dokku_zeta", Reason: "z"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RejectedPropertyFamilies = %+v; want %+v", got, want)
+	}
+	if families := RejectedPropertyFamilies(PropertyTable{Subcommand: "test:set"}); families != nil {
+		t.Errorf("a table with no rejected families = %+v; want nil", families)
+	}
+}
+
 func TestValidatePropertyDynamic(t *testing.T) {
 	keys := map[string]PropertyKeys{
 		"email": {PerApp: "email", Global: "global-email"},

--- a/tasks/property_coverage_test.go
+++ b/tasks/property_coverage_test.go
@@ -231,6 +231,97 @@ func TestPropertyTaskValidatesAgainstItsPublishedTable(t *testing.T) {
 	}
 }
 
+// TestRejectedPropertyFamiliesAreWellFormed checks the declarations themselves.
+// RejectedPropertyFamily.err() formats all three fields unconditionally, so an
+// empty one would ship a sentence with a hole in it; and a prefix that shadows
+// a name the table publishes, or a dynamic family the plugin accepts, would
+// make a legal recipe unwritable.
+func TestRejectedPropertyFamiliesAreWellFormed(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		table, declared := TaskPropertyTable(task)
+		if !declared {
+			continue
+		}
+		for _, family := range table.Rejected {
+			if family.Prefix == "" || family.Replacement == "" || family.Reason == "" {
+				t.Errorf("task %q declares an incomplete rejected family %+v", name, family)
+				continue
+			}
+			if _, ok := RegisteredTasks[family.Replacement]; !ok {
+				t.Errorf("task %q points %q at %q, which is not a registered task", name, family.Prefix, family.Replacement)
+			}
+			for property := range table.Keys {
+				if strings.HasPrefix(property, family.Prefix) {
+					t.Errorf("task %q rejects prefix %q, which shadows its own property %q", name, family.Prefix, property)
+				}
+			}
+			for _, dynamic := range DynamicPropertyFamilies(table.Plugin()) {
+				if strings.HasPrefix(family.Prefix, dynamic.Prefix) || strings.HasPrefix(dynamic.Prefix, family.Prefix) {
+					t.Errorf("task %q rejects prefix %q, which overlaps the dynamic family %q on plugin %q",
+						name, family.Prefix, dynamic.Prefix, table.Plugin())
+				}
+			}
+		}
+	}
+}
+
+// TestRejectedPropertyFamiliesReportIdenticallyFromPlanAndValidate is the
+// invariant behind #458: a refusal declared on the table is reached through
+// validatePropertyInput, which planProperty and every task's Validate() both
+// call, so the two cannot report a member of the family differently. Driving it
+// generically means the next task to declare a family gets the guarantee
+// without writing its own test.
+//
+// No server is contacted: validatePropertyInput returns before planProperty
+// probes anything.
+func TestRejectedPropertyFamiliesReportIdenticallyFromPlanAndValidate(t *testing.T) {
+	checked := 0
+	for name, task := range RegisteredTasks {
+		table, declared := TaskPropertyTable(task)
+		if !declared {
+			continue
+		}
+		for _, family := range table.Rejected {
+			checked++
+			property := family.Prefix + "example"
+			instance := newPropertyTaskInstance(t, task, property, false)
+			if instance == nil {
+				continue
+			}
+
+			validateErr := instance.Validate()
+			if validateErr == nil {
+				t.Errorf("task %q accepts %q from its own rejected family", name, property)
+				continue
+			}
+
+			planner, ok := instance.(interface{ Plan() PlanResult })
+			if !ok {
+				t.Errorf("task %q has no Plan() to compare against", name)
+				continue
+			}
+			plan := planner.Plan()
+			if plan.Status != PlanStatusError || plan.Error == nil {
+				t.Errorf("task %q plans %q instead of rejecting it: status %q", name, property, plan.Status)
+				continue
+			}
+
+			if validateErr.Error() != plan.Error.Error() {
+				t.Errorf("task %q reports %q differently:\n  validate: %v\n  plan:     %v", name, property, validateErr, plan.Error)
+			}
+			if !strings.Contains(validateErr.Error(), family.Replacement) {
+				t.Errorf("task %q rejects %q without naming %q: %v", name, property, family.Replacement, validateErr)
+			}
+		}
+	}
+
+	// A registry-wide loop that iterates nothing passes silently, and this one
+	// is the whole guarantee behind #458.
+	if checked == 0 {
+		t.Error("no task declares a rejected property family; the parity invariant went untested")
+	}
+}
+
 // newPropertyTaskInstance builds a runnable copy of a property task addressing
 // one property, so its Validate() can be driven against its own table. Returns
 // nil for a task whose fields do not fit the shape (none today).

--- a/tasks/property_keys_test.go
+++ b/tasks/property_keys_test.go
@@ -393,9 +393,10 @@ func TestSchedulerK3sPropertyKeys(t *testing.T) {
 	})
 	checkUnsupportedProperty(t, schedulerK3sPropertyTable)
 	checkScopeMismatch(t, schedulerK3sPropertyTable, "", "token")
-	// chart.* properties used to be dynamic; they are now rejected by
-	// SchedulerK3sPropertyTask.Plan and routed to dokku_scheduler_k3s_chart,
-	// so validateProperty against the property-keys map should fail.
+	// chart.* properties used to be dynamic, so the key map must no longer let
+	// them through. This is the backstop, not the guard a user meets: the
+	// table's Rejected family answers them first, with dokku_scheduler_k3s_chart
+	// by name - see TestSchedulerK3sPropertyTaskChartRejectionIsIdenticalOffline.
 	if err := validateProperty("scheduler-k3s", "chart.traefik.replicas", false, schedulerK3sPropertyTable.Keys); err == nil {
 		t.Error("expected chart.* to be rejected by the property map (no longer dynamic)")
 	}

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -1,10 +1,5 @@
 package tasks
 
-import (
-	"fmt"
-	"strings"
-)
-
 // SchedulerK3sPropertyTask manages the scheduler-k3s configuration for a given dokku application
 type SchedulerK3sPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
@@ -97,12 +92,20 @@ func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
 
 // schedulerK3sPropertyTable maps scheduler-k3s property names to the JSON
 // keys emitted by `dokku scheduler-k3s:report --format json` on dokku
-// 0.38.8+. The `chart.*.*` family is intentionally absent: chart value
-// overrides are managed by dokku_scheduler_k3s_chart through dokku's
-// dedicated scheduler-k3s:charts:set surface, and Plan() rejects any
-// chart.* property before reaching this map.
+// 0.38.8+. The `chart.*.*` family is absent from Keys and declared under
+// Rejected instead: chart value overrides are managed by
+// dokku_scheduler_k3s_chart through dokku's dedicated
+// scheduler-k3s:charts:set surface, so a recipe naming one is answered with
+// the task that owns it rather than with the list of names this task supports.
 var schedulerK3sPropertyTable = PropertyTable{
 	Subcommand: "scheduler-k3s:set",
+	Rejected: []RejectedPropertyFamily{
+		{
+			Prefix:      "chart.",
+			Replacement: "dokku_scheduler_k3s_chart",
+			Reason:      "the scheduler-k3s:set path for chart values is deprecated in dokku",
+		},
+	},
 	Keys: map[string]PropertyKeys{
 		"deploy-timeout":         {PerApp: "deploy-timeout", Global: "global-deploy-timeout"},
 		"image-pull-secrets":     {PerApp: "image-pull-secrets", Global: "global-image-pull-secrets"},
@@ -132,17 +135,7 @@ func (t SchedulerK3sPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerK3sPropertyTask would produce.
-//
-// The chart.* guard lives here rather than in Validate(), so `docket validate`
-// rejects the same recipe for the generic "unsupported property" reason
-// instead of naming the replacement task (#458).
 func (t SchedulerK3sPropertyTask) Plan() PlanResult {
-	if strings.HasPrefix(t.Property, "chart.") {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  fmt.Errorf("chart.* properties are managed by dokku_scheduler_k3s_chart; the scheduler-k3s:set path for chart values is deprecated in dokku"),
-		}
-	}
 	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 

--- a/tasks/scheduler_k3s_property_task_test.go
+++ b/tasks/scheduler_k3s_property_task_test.go
@@ -89,3 +89,76 @@ func TestSchedulerK3sPropertyTaskRejectsChartProperty(t *testing.T) {
 		t.Errorf("error should mention the dokku deprecation, got: %v", result.Error)
 	}
 }
+
+// TestSchedulerK3sPropertyTaskChartRejectionIsIdenticalOffline pins the fix for
+// #458: the chart.* refusal used to be a guard inside Plan(), so `docket
+// validate` fell through to the generic "unsupported property" list - a list
+// that can never contain what the user wrote. It now lives on the property
+// table both paths read, so the two report the same sentence.
+func TestSchedulerK3sPropertyTaskChartRejectionIsIdenticalOffline(t *testing.T) {
+	task := SchedulerK3sPropertyTask{
+		Global:   true,
+		Property: "chart.traefik.replicas",
+		Value:    "3",
+		State:    StatePresent,
+	}
+
+	validateErr := task.Validate()
+	if validateErr == nil {
+		t.Fatal("Validate should reject a chart.* property")
+	}
+
+	plan := task.Plan()
+	if plan.Status != PlanStatusError || plan.Error == nil {
+		t.Fatalf("Plan should reject a chart.* property, got status %q error %v", plan.Status, plan.Error)
+	}
+
+	if validateErr.Error() != plan.Error.Error() {
+		t.Errorf("validate and plan disagree:\n  validate: %v\n  plan:     %v", validateErr, plan.Error)
+	}
+	if !strings.Contains(validateErr.Error(), "dokku_scheduler_k3s_chart") {
+		t.Errorf("Validate should name the replacement task, got: %v", validateErr)
+	}
+	if strings.Contains(validateErr.Error(), "unsupported property") {
+		t.Errorf("Validate should not fall through to the supported-name list, got: %v", validateErr)
+	}
+}
+
+// TestSchedulerK3sPropertyTaskChartRejectionOutranksScoping documents the
+// ordering validatePropertyInput uses: a chart.* property with no app is
+// answered with the task that owns it, not with the missing app, because the
+// scoping error would send the user off to fix a recipe this task will never
+// accept.
+func TestSchedulerK3sPropertyTaskChartRejectionOutranksScoping(t *testing.T) {
+	task := SchedulerK3sPropertyTask{
+		Property: "chart.traefik.replicas",
+		Value:    "3",
+		State:    StatePresent,
+	}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("Validate should reject a chart.* property with no app")
+	}
+	if !strings.Contains(err.Error(), "dokku_scheduler_k3s_chart") {
+		t.Errorf("chart.* rejection should win over the missing-app error, got: %v", err)
+	}
+}
+
+// TestSchedulerK3sPropertyTaskAcceptsChartPrefixedName guards the prefix
+// boundary: the family is "chart." with the dot, so a supported-looking name
+// that merely starts with the same letters is not swallowed by it.
+func TestSchedulerK3sPropertyTaskAcceptsChartPrefixedName(t *testing.T) {
+	task := SchedulerK3sPropertyTask{
+		App:      "test-app",
+		Property: "chartreuse",
+		Value:    "3",
+		State:    StatePresent,
+	}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("Validate should reject an unknown property")
+	}
+	if !strings.Contains(err.Error(), "unsupported property") {
+		t.Errorf("a near-miss name should get the generic error, got: %v", err)
+	}
+}

--- a/tests/bats/schema.bats
+++ b/tests/bats/schema.bats
@@ -95,6 +95,36 @@ setup() {
     fail "traefik does not publish its dns-provider- family as sensitive"
 }
 
+@test "docket schema publishes property name families a task refuses (#458)" {
+  run "$(docket_bin)" schema
+  assert_success
+
+  # chart.* is absent from scheduler-k3s's properties for a different reason
+  # than a typo is. Publishing the replacement lets a consumer validating
+  # offline answer the way docket does, instead of reporting an unknown name.
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_scheduler_k3s_property") | .property_schema.rejected[]
+           | select(.prefix == "chart.")
+           | .replacement == "dokku_scheduler_k3s_chart" and (.reason | length) > 0' >/dev/null ||
+    fail "scheduler-k3s does not publish its rejected chart. family"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_scheduler_k3s_property") | .property_schema.properties
+           | map(select(.name | startswith("chart."))) | length == 0' >/dev/null ||
+    fail "scheduler-k3s publishes a chart. property as supported and rejected at once"
+
+  # The replacement always names a task the same catalog describes.
+  echo "$output" |
+    jq -e '[.tasks[].type] as $types
+           | [.tasks[] | select(has("property_schema")) | .property_schema.rejected // []
+              | .[].replacement] | all(. as $r | $types | index($r) != null)' >/dev/null ||
+    fail "a rejected family points at a task the catalog does not describe"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_apps_property") | .property_schema | has("rejected") | not' >/dev/null ||
+    fail "a table with nothing to refuse should omit the rejected key"
+}
+
 @test "docket schema omits a property schema when the names are not enumerable" {
   run "$(docket_bin)" schema
   assert_success

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -231,6 +231,24 @@ EOF
   assert_output --partial "label values must not be empty for state 'present'"
 }
 
+@test "docket validate names the replacement task for a rejected property family (#458)" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_scheduler_k3s_property:
+        global: true
+        property: chart.traefik.replicas
+        value: "3"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "chart.* properties are managed by dokku_scheduler_k3s_chart"
+  assert_output --partial "deprecated in dokku"
+  # The whole point is that the generic list never appears here: it cannot
+  # contain the name the user wrote.
+  refute_output --partial "unsupported property"
+}
+
 @test "docket validate --json emits invalid_task_input" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
`dokku_scheduler_k3s_property` refused `chart.*` properties from `plan` and `apply` only, so `docket validate` reported the generic unsupported-property list instead of naming `dokku_scheduler_k3s_chart`. The refusal now reaches all three, and is published in `docket schema` so a consumer validating a recipe offline can give the same answer.

Fixes #458
