### PR TITLE
refactor: declare the property task fields once

### DIFF
--- a/docs/tasks/dokku_app_json_property.md
+++ b/docs/tasks/dokku_app_json_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the app.json configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the app.json property to set |
-| `value` | string | no |  |  | Value to set for the app.json property |
-| `state` | string | no | present | present, absent | Desired state of the app.json configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_apps_property.md
+++ b/docs/tasks/dokku_apps_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the apps property should be applied globally |
-| `property` | string | yes |  |  | Name of the apps property to set |
-| `value` | string | no |  |  | Value to set for the apps property |
-| `state` | string | no | present | present, absent | Desired state of the apps configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builder_dockerfile_property.md
+++ b/docs/tasks/dokku_builder_dockerfile_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builder-dockerfile configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builder-dockerfile property to set |
-| `value` | string | no |  |  | Value to set for the builder-dockerfile property |
-| `state` | string | no | present | present, absent | Desired state of the builder-dockerfile configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builder_herokuish_property.md
+++ b/docs/tasks/dokku_builder_herokuish_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builder-herokuish configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builder-herokuish property to set |
-| `value` | string | no |  |  | Value to set for the builder-herokuish property |
-| `state` | string | no | present | present, absent | Desired state of the builder-herokuish configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builder_lambda_property.md
+++ b/docs/tasks/dokku_builder_lambda_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builder-lambda configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builder-lambda property to set |
-| `value` | string | no |  |  | Value to set for the builder-lambda property |
-| `state` | string | no | present | present, absent | Desired state of the builder-lambda configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builder_nixpacks_property.md
+++ b/docs/tasks/dokku_builder_nixpacks_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builder-nixpacks configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builder-nixpacks property to set |
-| `value` | string | no |  |  | Value to set for the builder-nixpacks property |
-| `state` | string | no | present | present, absent | Desired state of the builder-nixpacks configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builder_pack_property.md
+++ b/docs/tasks/dokku_builder_pack_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builder-pack configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builder-pack property to set |
-| `value` | string | no |  |  | Value to set for the builder-pack property |
-| `state` | string | no | present | present, absent | Desired state of the builder-pack configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builder_property.md
+++ b/docs/tasks/dokku_builder_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builder configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builder property to set |
-| `value` | string | no |  |  | Value to set for the builder property |
-| `state` | string | no | present | present, absent | Desired state of the builder configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builder_railpack_property.md
+++ b/docs/tasks/dokku_builder_railpack_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builder-railpack configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builder-railpack property to set |
-| `value` | string | no |  |  | Value to set for the builder-railpack property |
-| `state` | string | no | present | present, absent | Desired state of the builder-railpack configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_buildpacks_property.md
+++ b/docs/tasks/dokku_buildpacks_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the buildpacks configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the buildpacks property to set |
-| `value` | string | no |  |  | Value to set for the buildpacks property |
-| `state` | string | no | present | present, absent | Desired state of the buildpacks configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_builds_property.md
+++ b/docs/tasks/dokku_builds_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the builds configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the builds property to set |
-| `value` | string | no |  |  | Value to set for the builds property |
-| `state` | string | no | present | present, absent | Desired state of the builds configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_caddy_property.md
+++ b/docs/tasks/dokku_caddy_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the caddy configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the caddy property to set |
-| `value` | string | no |  |  | Value to set for the caddy property |
-| `state` | string | no | present | present, absent | Desired state of the caddy configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_checks_property.md
+++ b/docs/tasks/dokku_checks_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the checks configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the checks property to set |
-| `value` | string | no |  |  | Value to set for the checks property |
-| `state` | string | no | present | present, absent | Desired state of the checks configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_cron_property.md
+++ b/docs/tasks/dokku_cron_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the cron configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the cron property to set |
-| `value` | string | no |  |  | Value to set for the cron property |
-| `state` | string | no | present | present, absent | Desired state of the cron configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_git_property.md
+++ b/docs/tasks/dokku_git_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the git configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the git property to set |
-| `value` | string | no |  |  | Value to set for the git property |
-| `state` | string | no | present | present, absent | Desired state of the git configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_haproxy_property.md
+++ b/docs/tasks/dokku_haproxy_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the haproxy configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the haproxy property to set |
-| `value` | string | no |  |  | Value to set for the haproxy property |
-| `state` | string | no | present | present, absent | Desired state of the haproxy configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_letsencrypt_property.md
+++ b/docs/tasks/dokku_letsencrypt_property.md
@@ -25,10 +25,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the letsencrypt configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the letsencrypt property to set |
-| `value` | string | no |  |  | Value to set for the letsencrypt property (sensitive) |
-| `state` | string | no | present | present, absent | Desired state of the letsencrypt configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property (sensitive) |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_logs_property.md
+++ b/docs/tasks/dokku_logs_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the logs configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the logs property to set |
-| `value` | string | no |  |  | Value to set for the logs property |
-| `state` | string | no | present | present, absent | Desired state of the logs configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_network_property.md
+++ b/docs/tasks/dokku_network_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the network property should be applied globally |
-| `property` | string | yes |  |  | Name of the network property to set |
-| `value` | string | no |  |  | Value of the network property to set |
-| `state` | string | no | present | present, absent | Desired state of the network property |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_nginx_property.md
+++ b/docs/tasks/dokku_nginx_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the nginx configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the nginx property to set |
-| `value` | string | no |  |  | Value to set for the nginx property |
-| `state` | string | no | present | present, absent | Desired state of the nginx configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_openresty_property.md
+++ b/docs/tasks/dokku_openresty_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the openresty configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the openresty property to set |
-| `value` | string | no |  |  | Value to set for the openresty property |
-| `state` | string | no | present | present, absent | Desired state of the openresty configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_proxy_property.md
+++ b/docs/tasks/dokku_proxy_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the proxy configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the proxy property to set |
-| `value` | string | no |  |  | Value to set for the proxy property |
-| `state` | string | no | present | present, absent | Desired state of the proxy configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_ps_property.md
+++ b/docs/tasks/dokku_ps_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the ps configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the ps property to set |
-| `value` | string | no |  |  | Value to set for the ps property |
-| `state` | string | no | present | present, absent | Desired state of the ps configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_registry_property.md
+++ b/docs/tasks/dokku_registry_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the registry configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the registry property to set |
-| `value` | string | no |  |  | Value to set for the registry property |
-| `state` | string | no | present | present, absent | Desired state of the registry configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the scheduler-k3s configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the scheduler-k3s property to set |
-| `value` | string | no |  |  | Value to set for the scheduler-k3s property |
-| `state` | string | no | present | present, absent | Desired state of the scheduler-k3s configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_scheduler_property.md
+++ b/docs/tasks/dokku_scheduler_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the scheduler configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the scheduler property to set |
-| `value` | string | no |  |  | Value to set for the scheduler property |
-| `state` | string | no | present | present, absent | Desired state of the scheduler configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/tasks/dokku_traefik_property.md
+++ b/docs/tasks/dokku_traefik_property.md
@@ -21,10 +21,10 @@ Keyed by `app`, `global`, and `property`. Fields left empty are omitted from the
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
-| `global` | bool | no |  |  | Flag indicating if the traefik configuration should be applied globally |
-| `property` | string | yes |  |  | Name of the traefik property to set |
-| `value` | string | no |  |  | Value to set for the traefik property |
-| `state` | string | no | present | present, absent | Desired state of the traefik configuration |
+| `global` | bool | no |  |  | Flag indicating if the property should be applied globally |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set for the property |
+| `state` | string | no | present | present, absent | Desired state of the property |
 
 ## Properties
 

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -231,14 +231,12 @@ global scope. An empty string for a scope means the property is not supported th
 `planProperty` rejects that scope at plan time. `present` sets the property and requires a `value`;
 `absent` clears it and must not have one - the helper enforces both.
 
