### PR TITLE
fix: mask a whitespace-padded sensitive loop item

### DIFF
--- a/commands/loop_item_whitespace_masking_test.go
+++ b/commands/loop_item_whitespace_masking_test.go
@@ -1,0 +1,191 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// loop_item_whitespace_masking_test.go covers #473: a sensitive value carrying
+// leading or trailing whitespace reaches the `(item=<value>)` task-name suffix
+// through strings.TrimSpace, so the literal registered in the mask registry no
+// longer matches it there. Every stream that prints a task name leaked it -
+// the apply and plan run streams as well as --list-tasks - so there is a case
+// per stream, on both the human and the --json path.
+//
+// The recipes all pad the value with spaces on both sides and pin the task
+// name, so the only place the item value can surface is the name suffix.
+
+// whitespaceLoopItemRecipe loops over a sensitive input whose single element
+// keeps the input's surrounding whitespace.
+const whitespaceLoopItemRecipe = `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: deploy
+      loop: 'split(secret_value, ",")'
+      dokku_stub: { key: "{{ .item }}" }
+`
+
+// whitespacePaddedSecret is the flag value every case below passes. The
+// padding is what defeats the literal match; the `zzz` suffix keeps the
+// value from colliding with anything docket prints of its own.
+const whitespacePaddedSecret = " whitespacezzz "
+
+func TestListTasksMasksWhitespacePaddedLoopItemInName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, whitespaceLoopItemRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "whitespacezzz") {
+		t.Errorf("listing leaked the whitespace-padded sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "deploy (item=***)") {
+		t.Errorf("expected a masked loop item in the name; got:\n%s", stdout)
+	}
+}
+
+func TestListTasksJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, whitespaceLoopItemRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret, "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "whitespacezzz") {
+		t.Errorf("--json listing leaked the whitespace-padded sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"deploy (item=***)"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+func TestApplyMasksWhitespacePaddedLoopItemInName(t *testing.T) {
+	defer stubReset()
+	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, whitespaceLoopItemRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "whitespacezzz") {
+		t.Errorf("the apply run stream leaked the whitespace-padded sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "deploy (item=***)") {
+		t.Errorf("expected a masked loop item in the name; got:\n%s", stdout)
+	}
+}
+
+func TestApplyJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
+	defer stubReset()
+	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, whitespaceLoopItemRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret, "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "whitespacezzz") {
+		t.Errorf("the apply --json run stream leaked the whitespace-padded sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"deploy (item=***)"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+func TestPlanMasksWhitespacePaddedLoopItemInName(t *testing.T) {
+	defer stubReset()
+	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, whitespaceLoopItemRecipe)
+
+	stdout, stderr, exit := runPlan(t, path, "--secret_value="+whitespacePaddedSecret)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "whitespacezzz") {
+		t.Errorf("the plan run stream leaked the whitespace-padded sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "deploy (item=***)") {
+		t.Errorf("expected a masked loop item in the name; got:\n%s", stdout)
+	}
+}
+
+func TestPlanJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
+	defer stubReset()
+	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, whitespaceLoopItemRecipe)
+
+	stdout, stderr, exit := runPlan(t, path, "--secret_value="+whitespacePaddedSecret, "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "whitespacezzz") {
+		t.Errorf("the plan --json run stream leaked the whitespace-padded sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"deploy (item=***)"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksMasksWhitespacePaddedTaskDeclaredLoopItem is why the trimmed
+// spelling is registered in the mask registry rather than at the loop's own
+// expansion site. Nothing here is a sensitive *input*: dokku_config declares
+// its whole `config:` map sensitive, so the value joins the registry through
+// CollectPlaySensitiveValues - after the recipe has parsed and already named
+// its expansions. A fix that trimmed at expansion time would still leak here.
+func TestListTasksMasksWhitespacePaddedTaskDeclaredLoopItem(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: configure
+      loop: [" taskdeclaredzzz "]
+      dokku_config:
+        app: api
+        config:
+          TOKEN: "{{ .item }}"
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "taskdeclaredzzz") {
+		t.Errorf("listing leaked a whitespace-padded task-declared sensitive value; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"configure (item=***)"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksLeavesUnpaddedLoopItemsAlone pins the boundary: registering the
+// trimmed spelling must not widen masking to values that merely resemble a
+// secret. `keepzzz` is not registered, so it prints in full even though the
+// registered secret trims to a different value entirely.
+func TestListTasksLeavesUnpaddedLoopItemsAlone(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: deploy
+      loop: ["{{ .secret_value }}", keepzzz]
+      dokku_stub: { key: "{{ .item }}" }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "whitespacezzz") {
+		t.Errorf("listing leaked the whitespace-padded sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "deploy (item=keepzzz)") {
+		t.Errorf("expected the non-sensitive loop item to print in full; got:\n%s", stdout)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -25,7 +25,7 @@ so a dashboard or a CI job comparing `plan` to `apply` can line them up. A task 
 the recipe is named after the [resource it manages](task-envelope.md#names-and-resource-addresses) -
 `dokku_config[app=api]` - which is stable for the same reason.
 
-Two caveats on masking, both of which can make two distinct tasks indistinguishable in the stream:
+Three caveats on masking, each of which can make two distinct tasks indistinguishable in the stream:
 
 - A generated name embeds the task's identity field values. No field is ever both an identity key
   and declared sensitive, but a `sensitive: true` input interpolated into one still reaches the
@@ -33,6 +33,10 @@ Two caveats on masking, both of which can make two distinct tasks indistinguisha
   into `--start-at-task`, which matches on the real name.
 - Masking is substring replacement. A short sensitive value can mask a large part of two different
   names into the same `***`-bearing string. Pin a `name:` on the tasks a consumer must tell apart.
+- A sensitive value carrying leading or trailing whitespace masks its trimmed spelling as well as
+  its literal one. Docket trims some of the text it builds - a loop item in a task name, for one -
+  and substring replacement would otherwise miss the trimmed form, so both are masked everywhere
+  they appear. Padding a secret therefore widens what masks rather than narrowing it.
 
 ## Events
 

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -63,18 +63,32 @@ func AddGlobalSensitive(values ...string) {
 // cleanSensitive drops empty and duplicate entries and returns the values
 // sorted by length descending so a longer secret is masked before any shorter
 // secret that is a substring of it would be.
+//
+// A value carrying leading or trailing whitespace registers its trimmed
+// spelling alongside the literal. Masking is literal substring replacement,
+// but docket renders some user-facing text through strings.TrimSpace - a loop
+// item in the `(item=<value>)` task-name suffix, most visibly - so without the
+// trimmed spelling a padded secret prints in the clear wherever it was
+// trimmed (#473). Registering both here rather than at each collection site
+// keeps the two spellings in step no matter when a value joins the registry:
+// a task-declared secret is added after the recipe has already parsed and
+// named its loop expansions.
 func cleanSensitive(values []string) []string {
 	cleaned := make([]string, 0, len(values))
 	seen := make(map[string]struct{}, len(values))
-	for _, v := range values {
+	add := func(v string) {
 		if v == "" {
-			continue
+			return
 		}
 		if _, ok := seen[v]; ok {
-			continue
+			return
 		}
 		seen[v] = struct{}{}
 		cleaned = append(cleaned, v)
+	}
+	for _, v := range values {
+		add(v)
+		add(strings.TrimSpace(v))
 	}
 	sort.SliceStable(cleaned, func(i, j int) bool {
 		return len(cleaned[i]) > len(cleaned[j])

--- a/subprocess/mask_test.go
+++ b/subprocess/mask_test.go
@@ -141,6 +141,82 @@ func TestAddGlobalSensitiveNoValuesIsNoop(t *testing.T) {
 	}
 }
 
+// TestSetGlobalSensitiveRegistersTrimmedSpelling covers #473: a secret whose
+// value carries leading or trailing whitespace is rendered trimmed in places
+// docket builds text - the `(item=<value>)` loop suffix on a task name - and
+// masking is literal substring replacement, so both spellings must register.
+func TestSetGlobalSensitiveRegistersTrimmedSpelling(t *testing.T) {
+	SetGlobalSensitive([]string{"  padded  "})
+	defer SetGlobalSensitive(nil)
+
+	if got := MaskString("deploy (item=padded)"); got != "deploy (item=***)" {
+		t.Errorf("MaskString = %q, want the trimmed spelling masked", got)
+	}
+	if got := MaskString("raw:  padded  ."); got != "raw:***." {
+		t.Errorf("MaskString = %q, want the literal spelling masked", got)
+	}
+}
+
+// TestAddGlobalSensitiveRegistersTrimmedSpelling pins the same rule on the
+// late-registration path, which is how a task-declared secret joins the
+// registry - after the recipe has parsed and already named its expansions.
+func TestAddGlobalSensitiveRegistersTrimmedSpelling(t *testing.T) {
+	SetGlobalSensitive(nil)
+	defer SetGlobalSensitive(nil)
+
+	AddGlobalSensitive("\tlate\n")
+
+	if got := MaskString("configure (item=late)"); got != "configure (item=***)" {
+		t.Errorf("MaskString = %q, want the trimmed spelling masked", got)
+	}
+}
+
+// TestSensitiveTrimmedSpellingSortsAfterLiteral pins the ordering the
+// length-descending sort gives the two spellings: the padded literal is
+// replaced first, so text holding the full value masks to a single `***`
+// rather than leaving the padding behind around an inner match.
+func TestSensitiveTrimmedSpellingSortsAfterLiteral(t *testing.T) {
+	SetGlobalSensitive([]string{" tok "})
+	defer SetGlobalSensitive(nil)
+
+	values := GlobalSensitive()
+	want := []string{" tok ", "tok"}
+	if len(values) != len(want) {
+		t.Fatalf("GlobalSensitive = %v, want %v", values, want)
+	}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("GlobalSensitive = %v, want %v", values, want)
+		}
+	}
+}
+
+// TestSensitiveWhitespaceOnlyValueIsDropped keeps the trimmed spelling from
+// reintroducing the empty entry SetGlobalSensitive drops: an all-whitespace
+// value trims to "", which would otherwise match every position in a string.
+func TestSensitiveWhitespaceOnlyValueIsDropped(t *testing.T) {
+	SetGlobalSensitive([]string{"   "})
+	defer SetGlobalSensitive(nil)
+
+	if got := GlobalSensitive(); len(got) != 1 || got[0] != "   " {
+		t.Fatalf("GlobalSensitive = %v, want only the literal whitespace value", got)
+	}
+	if got := MaskString("plain"); got != "plain" {
+		t.Errorf("MaskString = %q, want %q; an empty entry masked everything", got, "plain")
+	}
+}
+
+// TestSensitiveUnpaddedValueRegistersOnce keeps the common case free of a
+// duplicate entry: a value that is already trimmed contributes one spelling.
+func TestSensitiveUnpaddedValueRegistersOnce(t *testing.T) {
+	SetGlobalSensitive([]string{"plain"})
+	defer SetGlobalSensitive(nil)
+
+	if got := GlobalSensitive(); len(got) != 1 || got[0] != "plain" {
+		t.Errorf("GlobalSensitive = %v, want a single entry", got)
+	}
+}
+
 func TestMaskStringConcurrent(t *testing.T) {
 	SetGlobalSensitive([]string{"secret"})
 	defer SetGlobalSensitive(nil)

--- a/tasks/loop.go
+++ b/tasks/loop.go
@@ -299,6 +299,11 @@ func loopExpansionNames(base string, items []interface{}) []string {
 // renderItemForName returns a stringified item value safe for use in a
 // task-name suffix. Returns "" for non-scalar values so the caller can
 // fall back to an index-based suffix.
+//
+// A string item is trimmed so `(item= api )` reads as `(item=api)`. That
+// trimming is why subprocess.cleanSensitive registers a padded secret's
+// trimmed spelling as well as its literal one: masking matches literals, and
+// the name is masked after this rendering, not before (#473).
 func renderItemForName(item interface{}) string {
 	switch v := item.(type) {
 	case nil:

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -415,6 +415,25 @@ EOF
   assert_output --partial '"name":"deploy (item=***)"'
 }
 
+@test "--list-tasks masks a whitespace-padded sensitive loop item in the name" {
+  # #473: the `(item=<value>)` suffix renders the item through TrimSpace, so a
+  # secret carrying leading or trailing whitespace stopped matching the literal
+  # registered in the mask registry, and printed in the clear.
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: deploy
+      loop: 'split(secret_value, ",")'
+      dokku_app: { app: "{{ .item }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=" listpaddedzzz " --list-tasks --json
+  assert_success
+  refute_output --partial "listpaddedzzz"
+  assert_output --partial '"name":"deploy (item=***)"'
+}
+
 @test "--list-tasks masks a task-declared sensitive value" {
   # Nothing here is a sensitive *input*: dokku_config declares its whole
   # config: map sensitive, so the value reaches the mask registry only via

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -126,6 +126,31 @@ EOF
   assert_output --partial "***"
 }
 
+@test "docket apply masks a whitespace-padded sensitive loop item in the task name" {
+  # #473: the `(item=<value>)` suffix trims the item, so a secret padded with
+  # whitespace stopped matching the registered literal and reached the run
+  # stream unmasked.
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - name: set padded secret config
+      loop: 'split(secret_value, ",")'
+      dokku_config:
+        app: docket-test-mask
+        config:
+          PADDED_LOOP_SECRET: "{{ .item }}"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=" paddedloopzzz "
+  assert_success
+  refute_output --partial "paddedloopzzz"
+  assert_output --partial "set padded secret config (item=***)"
+}
+
 @test "docket apply masks a sensitive value interpolated into a play when:" {
   # A play predicate sigil-interpolates a sensitive input, so the recipe text
   # (and the skip line echoing it) contains the literal secret (#335).


### PR DESCRIPTION
A loop expansion's task name renders its item trimmed of surrounding whitespace, and masking replaces registered values literally, so a sensitive value carrying leading or trailing whitespace printed in the clear on the `apply` and `plan` run streams and in `--list-tasks`. Both the padded and the trimmed spelling of such a value now mask everywhere they appear, which widens masking rather than narrowing it: padding a secret costs the trimmed text as well, and that is documented rather than avoided. A generated resource address quotes and escapes a value holding a comma, bracket, or double quote, which defeats the same literal match for a different reason; that gap predates this change and is tracked separately as #475.

Closes #473.
