### PR TITLE
refactor: declare the toggle task fields once

### DIFF
--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -124,7 +124,7 @@ specific step, for example enabling Let's Encrypt only in production:
       when: 'env == "prod"'
       dokku_letsencrypt:
         app: api
-        state: enabled
+        state: present
 ```
 
 The expression sees the file-level inputs. Inside a `loop:` it also sees `.item` and `.index`.
@@ -279,7 +279,7 @@ tasks. Use it when a sequence of steps needs a cleanup or rollback path. The out
       block:
         - dokku_app_clone:     { source_app: api, app: api-candidate }
         - dokku_git_sync:      { app: api-candidate, remote: "{{ .repo }}" }
-        - dokku_checks_toggle: { app: api-candidate, state: enabled }
+        - dokku_checks_toggle: { app: api-candidate, state: present }
       rescue:
         - dokku_app: { app: api-candidate, state: absent }
       always:

--- a/docs/tasks/dokku_checks_toggle.md
+++ b/docs/tasks/dokku_checks_toggle.md
@@ -21,7 +21,7 @@ Keyed by `app`.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `state` | string | no | present | present, absent | Desired state of the checks plugin |
+| `state` | string | no | present | present, absent | Desired state of the plugin for the app |
 
 ## Examples
 

--- a/docs/tasks/dokku_domains_toggle.md
+++ b/docs/tasks/dokku_domains_toggle.md
@@ -21,7 +21,7 @@ Keyed by `app`.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `state` | string | no | present | present, absent | Desired state of the domains plugin |
+| `state` | string | no | present | present, absent | Desired state of the plugin for the app |
 
 ## Examples
 

--- a/docs/tasks/dokku_maintenance.md
+++ b/docs/tasks/dokku_maintenance.md
@@ -25,7 +25,7 @@ Keyed by `app`.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `state` | string | no | present | present, absent | Desired state of maintenance mode |
+| `state` | string | no | present | present, absent | Desired state of the plugin for the app |
 
 ## Examples
 

--- a/docs/tasks/dokku_proxy_toggle.md
+++ b/docs/tasks/dokku_proxy_toggle.md
@@ -21,7 +21,7 @@ Keyed by `app`.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `state` | string | no | present | present, absent | Desired state of the proxy |
+| `state` | string | no | present | present, absent | Desired state of the plugin for the app |
 
 ## Examples
 

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -186,8 +186,8 @@ Most dokku plugins expose one of two shapes, and docket has a shared `Plan()` he
 your task fits one, reach for the helper instead of hand-writing `DispatchPlan` - the task becomes
 mostly declaration, and the idempotency probing is handled for you.
 
-- A **toggle** turns a plugin on or off for an app or globally - for example `checks`, `proxy`, and
-  `domains`.
+- A **toggle** turns a plugin on or off for an app - for example `checks`, `proxy`, `domains`, and
+  `maintenance`.
 - A **property** stores named key/value settings you set or clear - for example `nginx`, `builder`,
   and `git`.
 
@@ -199,28 +199,34 @@ For both shapes the `State` field accepts only `present` and `absent`, declared 
 A toggle task delegates `Plan()` to `planToggle`, passing the plugin's enable and disable
 subcommands and a *probe* - a function that reports whether the plugin is currently enabled. The
 probe is what keeps the task idempotent: when it reports the plugin is already in the desired
-position, the task is in sync and nothing runs. `present` means enabled, `absent` means disabled.
-The `allowGlobal` argument controls whether `global: true` is accepted; pass `false` for plugins
-that are app-only.
+position, the task is in sync and nothing runs. `present` means enabled, `absent` means disabled. A
+toggle always targets an app; there is no global scope.
+
+The two recipe keys a toggle task accepts - `app` and `state` - are declared once, in `ToggleFields`.
+Do not restate them: name your task as a defined type over it, so a cross-cutting field change lands
+in one place rather than in every toggle task.
 
 ```go