+The five recipe keys a property task accepts - `app`, `global`, `property`, `value`, `state` - are
+declared once, in `PropertyFields`. Do not restate them: name your task as a defined type over it,
+so a cross-cutting field change lands in one place rather than in every property task.
+
 ```go
-type NginxPropertyTask struct {
-  App      string `required:"false" identity:"key" yaml:"app"`
-  Global   bool   `required:"false" identity:"key" yaml:"global,omitempty"`
-  Property string `required:"true" identity:"key" yaml:"property"`
-  Value    string `required:"false" yaml:"value,omitempty"`
-  State    State  `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
-}
+type NginxPropertyTask PropertyFields
 
 // Maps each property to the report JSON keys per scope. "" means unsupported.
 var nginxPropertyTable = PropertyTable{
@@ -272,6 +270,19 @@ the task's reference page and the `property_schema` key in
 [`docket schema`](task-catalog.md#property-tasks). The property exporters take the task the same
 way, and `TestEveryPropertyTaskDeclaresPropertyTable` fails the build for a `*_property` task that
 declares no table and is not explicitly exempt.
+
+Use `SensitivePropertyFields` instead when the plugin's property values can be credentials, as
+letsencrypt's `dns-provider-*` ones are. It is `PropertyFields` with `value` tagged
+`sensitive:"true"`, which masks every value the task echoes, benign ones included - preferable to
+leaking a secret because the per-property judgement was wrong. Masking and export are separate
+questions: export decides what to lift into a vars file from the property's `PropertyKeys` entry, so
+a benign value stays readable in an exported recipe.
+
+A property task addressed differently declares its own fields and goes on the
+`propertyTasksWithOwnFields` allowlist with the reason, the way `dokku_scheduler_docker_local_property`
+(per-app only, so `app` is required and there is no `global`) and `dokku_service_property` (keyed by
+`service` plus `name`) do. `TestPropertyTasksDeclareTheSharedFields` fails the build for a
+`*_property` task that restates the shared field set without being on it.
 
 Keep the table in sync with the plugin's `:report` output - that mapping is how `plan` and `apply`
 detect drift without mutating. Some plugins take a dynamic family of properties whose names cannot

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // AppJsonPropertyTask manages the app.json configuration for a given dokku application
-type AppJsonPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the app.json configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the app.json configuration should be applied globally"`
-
-	// Property is the name of the app.json property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the app.json property to set"`
-
-	// Value is the value to set for the app.json property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the app.json property"`
-
-	// State is the desired state of the app.json configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the app.json configuration"`
-}
+type AppJsonPropertyTask PropertyFields
 
 // AppJsonPropertyTaskExample contains an example of an AppJsonPropertyTask
 type AppJsonPropertyTaskExample struct {

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // AppsPropertyTask manages the apps plugin configuration for a given dokku application or globally
-type AppsPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the apps property should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the apps property should be applied globally"`
-
-	// Property is the name of the apps property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the apps property to set"`
-
-	// Value is the value to set for the apps property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the apps property"`
-
-	// State is the desired state of the apps configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the apps configuration"`
-}
+type AppsPropertyTask PropertyFields
 
 // AppsPropertyTaskExample contains an example of an AppsPropertyTask
 type AppsPropertyTaskExample struct {

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuilderDockerfilePropertyTask manages the builder-dockerfile configuration for a given dokku application
-type BuilderDockerfilePropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builder-dockerfile configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-dockerfile configuration should be applied globally"`
-
-	// Property is the name of the builder-dockerfile property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-dockerfile property to set"`
-
-	// Value is the value to set for the builder-dockerfile property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-dockerfile property"`
-
-	// State is the desired state of the builder-dockerfile configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-dockerfile configuration"`
-}
+type BuilderDockerfilePropertyTask PropertyFields
 
 // BuilderDockerfilePropertyTaskExample contains an example of a BuilderDockerfilePropertyTask
 type BuilderDockerfilePropertyTaskExample struct {

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuilderHerokuishPropertyTask manages the builder-herokuish configuration for a given dokku application
-type BuilderHerokuishPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builder-herokuish configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-herokuish configuration should be applied globally"`
-
-	// Property is the name of the builder-herokuish property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-herokuish property to set"`
-
-	// Value is the value to set for the builder-herokuish property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-herokuish property"`
-
-	// State is the desired state of the builder-herokuish configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-herokuish configuration"`
-}
+type BuilderHerokuishPropertyTask PropertyFields
 
 // BuilderHerokuishPropertyTaskExample contains an example of a BuilderHerokuishPropertyTask
 type BuilderHerokuishPropertyTaskExample struct {

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuilderLambdaPropertyTask manages the builder-lambda configuration for a given dokku application
-type BuilderLambdaPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builder-lambda configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-lambda configuration should be applied globally"`
-
-	// Property is the name of the builder-lambda property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-lambda property to set"`
-
-	// Value is the value to set for the builder-lambda property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-lambda property"`
-
-	// State is the desired state of the builder-lambda configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-lambda configuration"`
-}
+type BuilderLambdaPropertyTask PropertyFields
 
 // BuilderLambdaPropertyTaskExample contains an example of a BuilderLambdaPropertyTask
 type BuilderLambdaPropertyTaskExample struct {

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuilderNixpacksPropertyTask manages the builder-nixpacks configuration for a given dokku application
-type BuilderNixpacksPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builder-nixpacks configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-nixpacks configuration should be applied globally"`
-
-	// Property is the name of the builder-nixpacks property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-nixpacks property to set"`
-
-	// Value is the value to set for the builder-nixpacks property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-nixpacks property"`
-
-	// State is the desired state of the builder-nixpacks configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-nixpacks configuration"`
-}
+type BuilderNixpacksPropertyTask PropertyFields
 
 // BuilderNixpacksPropertyTaskExample contains an example of a BuilderNixpacksPropertyTask
 type BuilderNixpacksPropertyTaskExample struct {

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuilderPackPropertyTask manages the builder-pack configuration for a given dokku application
-type BuilderPackPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builder-pack configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-pack configuration should be applied globally"`
-
-	// Property is the name of the builder-pack property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-pack property to set"`
-
-	// Value is the value to set for the builder-pack property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-pack property"`
-
-	// State is the desired state of the builder-pack configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-pack configuration"`
-}
+type BuilderPackPropertyTask PropertyFields
 
 // BuilderPackPropertyTaskExample contains an example of a BuilderPackPropertyTask
 type BuilderPackPropertyTaskExample struct {

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuilderTask manages the builder configuration for a given dokku application
-type BuilderPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builder configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder configuration should be applied globally"`
-
-	// Property is the name of the builder property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder property to set"`
-
-	// Value is the value to set for the builder property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder property"`
-
-	// State is the desired state of the builder configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder configuration"`
-}
+type BuilderPropertyTask PropertyFields
 
 // BuilderPropertyTaskExample contains an example of a BuilderPropertyTask
 type BuilderPropertyTaskExample struct {

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuilderRailpackPropertyTask manages the builder-railpack configuration for a given dokku application
-type BuilderRailpackPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builder-railpack configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builder-railpack configuration should be applied globally"`
-
-	// Property is the name of the builder-railpack property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builder-railpack property to set"`
-
-	// Value is the value to set for the builder-railpack property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-railpack property"`
-
-	// State is the desired state of the builder-railpack configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-railpack configuration"`
-}
+type BuilderRailpackPropertyTask PropertyFields
 
 // BuilderRailpackPropertyTaskExample contains an example of a BuilderRailpackPropertyTask
 type BuilderRailpackPropertyTaskExample struct {

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuildpacksPropertyTask manages the buildpacks configuration for a given dokku application
-type BuildpacksPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the buildpacks configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the buildpacks configuration should be applied globally"`
-
-	// Property is the name of the buildpacks property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the buildpacks property to set"`
-
-	// Value is the value to set for the buildpacks property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the buildpacks property"`
-
-	// State is the desired state of the buildpacks configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the buildpacks configuration"`
-}
+type BuildpacksPropertyTask PropertyFields
 
 // BuildpacksPropertyTaskExample contains an example of a BuildpacksPropertyTask
 type BuildpacksPropertyTaskExample struct {

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // BuildsPropertyTask manages the builds configuration for a given dokku application
-type BuildsPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the builds configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the builds configuration should be applied globally"`
-
-	// Property is the name of the builds property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the builds property to set"`
-
-	// Value is the value to set for the builds property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builds property"`
-
-	// State is the desired state of the builds configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builds configuration"`
-}
+type BuildsPropertyTask PropertyFields
 
 // BuildsPropertyTaskExample contains an example of a BuildsPropertyTask
 type BuildsPropertyTaskExample struct {

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // CaddyPropertyTask manages the caddy configuration for a given dokku application
-type CaddyPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the caddy configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the caddy configuration should be applied globally"`
-
-	// Property is the name of the caddy property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the caddy property to set"`
-
-	// Value is the value to set for the caddy property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the caddy property"`
-
-	// State is the desired state of the caddy configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the caddy configuration"`
-}
+type CaddyPropertyTask PropertyFields
 
 // CaddyPropertyTaskExample contains an example of a CaddyPropertyTask
 type CaddyPropertyTaskExample struct {

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // ChecksPropertyTask manages the checks configuration for a given dokku application
-type ChecksPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the checks configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the checks configuration should be applied globally"`
-
-	// Property is the name of the checks property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the checks property to set"`
-
-	// Value is the value to set for the checks property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the checks property"`
-
-	// State is the desired state of the checks configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the checks configuration"`
-}
+type ChecksPropertyTask PropertyFields
 
 // ChecksPropertyTaskExample contains an example of a ChecksPropertyTask
 type ChecksPropertyTaskExample struct {

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // CronPropertyTask manages the cron configuration for a given dokku application
-type CronPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the cron configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the cron configuration should be applied globally"`
-
-	// Property is the name of the cron property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the cron property to set"`
-
-	// Value is the value to set for the cron property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the cron property"`
-
-	// State is the desired state of the cron configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the cron configuration"`
-}
+type CronPropertyTask PropertyFields
 
 // CronPropertyTaskExample contains an example of a CronPropertyTask
 type CronPropertyTaskExample struct {

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // GitPropertyTask manages the git configuration for a given dokku application
-type GitPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the git configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the git configuration should be applied globally"`
-
-	// Property is the name of the git property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the git property to set"`
-
-	// Value is the value to set for the git property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the git property"`
-
-	// State is the desired state of the git configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the git configuration"`
-}
+type GitPropertyTask PropertyFields
 
 // GitPropertyTaskExample contains an example of a GitPropertyTask
 type GitPropertyTaskExample struct {

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // HaproxyPropertyTask manages the haproxy configuration for a given dokku application
-type HaproxyPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the haproxy configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the haproxy configuration should be applied globally"`
-
-	// Property is the name of the haproxy property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the haproxy property to set"`
-
-	// Value is the value to set for the haproxy property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the haproxy property"`
-
-	// State is the desired state of the haproxy configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the haproxy configuration"`
-}
+type HaproxyPropertyTask PropertyFields
 
 // HaproxyPropertyTaskExample contains an example of a HaproxyPropertyTask
 type HaproxyPropertyTaskExample struct {

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -1,27 +1,7 @@
 package tasks
 
 // LetsencryptPropertyTask manages the letsencrypt configuration for a given dokku application
-type LetsencryptPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the letsencrypt configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the letsencrypt configuration should be applied globally"`
-
-	// Property is the name of the letsencrypt property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the letsencrypt property to set"`
-
-	// Value is the value to set for the letsencrypt property. Tagged sensitive
-	// because some letsencrypt properties carry DNS-API credentials; benign
-	// property values get masked too, which is preferable to leaking secrets.
-	// The tag drives output masking only - export decides what to lift into a
-	// vars file from the property's PropertyKeys entry, so a benign value stays
-	// readable in the exported recipe (#451).
-	Value string `required:"false" sensitive:"true" yaml:"value,omitempty" description:"Value to set for the letsencrypt property"`
-
-	// State is the desired state of the letsencrypt configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the letsencrypt configuration"`
-}
+type LetsencryptPropertyTask SensitivePropertyFields
 
 // LetsencryptPropertyTaskExample contains an example of a LetsencryptPropertyTask
 type LetsencryptPropertyTaskExample struct {

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // LogsPropertyTask manages the logs configuration for a given dokku application
-type LogsPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the logs configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the logs configuration should be applied globally"`
-
-	// Property is the name of the logs property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the logs property to set"`
-
-	// Value is the value to set for the logs property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the logs property"`
-
-	// State is the desired state of the logs configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the logs configuration"`
-}
+type LogsPropertyTask PropertyFields
 
 // LogsPropertyTaskExample contains an example of a LogsPropertyTask
 type LogsPropertyTaskExample struct {

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // NetworkPropertyTask manages the network property for a given dokku application
-type NetworkPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the network property should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the network property should be applied globally"`
-
-	// Property is the name of the network property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the network property to set"`
-
-	// Value is the value of the network property to set
-	Value string `required:"false" yaml:"value,omitempty" description:"Value of the network property to set"`
-
-	// State is the desired state of the network property
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the network property"`
-}
+type NetworkPropertyTask PropertyFields
 
 // NetworkPropertyTaskExample contains an example of a NetworkPropertyTask
 type NetworkPropertyTaskExample struct {

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // NginxPropertyTask manages the nginx configuration for a given dokku application
-type NginxPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the nginx configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the nginx configuration should be applied globally"`
-
-	// Property is the name of the nginx property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the nginx property to set"`
-
-	// Value is the value to set for the nginx property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the nginx property"`
-
-	// State is the desired state of the nginx configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the nginx configuration"`
-}
+type NginxPropertyTask PropertyFields
 
 // NginxPropertyTaskExample contains an example of a NginxPropertyTask
 type NginxPropertyTaskExample struct {

--- a/tasks/nginx_property_task_test.go
+++ b/tasks/nginx_property_task_test.go
@@ -69,3 +69,51 @@ func TestNginxPropertyTaskAbsentWithValue(t *testing.T) {
 		t.Errorf("unexpected error: %v", result.Error)
 	}
 }
+
+// TestGetTasksNginxPropertyTaskParsedCorrectly decodes a property task from a
+// recipe rather than building it in Go, which is the one thing the sibling
+// tests here do not do. NginxPropertyTask is declared as `type NginxPropertyTask
+// PropertyFields` (#454), so this is what proves the shared field set still
+// yields the flat `app`/`global`/`property`/`value`/`state` recipe keys and that
+// SetDefaults still fills `state`.
+func TestGetTasksNginxPropertyTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: set the nginx read timeout
+      dokku_nginx_property:
+        app: node-js-app
+        property: proxy-read-timeout
+        value: 120s
+`)
+
+	tasks, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("set the nginx read timeout")
+	if task == nil {
+		t.Fatal("task 'set the nginx read timeout' not found")
+	}
+
+	npTask, ok := task.(*NginxPropertyTask)
+	if !ok {
+		t.Fatalf("task is not a NginxPropertyTask (type is %T)", task)
+	}
+
+	if npTask.App != "node-js-app" {
+		t.Errorf("App = %q, want %q", npTask.App, "node-js-app")
+	}
+	if npTask.Global {
+		t.Errorf("Global = true, want false")
+	}
+	if npTask.Property != "proxy-read-timeout" {
+		t.Errorf("Property = %q, want %q", npTask.Property, "proxy-read-timeout")
+	}
+	if npTask.Value != "120s" {
+		t.Errorf("Value = %q, want %q", npTask.Value, "120s")
+	}
+	if npTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", npTask.State)
+	}
+}

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // OpenrestyPropertyTask manages the openresty configuration for a given dokku application
-type OpenrestyPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the openresty configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the openresty configuration should be applied globally"`
-
-	// Property is the name of the openresty property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the openresty property to set"`
-
-	// Value is the value to set for the openresty property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the openresty property"`
-
-	// State is the desired state of the openresty configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the openresty configuration"`
-}
+type OpenrestyPropertyTask PropertyFields
 
 // OpenrestyPropertyTaskExample contains an example of an OpenrestyPropertyTask
 type OpenrestyPropertyTaskExample struct {

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -139,6 +139,69 @@ func pluginFromSubcommand(subcommand string) string {
 	return strings.SplitN(subcommand, ":", 2)[0]
 }
 
+// PropertyFields is the recipe shape every app-or-global property task shares:
+// the scope (`app` or `global`), the property being managed, its value, and
+// whether it should be present or absent. A property task declares
+// `type XPropertyTask PropertyFields` rather than restating the five fields, so
+// a cross-cutting field change - the identity tags of #427, say - lands in one
+// place instead of twenty-seven.
+//
+// A defined type rather than an embedded struct because the field set stays
+// flat to reflection: the catalog, the required-field walk behind
+// missing_required_field, the identity walk that names an unnamed task, and the
+// sensitive-value walks all read a task's fields at the top level, and an
+// embedded field set would empty every one of them out.
+//
+// The descriptions are deliberately plugin-agnostic. A task's page already
+// names its plugin in the title, the synopsis and the Properties table, so
+// repeating it in every parameter row bought nothing and cost twenty-seven
+// copies of the field set. See TestPropertyTasksDeclareTheSharedFields for the
+// tasks whose shape genuinely differs.
+type PropertyFields struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
+
+	// Global is a flag indicating if the property should be applied globally
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the property should be applied globally"`
+
+	// Property is the name of the property to set
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the property to set"`
+
+	// Value is the value to set for the property
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the property"`
+
+	// State is the desired state of the property
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the property"`
+}
+
+// SensitivePropertyFields is PropertyFields with a masked Value, for a plugin
+// whose property values can carry credentials. Every value is masked, benign
+// ones included, which is preferable to leaking a secret because the per-property
+// judgement was wrong.
+//
+// The tag drives output masking only - export decides what to lift into a vars
+// file from the property's PropertyKeys entry, so a benign value stays readable
+// in the exported recipe (#451). It is a separate type rather than a tag
+// override because a defined type carries the tags of exactly one struct;
+// TestSensitivePropertyFieldsMatchesPropertyFields fails if the two drift apart
+// in anything but that one tag.
+type SensitivePropertyFields struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
+
+	// Global is a flag indicating if the property should be applied globally
+	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the property should be applied globally"`
+
+	// Property is the name of the property to set
+	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the property to set"`
+
+	// Value is the value to set for the property
+	Value string `required:"false" sensitive:"true" yaml:"value,omitempty" description:"Value to set for the property"`
+
+	// State is the desired state of the property
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the property"`
+}
+
 // errUnknownProperty is returned by getProperty when the JSON :report payload
 // has no entry for the key the task asked us to look up.
 type errUnknownProperty struct {

--- a/tasks/property_coverage_test.go
+++ b/tasks/property_coverage_test.go
@@ -108,6 +108,120 @@ func TestPropertyTableGlobalKeysRequireAGlobalField(t *testing.T) {
 	}
 }
 
