### PR TITLE
fix: mask sensitive values in --list-tasks

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -240,6 +240,15 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Task-declared sensitive values join the input-level ones registered
+	// above, ahead of anything that renders a task name. Both branches below
+	// echo names and return without reaching the run loop: the
+	// --start-at-task hint lists every available name, and --list-tasks
+	// renders the whole resolved plan. Collecting from the filtered play
+	// list rather than the whole file keeps a value that is only secret in a
+	// play --play excluded from masking output it never appears in.
+	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
+
 	if c.startAtTask != "" {
 		if !startAtTaskMatches(plays, c.startAtTask) {
 			c.Ui.Error(subprocess.MaskString(fmt.Sprintf(
@@ -261,8 +270,6 @@ func (c *ApplyCommand) Run(args []string) int {
 			jsonOut:       c.json,
 		})
 	}
-
-	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if resolvedHost != "" {
 		defer subprocess.CloseSshControlMaster(resolvedHost)

--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/dokku/docket/tasks"
 	"github.com/mitchellh/cli"
 )
@@ -45,6 +46,14 @@ type listTasksOptions struct {
 // rendered [skipped], [unknown] or [when?] is never evaluated by a run,
 // so its own [when?] prints but leaves the exit code alone - the same
 // reason a skipped play's tasks are not walked at all.
+//
+// Every string this walk emits is masked against the global sensitive value
+// set (#455). The listing renders resolved values, so a `sensitive: true`
+// input interpolated into a play name, a task name, a `when:` predicate, a
+// tag, or a loop item would otherwise come back verbatim - and since #427 an
+// unnamed task's name embeds its identity field values, which widened what
+// can reach it. Callers register the task-declared values before this runs
+// (commands/apply.go, commands/plan.go).
 func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 	// whenError records that at least one predicate failed to evaluate.
 	// The walk is not short-circuited - every remaining play and task is
@@ -56,20 +65,31 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 		if play.IsFileLevel() {
 			continue
 		}
+		// Each recipe-derived value is masked exactly once, here, and both
+		// the human and the --json branch read only the masked form. Masking
+		// per value rather than per output site is what keeps the two paths
+		// from drifting apart, and it leaves docket's own decorations - the
+		// `==> Play: ` prefix, the markers, `(group)` - untouched.
+		playName := subprocess.MaskString(play.Name)
 		if play.HasWhen() {
+			whenSrc := subprocess.MaskString(play.When)
 			playCtx := buildEnvelopeExprContext(buildPlayWhenContext(opts.context, opts.fileLevelKeys, opts.userSet))
 			ok, err := tasks.EvalBool(play.WhenProgram(), playCtx)
 			if err != nil {
 				whenError = true
+				// An expr runtime error quotes the predicate's own source
+				// back in its snippet, so the formatted error - not just the
+				// play name - carries whatever the predicate interpolated.
+				reason := subprocess.MaskString(fmt.Sprintf("when error: %v", err))
 				if opts.jsonOut {
 					emitListJSON(ui, map[string]interface{}{
 						"type":   "play_skipped",
-						"play":   play.Name,
-						"when":   play.When,
-						"reason": fmt.Sprintf("when error: %v", err),
+						"play":   playName,
+						"when":   whenSrc,
+						"reason": reason,
 					})
 				} else {
-					ui.Output(fmt.Sprintf("==> Play: %s  (when error: %v)", play.Name, err))
+					ui.Output(fmt.Sprintf("==> Play: %s  (%s)", playName, reason))
 				}
 				continue
 			}
@@ -77,24 +97,24 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 				if opts.jsonOut {
 					emitListJSON(ui, map[string]interface{}{
 						"type":   "play_skipped",
-						"play":   play.Name,
-						"when":   play.When,
-						"reason": "when: " + play.When,
+						"play":   playName,
+						"when":   whenSrc,
+						"reason": "when: " + whenSrc,
 					})
 				} else {
-					ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", play.Name, play.When))
+					ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", playName, whenSrc))
 				}
 				continue
 			}
 		}
 
 		if !opts.jsonOut {
-			ui.Output(fmt.Sprintf("==> Play: %s", play.Name))
+			ui.Output(fmt.Sprintf("==> Play: %s", playName))
 		}
 
 		rc := listRenderContext{
 			ui:          ui,
-			playName:    play.Name,
+			playName:    playName,
 			playExprCtx: buildEnvelopeExprContext(tasks.BuildPerPlayContext(opts.context, play.Inputs, opts.userSet)),
 			jsonOut:     opts.jsonOut,
 		}
@@ -135,13 +155,17 @@ type listRenderContext struct {
 // reachable position anywhere in this subtree, which is what fails the
 // listing.
 //
-// The displayed label is the envelope name as-is. Before #427 an unnamed task
+// The displayed label is the envelope name, masked. Before #427 an unnamed task
 // carried a random `task #N <hex>` name, and this function substituted the
 // task type plus the first field named App / Name / Service / ... to keep the
 // listing readable - a heuristic that collapsed every phase and option of one
 // app's dokku_docker_options onto the same line. The loader now names an
 // unnamed task after the resource it addresses, so there is nothing to
 // substitute.
+//
+// Masking is display-only: env.Name keeps its real value, so --start-at-task
+// matching, the duplicate-name guard, and the loop collision suffix all still
+// work on the unmasked names even when two lines render identically.
 func renderListEnvelope(
 	rc listRenderContext,
 	env *tasks.TaskEnvelope,
@@ -151,12 +175,21 @@ func renderListEnvelope(
 	reachable bool,
 ) bool {
 	skipMarker := evaluateListWhen(env, rc.playExprCtx, phase)
-	display := env.Name
+	// Same rule as the play loop: every recipe-derived value is masked once
+	// here and both branches below read only the masked form. `probe` and
+	// `phase` are deliberately absent - they are docket's own vocabulary,
+	// pinned as enums in docs/schemas/list-tasks-v1.schema.json, and masking
+	// one would emit a stream that fails its own schema.
+	display := subprocess.MaskString(env.Name)
+	whenSrc := subprocess.MaskString(env.When)
+	tags := maskedStrings(env.Tags)
 	deprecation := ""
+	caveat := ""
 	var probe tasks.ProbeSupport
 	if env != nil && env.Task != nil {
-		deprecation = tasks.TaskDeprecation(env.Task)
+		deprecation = subprocess.MaskString(tasks.TaskDeprecation(env.Task))
 		probe, _ = tasks.TaskProbeSupport(env.Task)
+		caveat = subprocess.MaskString(probe.Caveat)
 	}
 
 	if rc.jsonOut {
@@ -166,8 +199,8 @@ func renderListEnvelope(
 			"name":  display,
 			"index": index,
 		}
-		if len(env.Tags) > 0 {
-			ev["tags"] = append([]string{}, env.Tags...)
+		if len(tags) > 0 {
+			ev["tags"] = tags
 		}
 		if env.IsGroup() {
 			ev["group"] = true
@@ -181,23 +214,23 @@ func renderListEnvelope(
 		}
 		if probe.Status == tasks.ProbeUnsupported || probe.Status == tasks.ProbePartial {
 			ev["probe"] = string(probe.Status)
-			ev["probe_caveat"] = probe.Caveat
+			ev["probe_caveat"] = caveat
 		}
 		switch skipMarker {
 		case "skipped":
 			ev["skipped"] = true
-			ev["when"] = env.When
+			ev["when"] = whenSrc
 		case "unknown":
 			ev["unknown"] = true
-			ev["when"] = env.When
+			ev["when"] = whenSrc
 		case "when_error":
 			ev["when_error"] = true
-			ev["when"] = env.When
+			ev["when"] = whenSrc
 		}
 		if env.IsLoopExpansion {
 			ev["loop_index"] = env.LoopIndex
 			if env.LoopItem != nil {
-				ev["loop_item"] = env.LoopItem
+				ev["loop_item"] = subprocess.MaskValue(env.LoopItem)
 			}
 		}
 		emitListJSON(rc.ui, ev)
@@ -233,8 +266,8 @@ func renderListEnvelope(
 		case tasks.ProbePartial:
 			b.WriteString("  (partial probe)")
 		}
-		if len(env.Tags) > 0 {
-			b.WriteString(fmt.Sprintf("  [tags=%s]", strings.Join(env.Tags, ",")))
+		if len(tags) > 0 {
+			b.WriteString(fmt.Sprintf("  [tags=%s]", strings.Join(tags, ",")))
 		}
 		rc.ui.Output(b.String())
 	}

--- a/commands/list_tasks_masking_test.go
+++ b/commands/list_tasks_masking_test.go
@@ -1,0 +1,389 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// list_tasks_masking_test.go covers #455: --list-tasks masks registered
+// sensitive values on both the human and the --json path. The listing renders
+// resolved values, so before #455 a `sensitive: true` input came back verbatim
+// in every field it reached, and a task-declared secret was not even in the
+// registry - commands/apply.go returned from the listing branch before
+// CollectPlaySensitiveValues ran.
+//
+// One test per field a secret can travel through, plus the two that pin what
+// must *not* be masked.
+
+// listMasksIdentityRecipe interpolates a sensitive input into a dokku_stub identity
+// field. Since #427 an unnamed task is named after the resource it addresses,
+// so the secret lands in the generated name.
+const listMasksIdentityRecipe = `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_stub: { key: "{{ .secret_value }}" }
+`
+
+func TestListTasksMasksSensitiveInputInGeneratedName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, listMasksIdentityRecipe)
+
+	stdout, _, exit := runApply(t, path, "--secret_value=identityzzz", "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "identityzzz") {
+		t.Errorf("listing leaked the sensitive input in the generated name; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "dokku_stub[key=***]") {
+		t.Errorf("expected the address to render with a masked key; got:\n%s", stdout)
+	}
+}
+
+func TestListTasksJSONMasksSensitiveInputInGeneratedName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, listMasksIdentityRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value=identityzzz", "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "identityzzz") {
+		t.Errorf("--json listing leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"dokku_stub[key=***]"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+// TestPlanListTasksMasksSensitiveInput pins that plan's listing branch got the
+// same treatment as apply's - they are separate call sites for the same
+// renderer, and only apply's was covered above.
+func TestPlanListTasksMasksSensitiveInput(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, listMasksIdentityRecipe)
+
+	stdout, _, exit := runPlan(t, path, "--secret_value=identityzzz", "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "identityzzz") {
+		t.Errorf("plan listing leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "***") {
+		t.Errorf("expected the mask placeholder; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksMasksSensitiveInputInWhen covers a task predicate that
+// sigil-interpolates a secret: the rendered source is what the [skipped] line
+// and the `when` field carry.
+func TestListTasksMasksSensitiveInputInWhen(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: gated
+      when: '"{{ .secret_value }}" == "will-not-match"'
+      dokku_stub: { key: a }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value=taskwhenzzz", "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "taskwhenzzz") {
+		t.Errorf("task when: leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"skipped":true`) || !strings.Contains(stdout, "***") {
+		t.Errorf("expected a masked when on a skipped task; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksMasksSensitivePlayWhen covers the play_skipped event, whose
+// play / when / reason fields are emitted by a different branch than the
+// per-task ones.
+func TestListTasksMasksSensitivePlayWhen(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- name: play {{ .secret_value }}
+  inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  when: '"{{ .secret_value }}" == "will-not-match"'
+  tasks:
+    - dokku_stub: { key: a }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value=playwhenzzz", "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "playwhenzzz") {
+		t.Errorf("play_skipped leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"play":"play ***"`) {
+		t.Errorf("expected a masked play name; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"reason":"when: `) || !strings.Contains(stdout, "***") {
+		t.Errorf("expected a masked reason; got:\n%s", stdout)
+	}
+
+	stdout, _, exit = runApply(t, path, "--secret_value=playwhenzzz", "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "playwhenzzz") {
+		t.Errorf("human play skip line leaked the sensitive input; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksMasksSensitiveLoopItem covers both fields a loop expansion
+// contributes: the `(item=<value>)` suffix on the name, and loop_item itself,
+// which is the one listing field that is not a string.
+func TestListTasksMasksSensitiveLoopItem(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: deploy
+      loop: 'split(secret_value, ",")'
+      dokku_stub: { key: "{{ .item }}" }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value=loopitemzzz", "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "loopitemzzz") {
+		t.Errorf("loop expansion leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"loop_item":"***"`) {
+		t.Errorf("expected a masked loop_item; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"deploy (item=***)"`) {
+		t.Errorf("expected a masked loop item in the name; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksMasksSensitiveTags covers the tags array, which is rendered
+// from the same whole-file template pass as the rest of the recipe.
+func TestListTasksMasksSensitiveTags(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: tagged
+      tags: ["{{ .secret_value }}"]
+      dokku_stub: { key: a }
+`)
+
+	stdout, _, exit := runApply(t, path, "--secret_value=tagsecretzzz", "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "tagsecretzzz") {
+		t.Errorf("human listing leaked the sensitive tag; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[tags=***]") {
+		t.Errorf("expected a masked tag suffix; got:\n%s", stdout)
+	}
+
+	stdout, _, exit = runApply(t, path, "--secret_value=tagsecretzzz", "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "tagsecretzzz") {
+		t.Errorf("--json listing leaked the sensitive tag; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"tags":["***"]`) {
+		t.Errorf("expected a masked tags array; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksMasksTaskDeclaredSensitiveValue pins the other half of #455:
+// the registry move in commands/apply.go. dokku_config declares its whole
+// `config:` map sensitive through SensitiveValues(), and nothing here is a
+// sensitive *input* - so the value reaches the mask registry only via
+// CollectPlaySensitiveValues. Fails if that call moves back below the
+// --list-tasks branch.
+func TestListTasksMasksTaskDeclaredSensitiveValue(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: configure
+      loop: [taskdeclaredzzz]
+      dokku_config:
+        app: api
+        config:
+          TOKEN: "{{ .item }}"
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "taskdeclaredzzz") {
+		t.Errorf("listing leaked a task-declared sensitive value; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"loop_item":"***"`) {
+		t.Errorf("expected a masked loop_item; got:\n%s", stdout)
+	}
+}
+
+// TestApplyStartAtTaskUnknownMasksTaskDeclaredSecret covers the second leak the
+// registry move closes: the --start-at-task hint lists every available name
+// and already calls MaskString, but before #455 the task-declared values were
+// not registered yet when it ran.
+func TestApplyStartAtTaskUnknownMasksTaskDeclaredSecret(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: configure taskdeclaredzzz
+      dokku_config:
+        app: api
+        config:
+          TOKEN: taskdeclaredzzz
+`)
+
+	_, stderr, exit := runApply(t, path, "--start-at-task", "nope")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%s", exit, stderr)
+	}
+	if strings.Contains(stderr, "taskdeclaredzzz") {
+		t.Errorf("--start-at-task hint leaked a task-declared sensitive value; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "***") {
+		t.Errorf("expected the mask placeholder in the hint; got:\n%s", stderr)
+	}
+}
+
+// TestListTasksMasksSensitiveInputInPlayWhenError covers the expr snippet: a
+// runtime error from a predicate quotes the predicate's own source back in
+// its `| <source>` frame, so the formatted error echoes the recipe line - the
+// play name alone is not enough to mask.
+func TestListTasksMasksSensitiveInputInPlayWhenError(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- name: broken
+  inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  when: '[][0] == "{{ .secret_value }}"'
+  tasks:
+    - dokku_stub: { key: a }
+
+- name: listed
+  tasks:
+    - name: still listed
+      dokku_stub: { key: b }
+`)
+
+	stdout, _, exit := runApply(t, path, "--secret_value=whenerrzzz", "--list-tasks")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "whenerrzzz") {
+		t.Errorf("the when-error snippet leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "(when error:") {
+		t.Errorf("expected the when error form to survive masking; got:\n%s", stdout)
+	}
+
+	stdout, _, exit = runApply(t, path, "--secret_value=whenerrzzz", "--list-tasks", "--json")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s", exit, stdout)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "whenerrzzz") {
+		t.Errorf("--json when-error reason leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"reason":"when error:`) {
+		t.Errorf("expected the when error reason form; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksJSONMasksLoopItemStructure drives the recursive walker end to
+// end: loop_item is the one listing field that is not a string, and a loop
+// over mappings puts a secret one level down from where MaskString reaches.
+func TestListTasksJSONMasksLoopItemStructure(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: deploy
+      loop:
+        - { user: alice, token: "{{ .secret_value }}" }
+      dokku_stub: { key: "{{ .item.user }}" }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value=nestedzzz", "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "nestedzzz") {
+		t.Errorf("a nested loop_item value leaked the sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"token":"***"`) {
+		t.Errorf("expected the nested token to be masked; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"user":"alice"`) {
+		t.Errorf("masking must leave the rest of the mapping intact; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksDoesNotMaskStructuralDecorations pins the other half of the
+// rule: docket's own vocabulary is never masked. `probe` and `phase` are
+// schema-pinned enums, so masking one would emit a stream that fails
+// docs/schemas/list-tasks-v1.schema.json - while `probe_caveat`, which is
+// prose, is masked like everything else.
+//
+// The secret is chosen to be a substring of every decoration under test.
+func TestListTasksDoesNotMaskStructuralDecorations(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: gate
+      block:
+        - name: unprobeable
+          dokku_git_auth:
+            host: github.com
+            username: u
+            password: p
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value=netrc", "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	for _, want := range []string{`"group":true`, `"phase":"block"`, `"probe":"unsupported"`} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("masking must not touch %s; got:\n%s", want, stdout)
+		}
+	}
+	if !strings.Contains(stdout, `"probe_caveat":"*** state has no read command`) {
+		t.Errorf("expected the prose caveat to be masked; got:\n%s", stdout)
+	}
+
+	stdout, _, exit = runApply(t, path, "--secret_value=group", "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	for _, want := range []string{"(group)", "[block] ", "(never converges)"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("masking must not touch the %q decoration; got:\n%s", want, stdout)
+		}
+	}
+}

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -110,7 +110,7 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 	default:
 		out["status"] = "ok"
 	}
-	if cmds := maskedCommands(ev.State.Commands); len(cmds) > 0 {
+	if cmds := maskedStrings(ev.State.Commands); len(cmds) > 0 {
 		out["commands"] = cmds
 	}
 	if ev.Phase != "" {
@@ -159,9 +159,9 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 			out["reason"] = subprocess.MaskString(ev.Result.Reason)
 		}
 		if len(ev.Result.Mutations) > 0 {
-			out["mutations"] = maskedCommands(ev.Result.Mutations)
+			out["mutations"] = maskedStrings(ev.Result.Mutations)
 		}
-		if cmds := maskedCommands(ev.Result.Commands); len(cmds) > 0 {
+		if cmds := maskedStrings(ev.Result.Commands); len(cmds) > 0 {
 			out["commands"] = cmds
 		}
 	}
@@ -236,16 +236,18 @@ func (e *JSONEmitter) write(ev map[string]interface{}) {
 	e.ui.Output(string(b))
 }
 
-// maskedCommands returns a copy of cmds with each entry passed through
+// maskedStrings returns a copy of in with each entry passed through
 // subprocess.MaskString. Returns nil for an empty slice so the caller can
-// detect "no commands" and omit the JSON field.
-func maskedCommands(cmds []string) []string {
-	if len(cmds) == 0 {
+// detect "nothing here" and omit the JSON field. Serves the run stream's
+// `commands` and `mutations` arrays and the --list-tasks `tags` array, all of
+// which are rendered from the recipe and can carry an interpolated secret.
+func maskedStrings(in []string) []string {
+	if len(in) == 0 {
 		return nil
 	}
-	out := make([]string, len(cmds))
-	for i, c := range cmds {
-		out[i] = subprocess.MaskString(c)
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = subprocess.MaskString(v)
 	}
 	return out
 }

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -230,6 +230,14 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Task-declared sensitive values join the input-level ones registered
+	// above, ahead of the --list-tasks branch below: it renders the whole
+	// resolved plan and returns without reaching the run loop. Collecting
+	// from the filtered play list rather than the whole file keeps a value
+	// that is only secret in a play --play excluded from masking output it
+	// never appears in.
+	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
+
 	if c.listTasks {
 		return renderListTasks(c.Ui, listTasksOptions{
 			plays:         plays,
@@ -241,8 +249,6 @@ func (c *PlanCommand) Run(args []string) int {
 			jsonOut:       c.json,
 		})
 	}
-
-	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if resolvedHost != "" {
 		defer subprocess.CloseSshControlMaster(resolvedHost)

--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -227,11 +227,12 @@ masked as `***` everywhere in the `apply` / `plan` / `validate` output, includin
 `name`. A wrapper cannot read a secret back out of those streams, which is the point - but it also
 means a wrapper must not diff a returned value against the one it sent.
 
-The one exception is `--list-tasks`, which renders the resolved plan before any sensitive value is
-registered and does no masking at all: an interpolated secret comes back verbatim in `name`,
-`when`, and `loop_item`. Never surface that stream to an Ansible caller. No task field is ever both
-an identity key and `sensitive:"true"`, so a generated `name` never embeds a task-declared secret -
-but a `sensitive: true` input interpolated into an identity field still reaches it.
+`--list-tasks` masks on the same terms, on both the human and the `--json` path: an interpolated
+secret comes back as `***` in `name`, `when`, `tags`, and `loop_item`. No task field is ever both an
+identity key and `sensitive:"true"`, so a generated `name` never embeds a task-declared secret - but
+a `sensitive: true` input interpolated into an identity field still reaches it, and is masked there
+too. A wrapper that resumes a run cannot feed such a name back to `--start-at-task`, which matches
+on the real value; emit an explicit `name:` on any task it needs to address.
 
 ## Module mapping
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -396,6 +396,13 @@ $ docket apply --list-tasks
 With `--json`, the same information is a `probe` field (`unsupported` or `partial`) plus a
 `probe_caveat` naming what cannot be read; a task that probes everything it manages carries neither.
 
+Sensitive values are masked in the listing exactly as they are in a run. A task name, play name,
+tag, `when:` predicate, or loop item that interpolated a `sensitive: true` input or a task field
+tagged `sensitive:"true"` renders as `***` on both the human and the `--json` path, so the listing
+is safe to paste into a ticket or a CI log. `--start-at-task` still matches on the real name, which
+means a name masked down to `***` cannot be copied out of the listing and used verbatim - write an
+explicit `name:` on any task you need to resume at.
+
 `--start-at-task <name>` takes an exact task `name:`. Earlier tasks render as `[skipped]` with a
 `(before --start-at-task)` reason and do not run; the matched task and everything after it run:
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -10,9 +10,13 @@ future schema change does not silently break them. Values marked sensitive - inp
 `sensitive: true`, or task fields tagged `sensitive:"true"` - are masked as `***`. Masking covers
 every string field a secret can reach, including `name` and `play` (a loop over a sensitive value
 expands the task name) and the `when` / `reason` fields on `play_skipped` (a play predicate can
-interpolate a sensitive input). Masking applies to the `apply` / `plan` run stream and to
-`validate --json`; the `--list-tasks --json` stream is **not** masked, so do not route it anywhere a
-secret must not land.
+interpolate a sensitive input). It applies to every stream docket emits: the `apply` / `plan` run
+stream, `validate --json`, and `--list-tasks --json` - including that stream's `loop_item`, whose
+strings are masked at any depth, object keys included.
+
+What is never masked is docket's own vocabulary: the `type`, `phase`, `probe`, and `status` fields
+are fixed enums rather than recipe content, and masking one would emit a stream that fails the
+schemas below.
 
 ## Correlating runs
 
@@ -25,7 +29,8 @@ Two caveats on masking, both of which can make two distinct tasks indistinguisha
 
 - A generated name embeds the task's identity field values. No field is ever both an identity key
   and declared sensitive, but a `sensitive: true` input interpolated into one still reaches the
-  name - masked in this stream, in the clear in `--list-tasks --json`.
+  name, and it is masked there. A name that renders entirely as `***` also cannot be pasted back
+  into `--start-at-task`, which matches on the real name.
 - Masking is substring replacement. A short sensitive value can mask a large part of two different
   names into the same `***`-bearing string. Pin a `name:` on the tasks a consumer must tell apart.
 
@@ -68,15 +73,16 @@ ordering. The `reason` is a stable machine key so consumers can branch on the ca
 In every case `message` is masked, so a registered sensitive value that reaches the warning (for
 example server stderr echoed by a rejected probe) renders as `***`. `--list-tasks --json` does not
 emit a separate `warning` event; instead, the `list_task` event for a deprecated task carries
-`"deprecated": true` and a `deprecation` field with the message.
+`"deprecated": true` and a `deprecation` field with the message, masked the same way.
 
 `unknown_property` and `probe_rejected` are probe failures: this run could not read the state, and
 another run against a different server or a newer plugin might. A task type that can *never* read
 its state is a different thing, declared rather than discovered, and it is not a warning at all. The
 `list_task` event carries it as `"probe": "unsupported"` (the task reports drift on every run) or
 `"probe": "partial"` (only some of its fields are read), each with a `probe_caveat` naming what
-cannot be read. Both keys are absent for a task that probes everything it manages. A recipe
-containing an `unsupported` task never exits `0` under `--detailed-exitcode`.
+cannot be read. Both keys are absent for a task that probes everything it manages. `probe_caveat` is
+prose and is masked; `probe` is an enum and is not. A recipe containing an `unsupported` task never
+exits `0` under `--detailed-exitcode`.
 
 ## Commands
 

--- a/docs/schemas/list-tasks-v1.schema.json
+++ b/docs/schemas/list-tasks-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/dokku/docket/main/docs/schemas/list-tasks-v1.schema.json",
   "title": "docket --list-tasks JSON-lines event",
-  "description": "One event emitted by `docket apply --list-tasks --json` or `docket plan --list-tasks --json`. This is a separate stream from the apply/plan run stream: no task runs, no server is contacted, and there is no summary event. Its `play_skipped` carries `play` where the run stream's carries `name`, and no `ts`. See docs/json-output.md.",
+  "description": "One event emitted by `docket apply --list-tasks --json` or `docket plan --list-tasks --json`. This is a separate stream from the apply/plan run stream: no task runs, no server is contacted, and there is no summary event. Its `play_skipped` carries `play` where the run stream's carries `name`, and no `ts`. Sensitive values - inputs declared `sensitive: true` and task fields tagged `sensitive:\"true\"` - are masked as `***`, the same as in the run stream. See docs/json-output.md.",
   "type": "object",
   "required": ["version", "type"],
   "properties": {
@@ -23,11 +23,11 @@
       "properties": {
         "version": { "$ref": "#/$defs/version" },
         "type": { "const": "play_skipped" },
-        "play": { "type": "string" },
-        "when": { "type": "string", "description": "The play predicate source." },
+        "play": { "type": "string", "description": "The play name, masked." },
+        "when": { "type": "string", "description": "The play predicate source, masked." },
         "reason": {
           "type": "string",
-          "description": "Either `when: <src>` for a false predicate or `when error: <err>` for one that failed to evaluate."
+          "description": "Either `when: <src>` for a false predicate or `when error: <err>` for one that failed to evaluate. Masked - an expr runtime error quotes the predicate source back."
         }
       }
     },
@@ -42,7 +42,7 @@
         "play": { "type": "string" },
         "name": {
           "type": "string",
-          "description": "The task's `name:`, or - when the recipe omits one - the address of the resource it manages (`dokku_config[app=api]`). Stable across runs of the same recipe."
+          "description": "The task's `name:`, or - when the recipe omits one - the address of the resource it manages (`dokku_config[app=api]`). Stable across runs of the same recipe. Masked, so a name that interpolated a secret renders as `***` and cannot be pasted back into `--start-at-task`."
         },
         "index": {
           "type": "integer",
@@ -52,7 +52,7 @@
         "tags": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Present only when the task carries tags."
+          "description": "Present only when the task carries tags. Masked."
         },
         "group": {
           "type": "boolean",
@@ -62,21 +62,21 @@
         "phase": {
           "type": "string",
           "enum": ["block", "rescue", "always"],
-          "description": "Set on a child of a group, naming the clause it belongs to."
+          "description": "Set on a child of a group, naming the clause it belongs to. Never masked - it is a fixed enum, not recipe content."
         },
         "deprecated": { "type": "boolean", "const": true },
         "deprecation": {
           "type": "string",
-          "description": "The deprecation notice. --list-tasks --json carries it here instead of emitting a separate warning event."
+          "description": "The deprecation notice. --list-tasks --json carries it here instead of emitting a separate warning event. Masked, matching the run stream's `warning.message`."
         },
         "probe": {
           "type": "string",
           "enum": ["partial", "unsupported"],
-          "description": "How much of its own state the task type can read. `unsupported` means it plans as drift on every run and never converges; `partial` means some of its fields do. Absent when the task probes everything it manages."
+          "description": "How much of its own state the task type can read. `unsupported` means it plans as drift on every run and never converges; `partial` means some of its fields do. Absent when the task probes everything it manages. Never masked - it is a fixed enum, not recipe content."
         },
         "probe_caveat": {
           "type": "string",
-          "description": "Human-readable note naming what cannot be read. Present whenever `probe` is."
+          "description": "Human-readable note naming what cannot be read. Present whenever `probe` is. Masked."
         },
         "skipped": {
           "type": "boolean",
@@ -95,7 +95,7 @@
         },
         "when": {
           "type": "string",
-          "description": "The predicate source. Present with skipped, unknown, or when_error."
+          "description": "The predicate source, masked. Present with skipped, unknown, or when_error."
         },
         "loop_index": {
           "type": "integer",
@@ -103,7 +103,7 @@
           "description": "Present on an expanded loop iteration."
         },
         "loop_item": {
-          "description": "The loop item for this iteration. Any JSON value."
+          "description": "The loop item for this iteration. Any JSON value. Every string inside it is masked at any depth, object keys included."
         }
       }
     }

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -59,6 +59,10 @@ Two properties follow, and both are the point:
   docket apply --start-at-task 'dokku_config[app=api]'
   ```
 
+  An address built from a `sensitive: true` input is masked wherever it is printed, so it comes back
+  as `dokku_config[app=***]` and cannot be copied out and used here. Write an explicit `name:` on
+  such a task.
+
 The desired state is deliberately *not* part of the address. `state: absent` on an app's config
 addresses the same resource as `state: present`, so changing a task's state does not rename it.
 

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -145,7 +145,9 @@ Three rules decide what is a key, and none of them is "the required fields":
   the address, which is what makes the two scopes render differently.
 
 A field must never be both `identity:"key"` and `sensitive:"true"`. An identity key is rendered into
-the task name, and `--list-tasks` does not mask - `TestIdentityKeysAreNeverSensitive` enforces this.
+the task name, and every stream masks the name - so a sensitive key would render the whole address
+as `dokku_config[app=***]`, which the reader can see but cannot type back into `--start-at-task` or
+`docket export --resource`. `TestIdentityKeysAreNeverSensitive` enforces this.
 
 Leave a collection untagged when it is an *attribute* of the resource rather than the set of items
 the task manages: `dokku_storage_mount`'s `phases` narrows one mount, it is not a set of mounts.

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -1,6 +1,8 @@
 package subprocess
 
 import (
+	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -111,4 +113,91 @@ func MaskString(s string) string {
 		s = strings.ReplaceAll(s, v, maskPlaceholder)
 	}
 	return s
+}
+
+// MaskValue returns v with every registered sensitive value replaced by `***`
+// in every string it contains, walking slices and maps recursively. Non-string
+// scalars - numbers, booleans, nil - are returned unchanged: masking is
+// substring replacement over text, and a value that carried a secret would
+// have been rendered as a string before it got here.
+//
+// Map keys are masked as well as map values. A recipe is rendered as one
+// template before it is parsed, so a key is interpolated user data exactly as
+// a value is. Two keys that differ only inside a secret therefore collapse
+// into a single `***` entry - the same "two distinct values become
+// indistinguishable" trade-off masking already makes for task names.
+//
+// It exists for the values that reach a stream as interface{} - today the
+// `loop_item` field of `--list-tasks --json`, which carries whatever the
+// recipe's `loop:` resolved to: a scalar, a list, or a mapping. Masking the
+// value rather than the marshalled line is deliberate: a secret containing a
+// quote or a backslash is escaped in the serialised form, so MaskString would
+// no longer match it there.
+func MaskValue(v interface{}) interface{} {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case string:
+		return MaskString(t)
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, item := range t {
+			out[i] = MaskValue(item)
+		}
+		return out
+	case []string:
+		out := make([]string, len(t))
+		for i, item := range t {
+			out[i] = MaskString(item)
+		}
+		return out
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, item := range t {
+			out[MaskString(k)] = MaskValue(item)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]string, len(t))
+		for k, item := range t {
+			out[MaskString(k)] = MaskString(item)
+		}
+		return out
+	}
+	return maskReflectValue(v)
+}
+
+// maskReflectValue is the fallback for the container types the switch in
+// MaskValue does not name - the typed slices and maps an expr-evaluated
+// `loop:` can produce, and the map[interface{}]interface{} shape a
+// hand-built value can carry. It mirrors the reflect normalisation
+// tasks.resolveLoopList already applies on the way in. The copy is
+// interface{}-shaped because the only consumer serialises it to JSON, where
+// an object key is a string regardless. Anything that is not a slice, array,
+// or map is returned unchanged: a non-string scalar cannot carry a secret.
+func maskReflectValue(v interface{}) interface{} {
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.String:
+		return MaskString(rv.String())
+	case reflect.Slice, reflect.Array:
+		out := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = MaskValue(rv.Index(i).Interface())
+		}
+		return out
+	case reflect.Map:
+		out := make(map[string]interface{}, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			out[MaskString(fmt.Sprint(iter.Key().Interface()))] = MaskValue(iter.Value().Interface())
+		}
+		return out
+	case reflect.Ptr, reflect.Interface:
+		if rv.IsNil() {
+			return nil
+		}
+		return MaskValue(rv.Elem().Interface())
+	}
+	return v
 }

--- a/subprocess/mask_test.go
+++ b/subprocess/mask_test.go
@@ -1,6 +1,7 @@
 package subprocess
 
 import (
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -168,5 +169,78 @@ func TestGlobalSensitiveReturnsCopy(t *testing.T) {
 	again := GlobalSensitive()
 	if again[0] != "a" {
 		t.Errorf("GlobalSensitive returned shared slice; mutation leaked: %v", again)
+	}
+}
+
+// TestMaskValue covers the walker that masks a value arriving as interface{}.
+// The `loop_item` field of `--list-tasks --json` is such a value: a recipe's
+// `loop:` can resolve to a scalar, a list, or a mapping, so a secret can sit
+// at any depth and on either side of a map entry.
+func TestMaskValue(t *testing.T) {
+	SetGlobalSensitive([]string{"sekret"})
+	defer SetGlobalSensitive(nil)
+
+	cases := []struct {
+		name string
+		in   interface{}
+		want interface{}
+	}{
+		{"nil", nil, nil},
+		{"string", "a-sekret-b", "a-***-b"},
+		{"int passes through", 42, 42},
+		{"float passes through", 1.5, 1.5},
+		{"bool passes through", true, true},
+		{"string slice", []string{"sekret", "plain"}, []string{"***", "plain"}},
+		{
+			"nested list",
+			[]interface{}{"sekret", []interface{}{"sekret", 1}},
+			[]interface{}{"***", []interface{}{"***", 1}},
+		},
+		{
+			"map masks keys and values",
+			map[string]interface{}{"sekret": "sekret", "k": 1},
+			map[string]interface{}{"***": "***", "k": 1},
+		},
+		{
+			"string map",
+			map[string]string{"sekret": "sekret"},
+			map[string]string{"***": "***"},
+		},
+		{
+			"map nested in a list",
+			[]interface{}{map[string]interface{}{"token": "sekret"}},
+			[]interface{}{map[string]interface{}{"token": "***"}},
+		},
+		{
+			"typed slice reaches the reflect fallback",
+			[]map[string]string{{"token": "sekret"}},
+			[]interface{}{map[string]string{"token": "***"}},
+		},
+		{
+			"non-string map key reaches the reflect fallback",
+			map[interface{}]interface{}{"sekret": "sekret"},
+			map[string]interface{}{"***": "***"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskValue(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("MaskValue(%#v) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMaskValueEmptyRegistry pins that a value survives the walk unchanged
+// when nothing is registered, so the listing renders identically for a recipe
+// that declares no secrets.
+func TestMaskValueEmptyRegistry(t *testing.T) {
+	SetGlobalSensitive(nil)
+	defer SetGlobalSensitive(nil)
+
+	in := map[string]interface{}{"user": "alice", "ports": []interface{}{80, "443"}}
+	if got := MaskValue(in); !reflect.DeepEqual(got, in) {
+		t.Errorf("MaskValue with an empty registry = %#v, want input unchanged", got)
 	}
 }

--- a/tasks/identity_coverage_test.go
+++ b/tasks/identity_coverage_test.go
@@ -27,13 +27,14 @@ func TestEveryTaskDeclaresIdentity(t *testing.T) {
 	}
 }
 
-// TestIdentityKeysAreNeverSensitive is the guard on the one stream that is
-// deliberately unmasked. `--list-tasks --json` prints resolved values by
-// design (docs/json-output.md), and since #427 a task's name embeds its
-// identity fields - so a field that is both an identity key and a declared
-// secret would put that secret into the listing. Every task satisfies this
-// today: the payload fields that are sensitive (an image reference, an
-// archive URL, a password, a certificate) are never the address.
+// TestIdentityKeysAreNeverSensitive keeps a task's address readable. Since
+// #427 a task's name embeds its identity fields, and every stream that prints
+// a name masks it (#455) - so a field that is both an identity key and a
+// declared secret would render the whole address as `***`, and an address is
+// not just a label: it is what `--start-at-task` and `export --resource`
+// parse back. Every task satisfies this today: the payload fields that are
+// sensitive (an image reference, an archive URL, a password, a certificate)
+// are never the address.
 func TestIdentityKeysAreNeverSensitive(t *testing.T) {
 	for name, task := range RegisteredTasks {
 		rt := taskStructType(task)
@@ -43,7 +44,7 @@ func TestIdentityKeysAreNeverSensitive(t *testing.T) {
 				continue
 			}
 			if field.Tag.Get("sensitive") == "true" {
-				t.Errorf("task %q field %s is both identity:%q and sensitive:\"true\"; an identity key is rendered into the task name, which --list-tasks does not mask",
+				t.Errorf("task %q field %s is both identity:%q and sensitive:\"true\"; an identity key is rendered into the task name, which every stream masks, so the address would render as ***",
 					name, field.Name, identityTagKey)
 			}
 		}

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -381,6 +381,77 @@ EOF
   refute_output --partial '"probe"'
 }
 
+@test "--list-tasks masks a sensitive input in a generated task name" {
+  # #455: the listing renders resolved values, and since #427 an unnamed task
+  # is named after the resource it addresses - so a sensitive input
+  # interpolated into an identity field lands in the name.
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: app_name, required: true, sensitive: true }
+  tasks:
+    - dokku_app: { app: "{{ .app_name }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --app_name=listnamezzz --list-tasks
+  assert_success
+  refute_output --partial "listnamezzz"
+  assert_output --partial "dokku_app[app=***]"
+}
+
+@test "--list-tasks --json masks a sensitive input in name and loop_item" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: deploy
+      loop: 'split(secret_value, ",")'
+      dokku_app: { app: "{{ .item }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=listloopzzz --list-tasks --json
+  assert_success
+  refute_output --partial "listloopzzz"
+  assert_output --partial '"loop_item":"***"'
+  assert_output --partial '"name":"deploy (item=***)"'
+}
+
+@test "--list-tasks masks a task-declared sensitive value" {
+  # Nothing here is a sensitive *input*: dokku_config declares its whole
+  # config: map sensitive, so the value reaches the mask registry only via
+  # CollectPlaySensitiveValues, which #455 moved above the listing branch.
+  write_tasks_file <<'EOF'
+---
+- tasks:
+    - name: configure
+      loop: [listconfigzzz]
+      dokku_config:
+        app: docket-test-list-1
+        config:
+          TOKEN: "{{ .item }}"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --json
+  assert_success
+  refute_output --partial "listconfigzzz"
+  assert_output --partial '"loop_item":"***"'
+}
+
+@test "--list-tasks masks a sensitive input in a play name and when:" {
+  write_tasks_file <<'EOF'
+---
+- name: play {{ .secret_value }}
+  inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  when: '"{{ .secret_value }}" == "will-not-match"'
+  tasks:
+    - dokku_app: { app: docket-test-list-1 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=listplayzzz --list-tasks
+  assert_success
+  refute_output --partial "listplayzzz"
+  assert_output --partial "==> Play: play ***"
+  assert_output --partial "(skipped:"
+}
+
 @test "--list-tasks works on plan as well" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -2,6 +2,11 @@
 
 load test_helper
 
+# Every test here drives a real apply/plan against a dokku server, so setup()
+# gates the whole file on require_dokku. The offline masking cases - the
+# --list-tasks listing, which contacts nothing - live in list_resume.bats so
+# they still run on a box without dokku.
+
 setup() {
   require_dokku
   docket_build


### PR DESCRIPTION
The listing was the one stream that masked nothing, which made a flag whose whole purpose is to show someone the plan unsafe to show anyone. It now masks on the same terms as every other stream, so a `sensitive: true` input or a field tagged `sensitive:"true"` renders as `***` in the play name, task name, tags, `when:` source, and `loop_item` on both the human and the `--json` path. Docket's own vocabulary is deliberately left alone: `type`, `phase`, and `probe` are schema-pinned enums rather than recipe content, and masking one would emit a stream that fails its own schema.

Two consequences are documented rather than avoided. Masking is substring replacement, so a short secret can collapse two distinct task names into the same `***`-bearing string, and a generated name masked down to `***` can no longer be pasted back into `--start-at-task`, which matches on the real value. Both already applied to the run stream, and the docs now tell the reader to pin an explicit `name:` on any task a consumer has to tell apart or resume at.

One knock-on worth calling out for review: `dokku_config` registers every config value as sensitive, so a recipe with `config: { A: "1" }` now masks every `1` the listing prints. That has always been true of the run stream and the listing simply inherits it, but it is the behaviour most likely to surprise.

The whitespace gap in `renderItemForName` is left alone and tracked separately as #473: a sensitive value with surrounding whitespace renders trimmed into the `(item=<value>)` name suffix, which `MaskString` does not match. It predates this change and affects the run stream identically.

Closes #455.