-type ChecksToggleTask struct {
-  App    string `required:"true" yaml:"app"`
-  Global bool   `required:"false" yaml:"global,omitempty"`
-  State  State  `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
-}
+type ChecksToggleTask ToggleFields
 
 // The probe reports the current position. A non-nil error (or a nil probe) is
 // treated as drift, so the enable/disable command runs anyway.
 func checksEnabled(ctx ToggleContext) (bool, error) {
-  // dokku --quiet checks:report <app> --checks-disabled
+  // dokku checks:report <app> --format json
   // ... return true when nothing is disabled
 }
 
 func (t ChecksToggleTask) Plan() PlanResult {
-  return planToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable", checksEnabled)
+  return planToggle(t.State, t.App, "checks:enable", "checks:disable", checksEnabled)
 }
 ```
+
+A toggle task addressed differently - one that needs a `global` scope, say - declares its own fields
+and goes on the `toggleTasksWithOwnFields` allowlist with the reason, the way property tasks use
+`propertyTasksWithOwnFields`. Nothing is on it today.
+`TestToggleTasksDeclareTheSharedFields` fails the build for a task that restates the shared field set
+without being on it, and it decides which tasks are toggles by whether their `Plan()` reaches
+`planToggle` rather than by their name - `dokku_maintenance` is a toggle that is not spelled like one.
 
 ### Property tasks
 

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -44,13 +44,7 @@ func (t ChecksToggleTask) ExportApp(app string) ([]interface{}, error) {
 }
 
 // ChecksToggleTask enables or disables the checks plugin for a given dokku application
-type ChecksToggleTask struct {
-	// App is the name of the app
-	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
-
-	// State is the desired state of the checks plugin
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the checks plugin"`
-}
+type ChecksToggleTask ToggleFields
 
 // ChecksToggleTaskExample contains an example of a ChecksToggleTask
 type ChecksToggleTaskExample struct {

--- a/tasks/checks_toggle_task_test.go
+++ b/tasks/checks_toggle_task_test.go
@@ -39,3 +39,39 @@ func TestChecksToggleTaskPlanSurfacesSSHError(t *testing.T) {
 		t.Errorf("Error = %v, want *subprocess.SSHError", plan.Error)
 	}
 }
+
+// TestGetTasksChecksToggleTaskParsedCorrectly decodes a toggle task from a
+// recipe rather than building it in Go, which is the one thing the sibling
+// tests here do not do. ChecksToggleTask is declared as `type ChecksToggleTask
+// ToggleFields` (#467), so this is what proves the shared field set still yields
+// the flat `app` / `state` recipe keys and that SetDefaults still fills `state`.
+func TestGetTasksChecksToggleTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: enable checks
+      dokku_checks_toggle:
+        app: node-js-app
+`)
+
+	tasks, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("enable checks")
+	if task == nil {
+		t.Fatal("task 'enable checks' not found")
+	}
+
+	ctTask, ok := task.(*ChecksToggleTask)
+	if !ok {
+		t.Fatalf("task is not a ChecksToggleTask (type is %T)", task)
+	}
+
+	if ctTask.App != "node-js-app" {
+		t.Errorf("App = %q, want %q", ctTask.App, "node-js-app")
+	}
+	if ctTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", ctTask.State)
+	}
+}

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -33,13 +33,7 @@ func (t DomainsToggleTask) ExportApp(app string) ([]interface{}, error) {
 }
 
 // DomainsToggleTask enables or disables the domains plugin for a given dokku application
-type DomainsToggleTask struct {
-	// App is the name of the app
-	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
-
-	// State is the desired state of the domains plugin
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the domains plugin"`
-}
+type DomainsToggleTask ToggleFields
 
 // DomainsToggleTaskExample contains an example of a DomainsToggleTask
 type DomainsToggleTaskExample struct {

--- a/tasks/maintenance_task.go
+++ b/tasks/maintenance_task.go
@@ -42,13 +42,7 @@ func (t MaintenanceTask) ExportApp(app string) ([]interface{}, error) {
 }
 
 // MaintenanceTask enables or disables maintenance mode for a given dokku application
-type MaintenanceTask struct {
-	// App is the name of the app
-	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
-
-	// State is the desired state of maintenance mode
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of maintenance mode"`
-}
+type MaintenanceTask ToggleFields
 
 // MaintenanceTaskExample contains an example of a MaintenanceTask
 type MaintenanceTaskExample struct {

--- a/tasks/probe_coverage_test.go
+++ b/tasks/probe_coverage_test.go
@@ -297,6 +297,32 @@ func (g *planGraph) inSyncCapable(k planFuncKey) bool {
 	return g.memo[k]
 }
 
+// reaches reports whether target is reachable from k across call edges, which
+// is how TestToggleTasksDeclareTheSharedFields asks whether a task's Plan()
+// delegates to planToggle. Delegation is the only honest way to ask what shape a
+// task is: keying on the `_toggle` name suffix instead would miss
+// dokku_maintenance, a toggle that is not spelled like one.
+func (g *planGraph) reaches(k, target planFuncKey) bool {
+	seen := map[planFuncKey]bool{}
+	var walk func(planFuncKey) bool
+	walk = func(node planFuncKey) bool {
+		if node == target {
+			return true
+		}
+		if seen[node] {
+			return false
+		}
+		seen[node] = true
+		for _, callee := range g.calls[node] {
+			if walk(callee) {
+				return true
+			}
+		}
+		return false
+	}
+	return walk(k)
+}
+
 // packageSourceFiles returns every non-test .go file in the tasks package
 // directory. Deliberately unfiltered: the in-sync results live in
 // properties.go, toggle.go, pairs.go, resources.go, scheduler_k3s_scoped_pairs.go
@@ -909,6 +935,78 @@ func (t FooTask) Plan() PlanResult {
 			}
 			if !reflect.DeepEqual(nonConverging, tc.nonConverging) {
 				t.Errorf("non-converging branches: got %v, want %v", nonConverging, tc.nonConverging)
+			}
+		})
+	}
+}
+
+// TestPlanGraphReachesFunc exercises the delegation lookup that
+// TestToggleTasksDeclareTheSharedFields uses to decide which tasks are toggles.
+// Every planToggle caller in the real package is one, so running against the
+// package proves only that the lookup does not over-report - these fixtures are
+// what prove it finds a helper a hop away and, more importantly, that it says no.
+func TestPlanGraphReachesFunc(t *testing.T) {
+	const drift = "PlanResult{InSync: false, Status: PlanStatusModify}"
+
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "calls the helper directly",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return planToggle(t.State, t.App)
+}
+
+func planToggle(state State, app string) PlanResult {
+	return ` + drift + `
+}`,
+			want: true,
+		},
+		{
+			name: "reaches the helper one hop away",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return planFooToggle(t)
+}
+
+func planFooToggle(t FooTask) PlanResult {
+	return planToggle(t.State, t.App)
+}
+
+func planToggle(state State, app string) PlanResult {
+	return ` + drift + `
+}`,
+			want: true,
+		},
+		{
+			name: "delegates elsewhere",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return planProperty(t.State)
+}
+
+func planProperty(state State) PlanResult {
+	return ` + drift + `
+}
+
+func planToggle(state State, app string) PlanResult {
+	return ` + drift + `
+}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g, problems := planGraphFixture(t, tc.src)
+			if len(problems) > 0 {
+				t.Fatalf("unexpected structural problems: %v", problems)
+			}
+			if got := g.reaches("FooTask.Plan", "planToggle"); got != tc.want {
+				t.Errorf("reaches(FooTask.Plan, planToggle) = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -33,13 +33,7 @@ func (t ProxyToggleTask) ExportApp(app string) ([]interface{}, error) {
 }
 
 // ProxyToggleTask manages the proxy for a given dokku application
-type ProxyToggleTask struct {
-	// App is the name of the app
-	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
-
-	// State is the desired state of the proxy
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the proxy"`
-}
+type ProxyToggleTask ToggleFields
 
 // ProxyToggleTaskExample contains an example of a ProxyToggleTask
 type ProxyToggleTaskExample struct {

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -7,6 +7,34 @@ import (
 	"github.com/dokku/docket/subprocess"
 )
 
+// ToggleFields is the recipe shape every toggle task shares: the app whose
+// plugin is being turned on or off, and whether it should be enabled (present)
+// or disabled (absent). A toggle task declares `type XToggleTask ToggleFields`
+// rather than restating the two fields, so a cross-cutting field change - the
+// identity tags of #427, say - lands in one place instead of in every copy.
+//
+// A defined type rather than an embedded struct because the field set stays
+// flat to reflection: the catalog, the required-field walk behind
+// missing_required_field, the identity walk that names an unnamed task, and the
+// sensitive-value walks all read a task's fields at the top level, and an
+// embedded field set would empty every one of them out.
+//
+// The descriptions are deliberately plugin-agnostic. A task's page already
+// names its plugin in the title and the synopsis, so repeating it in every
+// parameter row bought nothing and cost a copy of the field set per plugin.
+//
+// There is no `global` field: planToggle always targets an app, the global
+// machinery having been removed in #322. A toggle that later needs one declares
+// its own fields and goes on the toggleTasksWithOwnFields allowlist with the
+// reason. See TestToggleTasksDeclareTheSharedFields.
+type ToggleFields struct {
+	// App is the name of the app
+	App string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
+
+	// State is the desired state of the plugin for the app
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the plugin for the app"`
+}
+
 // ToggleContext represents the context for a toggle operation
 type ToggleContext struct {
 	// App is the name of the app

--- a/tasks/toggle_coverage_test.go
+++ b/tasks/toggle_coverage_test.go
@@ -1,0 +1,94 @@
+package tasks
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// toggleTasksWithOwnFields names the toggle tasks that declare their own field
+// set instead of ToggleFields, with the reason. Being on this list is a
+// statement that the task addresses its resource differently - a toggle that
+// needs a `global` scope, say - not that it was missed when the shared type was
+// extracted (#467).
+//
+// It is empty today: every toggle turns a plugin on or off for one app.
+var toggleTasksWithOwnFields = map[string]string{}
+
+// TestToggleTasksDeclareTheSharedFields asserts that every task delegating to
+// planToggle declares its recipe shape by reusing ToggleFields rather than
+// restating the two fields.
+//
+// This is the invariant #467 is about. Four tasks carried a field set that was
+// identical apart from the plugin named in its `description`, with nothing
+// binding the copies together, so a cross-cutting change - #427's identity tags
+// - had to be applied four times by hand, and a copy that was missed would have
+// failed nothing. The comparison is field-by-field including the full struct
+// tag: reflect's ConvertibleTo is no use here because Go conversion between
+// struct types ignores tag differences, which is exactly the difference that
+// matters.
+//
+// Which tasks are toggles is read off the plan graph rather than off a
+// `_toggle` name suffix. dokku_maintenance is a planToggle caller that is not
+// spelled that way, and keying on the name is precisely what left it out of the
+// issue's own count.
+func TestToggleTasksDeclareTheSharedFields(t *testing.T) {
+	g := buildPlanGraph(t)
+	shared := reflect.TypeOf(ToggleFields{})
+
+	toggles := map[string]bool{}
+	for name, task := range RegisteredTasks {
+		rt := taskStructType(task)
+		if !g.reaches(planFuncKey(rt.Name()+".Plan"), "planToggle") {
+			continue
+		}
+		toggles[name] = true
+
+		reason, exempt := toggleTasksWithOwnFields[name]
+		matched := sameStructShape(rt, shared)
+
+		switch {
+		case matched && exempt:
+			t.Errorf("task %q has the ToggleFields shape but is listed as exempt (%q); drop it from toggleTasksWithOwnFields", name, reason)
+		case !matched && !exempt:
+			t.Errorf("task %q restates the toggle field set; declare it as `type %s ToggleFields`, or explain the difference in toggleTasksWithOwnFields", name, rt.Name())
+		}
+	}
+
+	// A walk that silently found nothing would leave the whole test vacuous, so
+	// cross-check the AST predicate against the independent one it replaced:
+	// every task named `*_toggle` had better be in the set.
+	for name := range RegisteredTasks {
+		if strings.HasSuffix(name, "_toggle") && !toggles[name] {
+			t.Errorf("task %q is named as a toggle but its Plan() does not reach planToggle, so the shared-field check skipped it", name)
+		}
+	}
+
+	for name := range toggleTasksWithOwnFields {
+		if _, ok := RegisteredTasks[name]; !ok {
+			t.Errorf("toggleTasksWithOwnFields names %q, which is not a registered task", name)
+		}
+	}
+}
+
+// TestToggleFieldsShapeIsTagSensitive proves the check above fires on the
+// duplication it exists to stop, not merely on a differing field list. The four
+// copies #467 removed differed from one another in exactly one struct tag - the
+// plugin named in the `state` description - so a shape comparison blind to tags
+// would have called every one of them a match and enforced nothing.
+func TestToggleFieldsShapeIsTagSensitive(t *testing.T) {
+	shared := reflect.TypeOf(ToggleFields{})
+
+	// Same field names and types as ToggleFields, one plugin-specific description.
+	type pluginSpecificToggle struct {
+		App   string `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
+		State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the checks plugin"`
+	}
+
+	if sameStructShape(reflect.TypeOf(pluginSpecificToggle{}), shared) {
+		t.Error("a struct differing from ToggleFields only in the state description matches it; the shape check is not reading tags")
+	}
+	if !sameStructShape(reflect.TypeOf(ChecksToggleTask{}), shared) {
+		t.Error("ChecksToggleTask does not match ToggleFields, so the shape check would reject every toggle task")
+	}
+}

--- a/tests/bats/schema.bats
+++ b/tests/bats/schema.bats
@@ -96,6 +96,38 @@ setup() {
     fail "dokku_builds_property state lost its default or its choices"
 }
 
+@test "docket schema publishes the whole shape of a toggle task (#467)" {
+  run "$(docket_bin)" schema
+  assert_success
+
+  # The toggle tasks declare their fields once, as `type XToggleTask
+  # ToggleFields`. A recipe key that went missing from the published contract
+  # would be invisible in the Go tests that read the same struct, so assert the
+  # two keys and their tags from the outside.
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_checks_toggle")
+           | [.fields[].name] == ["app", "state"]' >/dev/null ||
+    fail "dokku_checks_toggle does not publish both recipe keys in order"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_checks_toggle")
+           | ([.fields[] | select(.identity == "key") | .name] == ["app"])
+             and ([.fields[] | select(.required) | .name] == ["app"])' >/dev/null ||
+    fail "dokku_checks_toggle does not key on app alone"
+
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_checks_toggle") | .fields[] | select(.name == "state")
+           | .default == "present" and .choices == ["present", "absent"]' >/dev/null ||
+    fail "dokku_checks_toggle state lost its default or its choices"
+
+  # dokku_maintenance is a toggle that is not named like one, so nothing but an
+  # assertion keeps it on the shared field set.
+  echo "$output" |
+    jq -e '.tasks[] | select(.type == "dokku_maintenance")
+           | [.fields[].name] == ["app", "state"]' >/dev/null ||
+    fail "dokku_maintenance does not publish the toggle recipe keys"
+}
+
 @test "docket schema publishes a property task's supported property names" {
   run "$(docket_bin)" schema
   assert_success


### PR DESCRIPTION
The three toggle tasks and `dokku_maintenance` each restated the same `app` and `state` field set, so every cross-cutting change had to be applied four times by hand. They now name a defined type over the shared `ToggleFields`. A defined type rather than an embedded struct keeps the field set flat to reflection, so the catalog, the required-field walk behind `missing_required_field`, the identity walk that names an unnamed task and the sensitive-value walks read the fields exactly as before. The parameter descriptions become plugin-agnostic as a result, which is what regenerates the task pages; each page's title and synopsis already name the plugin. `TestToggleTasksDeclareTheSharedFields` decides which tasks are toggles by whether their `Plan()` reaches `planToggle` rather than by their name, which is what keeps `dokku_maintenance` bound to the shared set despite not being spelled like one. The contributor docs described a `planToggle` signature removed in #322 and two envelope examples used a `state:` value no task accepts; both are corrected here. Fixes #467.