+// propertyTasksWithOwnFields names the property tasks that declare their own
+// field set instead of PropertyFields, with the reason. Being on this list is a
+// statement that the task addresses its resource differently, not that it was
+// missed when the shared type was extracted (#454).
+var propertyTasksWithOwnFields = map[string]string{
+	"dokku_scheduler_docker_local_property": "the scheduler-docker-local properties are per-app only, so `app` is required and there is no `global` field",
+	"dokku_service_property":                "a service property is keyed by `service` plus `name` rather than by an app-or-global scope",
+}
+
+// TestPropertyTasksDeclareTheSharedFields asserts that every property task
+// whose recipe shape is the app-or-global one declares it by reusing
+// PropertyFields (or SensitivePropertyFields) rather than restating the five
+// fields.
+//
+// This is the invariant #454 is about. Twenty-seven tasks carried a
+// byte-identical field set with nothing binding the copies together, so a
+// cross-cutting change - #427's identity tags - had to be applied twenty-seven
+// times by hand, and a copy that was missed would have failed nothing. The
+// comparison is field-by-field including the full struct tag: reflect's
+// ConvertibleTo is no use here because Go conversion between struct types
+// ignores tag differences, which is exactly the difference that matters.
+func TestPropertyTasksDeclareTheSharedFields(t *testing.T) {
+	shared := map[string]reflect.Type{
+		"PropertyFields":          reflect.TypeOf(PropertyFields{}),
+		"SensitivePropertyFields": reflect.TypeOf(SensitivePropertyFields{}),
+	}
+
+	for name, task := range RegisteredTasks {
+		if !strings.HasSuffix(name, "_property") {
+			continue
+		}
+		rt := taskStructType(task)
+		reason, exempt := propertyTasksWithOwnFields[name]
+
+		var matched string
+		for base, bt := range shared {
+			if sameStructShape(rt, bt) {
+				matched = base
+				break
+			}
+		}
+
+		switch {
+		case matched != "" && exempt:
+			t.Errorf("task %q has the %s shape but is listed as exempt (%q); drop it from propertyTasksWithOwnFields", name, matched, reason)
+		case matched == "" && !exempt:
+			t.Errorf("task %q restates the property field set; declare it as `type %s PropertyFields` (or SensitivePropertyFields), or explain the difference in propertyTasksWithOwnFields", name, rt.Name())
+		}
+	}
+
+	for name := range propertyTasksWithOwnFields {
+		if _, ok := RegisteredTasks[name]; !ok {
+			t.Errorf("propertyTasksWithOwnFields names %q, which is not a registered task", name)
+		}
+	}
+}
+
+// TestSensitivePropertyFieldsMatchesPropertyFields asserts the two shared field
+// sets differ only in that SensitivePropertyFields masks its value. They cannot
+// be one type - a defined type carries the tags of exactly one struct - so this
+// is what keeps the duplicate honest: a field added to one has to be added to
+// the other, which is the twenty-seven-copies problem in miniature.
+func TestSensitivePropertyFieldsMatchesPropertyFields(t *testing.T) {
+	plain := reflect.TypeOf(PropertyFields{})
+	sensitive := reflect.TypeOf(SensitivePropertyFields{})
+
+	if plain.NumField() != sensitive.NumField() {
+		t.Fatalf("PropertyFields has %d fields; SensitivePropertyFields has %d", plain.NumField(), sensitive.NumField())
+	}
+
+	const sensitiveTag = `sensitive:"true"`
+	for i := 0; i < plain.NumField(); i++ {
+		want, got := plain.Field(i), sensitive.Field(i)
+		if want.Name != got.Name || want.Type != got.Type {
+			t.Errorf("field %d: PropertyFields has %s %s; SensitivePropertyFields has %s %s", i, want.Name, want.Type, got.Name, got.Type)
+			continue
+		}
+
+		wantTag, gotTag := string(want.Tag), string(got.Tag)
+		if want.Name == "Value" {
+			if !strings.Contains(gotTag, sensitiveTag) {
+				t.Errorf("SensitivePropertyFields.Value is not tagged %s, so it masks nothing", sensitiveTag)
+			}
+			if strings.Contains(wantTag, sensitiveTag) {
+				t.Errorf("PropertyFields.Value is tagged %s, so the two types no longer differ", sensitiveTag)
+			}
+			gotTag = strings.Replace(gotTag, sensitiveTag+" ", "", 1)
+		}
+		if gotTag != wantTag {
+			t.Errorf("SensitivePropertyFields.%s is tagged %q; want %q once %s is removed", got.Name, got.Tag, wantTag, sensitiveTag)
+		}
+	}
+}
+
+// sameStructShape reports whether two struct types declare the same fields in
+// the same order with the same tags. Tags are compared because they are the
+// whole contract here: `required`, `identity`, `yaml`, `default` and
+// `description` are what the catalog, the validator and the identity walk read.
+func sameStructShape(a, b reflect.Type) bool {
+	if a == nil || b == nil || a.Kind() != reflect.Struct || b.Kind() != reflect.Struct {
+		return false
+	}
+	if a.NumField() != b.NumField() {
+		return false
+	}
+	for i := 0; i < a.NumField(); i++ {
+		x, y := a.Field(i), b.Field(i)
+		if x.Name != y.Name || x.Type != y.Type || x.Tag != y.Tag {
+			return false
+		}
+	}
+	return true
+}
+
 // hasGlobalField reports whether a task accepts `global:` in a recipe.
 func hasGlobalField(task Task) bool {
 	rt := taskStructType(task)

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // ProxyPropertyTask manages the proxy configuration for a given dokku application
-type ProxyPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the proxy configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the proxy configuration should be applied globally"`
-
-	// Property is the name of the proxy property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the proxy property to set"`
-
-	// Value is the value to set for the proxy property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the proxy property"`
-
-	// State is the desired state of the proxy configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the proxy configuration"`
-}
+type ProxyPropertyTask PropertyFields
 
 // ProxyPropertyTaskExample contains an example of a ProxyPropertyTask
 type ProxyPropertyTaskExample struct {

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // PsPropertyTask manages the ps configuration for a given dokku application
-type PsPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the ps configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the ps configuration should be applied globally"`
-
-	// Property is the name of the ps property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the ps property to set"`
-
-	// Value is the value to set for the ps property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the ps property"`
-
-	// State is the desired state of the ps configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ps configuration"`
-}
+type PsPropertyTask PropertyFields
 
 // PsPropertyTaskExample contains an example of a PsPropertyTask
 type PsPropertyTaskExample struct {

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // RegistryPropertyTask manages the registry configuration for a given dokku application
-type RegistryPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the registry configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the registry configuration should be applied globally"`
-
-	// Property is the name of the registry property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the registry property to set"`
-
-	// Value is the value to set for the registry property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the registry property"`
-
-	// State is the desired state of the registry configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the registry configuration"`
-}
+type RegistryPropertyTask PropertyFields
 
 // RegistryPropertyTaskExample contains an example of a RegistryPropertyTask
 type RegistryPropertyTaskExample struct {

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // SchedulerK3sPropertyTask manages the scheduler-k3s configuration for a given dokku application
-type SchedulerK3sPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the scheduler-k3s configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the scheduler-k3s configuration should be applied globally"`
-
-	// Property is the name of the scheduler-k3s property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the scheduler-k3s property to set"`
-
-	// Value is the value to set for the scheduler-k3s property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler-k3s property"`
-
-	// State is the desired state of the scheduler-k3s configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the scheduler-k3s configuration"`
-}
+type SchedulerK3sPropertyTask PropertyFields
 
 // SchedulerK3sPropertyTaskExample contains an example of a SchedulerK3sPropertyTask
 type SchedulerK3sPropertyTaskExample struct {

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // SchedulerPropertyTask manages the scheduler configuration for a given dokku application
-type SchedulerPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the scheduler configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the scheduler configuration should be applied globally"`
-
-	// Property is the name of the scheduler property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the scheduler property to set"`
-
-	// Value is the value to set for the scheduler property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler property"`
-
-	// State is the desired state of the scheduler configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the scheduler configuration"`
-}
+type SchedulerPropertyTask PropertyFields
 
 // SchedulerPropertyTaskExample contains an example of a SchedulerPropertyTask
 type SchedulerPropertyTaskExample struct {

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -1,22 +1,7 @@
 package tasks
 
 // TraefikPropertyTask manages the traefik configuration for a given dokku application
-type TraefikPropertyTask struct {
-	// App is the name of the app. Required if Global is false.
-	App string `required:"false" identity:"key" yaml:"app" description:"Name of the app. Required if Global is false."`
-
-	// Global is a flag indicating if the traefik configuration should be applied globally
-	Global bool `required:"false" identity:"key" yaml:"global,omitempty" description:"Flag indicating if the traefik configuration should be applied globally"`
-
-	// Property is the name of the traefik property to set
-	Property string `required:"true" identity:"key" yaml:"property" description:"Name of the traefik property to set"`
-
-	// Value is the value to set for the traefik property
-	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the traefik property"`
-
-	// State is the desired state of the traefik configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the traefik configuration"`
-}
+type TraefikPropertyTask PropertyFields
 
 // TraefikPropertyTaskExample contains an example of a TraefikPropertyTask
 type TraefikPropertyTaskExample struct {

--- a/tests/bats/schema.bats
+++ b/tests/bats/schema.bats
@@ -62,6 +62,38 @@ setup() {
   echo "$output" |
     jq -e '.tasks[] | select(.type == "dokku_git_from_image") | .fields[] | select(.name == "image") | .sensitive == true' >/dev/null ||
     fail "dokku_git_from_image image is not marked sensitive"
+
+  # letsencrypt is the one property task declared over SensitivePropertyFields
+  # rather than PropertyFields, and the whole difference between the two types
+  # is this flag.
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_letsencrypt_property") | .fields[] | select(.name == "value") | .sensitive == true' >/dev/null ||
+    fail "dokku_letsencrypt_property value is not marked sensitive"
+}
+
+@test "docket schema publishes the whole shape of a property task (#454)" {
+  run "$(docket_bin)" schema
+  assert_success
+
+  # The property tasks declare their fields once, as `type XPropertyTask
+  # PropertyFields`. A recipe key that went missing from the published contract
+  # would be invisible in the Go tests that read the same struct, so assert the
+  # five keys and their tags from the outside.
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_builds_property")
+           | [.fields[].name] == ["app", "global", "property", "value", "state"]' >/dev/null ||
+    fail "dokku_builds_property does not publish all five recipe keys in order"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_builds_property")
+           | ([.fields[] | select(.identity == "key") | .name] == ["app", "global", "property"])
+             and ([.fields[] | select(.required) | .name] == ["property"])' >/dev/null ||
+    fail "dokku_builds_property does not key on app, global and property"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_builds_property") | .fields[] | select(.name == "state")
+           | .default == "present" and .choices == ["present", "absent"]' >/dev/null ||
+    fail "dokku_builds_property state lost its default or its choices"
 }
 
 @test "docket schema publishes a property task's supported property names" {


### PR DESCRIPTION
The twenty-seven property tasks each restated the same `app`, `global`, `property`, `value`, `state` field set, so every cross-cutting change had to be applied twenty-seven times by hand. They now name a defined type over the shared `PropertyFields`, or over `SensitivePropertyFields` for a plugin whose values can be credentials. A defined type rather than an embedded struct keeps the field set flat to reflection, so the catalog, the required-field walk behind `missing_required_field`, the identity walk that names an unnamed task and the sensitive-value walks read the fields exactly as before. The parameter descriptions become plugin-agnostic as a result, which is what regenerates the task pages; the page title, synopsis and Properties table already name the plugin. Fixes #454.

`dokku_scheduler_docker_local_property` and `dokku_service_property` address their resources differently and keep their own fields, listed with the reason in `propertyTasksWithOwnFields`. `TestPropertyTasksDeclareTheSharedFields` fails the build for any other `*_property` task that restates the shared set, comparing struct tags rather than using `ConvertibleTo`, which ignores exactly the difference that matters. `TestSensitivePropertyFieldsMatchesPropertyFields` keeps the two shared types from drifting apart in anything but the `sensitive` tag on `value`.

The three toggle tasks carry the same duplication at smaller scale; that is #467 rather than part of this change.
