### PR TITLE
fix: mask a quote-bearing sensitive identity value

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -858,6 +858,13 @@ func startAtTaskMatches(plays []*tasks.Play, target string) bool {
 // unmatched --start-at-task error. Names are deduplicated and rendered
 // in source order, quoted so the user can copy a name verbatim back
 // onto the CLI.
+//
+// Each name is masked before it is quoted, not after. `%q` escapes what it
+// wraps, and a generated address is already escaped where it quotes a key
+// value, so masking the finished message would be matching a literal against
+// text that carries the secret escaped twice over - and would miss it (#475).
+// Deduplication still keys on the real name: two tasks that mask alike are two
+// tasks.
 func formatStartAtTaskNames(plays []*tasks.Play) string {
 	seen := map[string]bool{}
 	var quoted []string
@@ -868,7 +875,7 @@ func formatStartAtTaskNames(plays []*tasks.Play) string {
 		for _, name := range play.Tasks.Keys() {
 			if !seen[name] {
 				seen[name] = true
-				quoted = append(quoted, fmt.Sprintf("%q", name))
+				quoted = append(quoted, fmt.Sprintf("%q", subprocess.MaskString(name)))
 			}
 			env := play.Tasks.GetEnvelope(name)
 			for _, descendant := range tasks.CollectEnvelopeNames([]*tasks.TaskEnvelope{env}) {
@@ -877,7 +884,7 @@ func formatStartAtTaskNames(plays []*tasks.Play) string {
 				}
 				if !seen[descendant] {
 					seen[descendant] = true
-					quoted = append(quoted, fmt.Sprintf("%q", descendant))
+					quoted = append(quoted, fmt.Sprintf("%q", subprocess.MaskString(descendant)))
 				}
 			}
 		}

--- a/commands/identity_address_quoting_masking_test.go
+++ b/commands/identity_address_quoting_masking_test.go
@@ -1,0 +1,218 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// identity_address_quoting_masking_test.go covers #475: a generated resource
+// address wraps a key value in strconv.Quote when a bare form would not parse
+// back out of the address, and that escapes the value, so the literal
+// registered in the mask registry no longer matches it there. Every stream
+// that prints a task name leaked it - the apply and plan run streams as well
+// as --list-tasks - so there is a case per stream, on both the human and the
+// --json path.
+//
+// None of the recipes here pins a `name:`, because the generated address is
+// exactly what is under test.
+
+// quotedIdentityRecipe interpolates a sensitive input into the stub's single
+// identity key. `dq` escapes the value for the double-quoted scalar it sits
+// in, which is what keeps the recipe parseable with a quote in the value.
+const quotedIdentityRecipe = `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_stub: { key: "{{ .secret_value | dq }}" }
+`
+
+// quoteBearingSecret is the flag value every case below passes. The embedded
+// double quote is what forces the address to quote and escape the value; the
+// `zzz` suffix keeps it from colliding with anything docket prints of its own.
+const quoteBearingSecret = `quo"tedzzz`
+
+// maskedStubAddress is the address every case expects once the secret masks:
+// the key value collapses to `***` inside the quotes the address still needs.
+const maskedStubAddress = `dokku_stub[key="***"]`
+
+func TestListTasksMasksQuotedIdentityValueInName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, quotedIdentityRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "tedzzz") {
+		t.Errorf("listing leaked the quote-bearing sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, maskedStubAddress) {
+		t.Errorf("expected a masked identity value in the address; got:\n%s", stdout)
+	}
+}
+
+func TestListTasksJSONMasksQuotedIdentityValueInName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, quotedIdentityRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "tedzzz") {
+		t.Errorf("--json listing leaked the quote-bearing sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"dokku_stub[key=\"***\"]"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+func TestApplyMasksQuotedIdentityValueInName(t *testing.T) {
+	defer stubReset()
+	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, quotedIdentityRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "tedzzz") {
+		t.Errorf("the apply run stream leaked the quote-bearing sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, maskedStubAddress) {
+		t.Errorf("expected a masked identity value in the address; got:\n%s", stdout)
+	}
+}
+
+func TestApplyJSONMasksQuotedIdentityValueInName(t *testing.T) {
+	defer stubReset()
+	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, quotedIdentityRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "tedzzz") {
+		t.Errorf("the apply --json run stream leaked the quote-bearing sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"dokku_stub[key=\"***\"]"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+func TestPlanMasksQuotedIdentityValueInName(t *testing.T) {
+	defer stubReset()
+	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, quotedIdentityRecipe)
+
+	stdout, stderr, exit := runPlan(t, path, "--secret_value="+quoteBearingSecret)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "tedzzz") {
+		t.Errorf("the plan run stream leaked the quote-bearing sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, maskedStubAddress) {
+		t.Errorf("expected a masked identity value in the address; got:\n%s", stdout)
+	}
+}
+
+func TestPlanJSONMasksQuotedIdentityValueInName(t *testing.T) {
+	defer stubReset()
+	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	path := writeTasksFile(t, quotedIdentityRecipe)
+
+	stdout, stderr, exit := runPlan(t, path, "--secret_value="+quoteBearingSecret, "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "tedzzz") {
+		t.Errorf("the plan --json run stream leaked the quote-bearing sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"dokku_stub[key=\"***\"]"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+// TestStartAtTaskHintMasksQuotedIdentityValueInName covers the one stream the
+// registry alone cannot reach. The "available names" hint renders every name
+// through `%q`, a second layer of Go quoting on top of the escaping a
+// generated address already carries, so no registered spelling can match the
+// finished message. The hint masks each name before quoting it instead.
+func TestStartAtTaskHintMasksQuotedIdentityValueInName(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, quotedIdentityRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--start-at-task", "nozzz")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stderr, "tedzzz") {
+		t.Errorf("the --start-at-task hint leaked the quote-bearing sensitive input; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, `"dokku_stub[key=\"***\"]"`) {
+		t.Errorf("expected a masked name in the hint; got:\n%s", stderr)
+	}
+}
+
+// TestListTasksMasksQuotedTaskDeclaredIdentityValue is why the escaped
+// spelling is registered in the mask registry rather than where the address is
+// built. Nothing here is a sensitive *input*: dokku_config declares its whole
+// `config:` map sensitive, so the value joins the registry through the task
+// walk - after the recipe has parsed and already generated every name. The
+// address cannot escape-and-mask at generation time, because the registry is
+// not populated yet.
+func TestListTasksMasksQuotedTaskDeclaredIdentityValue(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - dokku_config:
+        app: api
+        config:
+          LABEL: '--label quotedeclaredzzz="x"'
+    - dokku_docker_options:
+        app: api
+        phase: deploy
+        option: '--label quotedeclaredzzz="x"'
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "quotedeclaredzzz") {
+		t.Errorf("listing leaked a quote-bearing task-declared sensitive value; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"dokku_docker_options[app=api,phase=deploy,option=\"***\"]"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}
+
+// TestListTasksLeavesUnquotedIdentityValuesAlone pins the boundary:
+// registering the escaped spelling must not widen masking to values that
+// merely resemble a secret. `keepzzz` is not registered, so it prints in full
+// alongside the masked task.
+func TestListTasksLeavesUnquotedIdentityValuesAlone(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_stub: { key: "{{ .secret_value | dq }}" }
+    - dokku_stub: { key: keepzzz }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "tedzzz") {
+		t.Errorf("listing leaked the quote-bearing sensitive input; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "dokku_stub[key=keepzzz]") {
+		t.Errorf("expected the non-sensitive identity value to print in full; got:\n%s", stdout)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -25,7 +25,7 @@ so a dashboard or a CI job comparing `plan` to `apply` can line them up. A task 
 the recipe is named after the [resource it manages](task-envelope.md#names-and-resource-addresses) -
 `dokku_config[app=api]` - which is stable for the same reason.
 
-Three caveats on masking, each of which can make two distinct tasks indistinguishable in the stream:
+Four caveats on masking, each of which can make two distinct tasks indistinguishable in the stream:
 
 - A generated name embeds the task's identity field values. No field is ever both an identity key
   and declared sensitive, but a `sensitive: true` input interpolated into one still reaches the
@@ -37,6 +37,10 @@ Three caveats on masking, each of which can make two distinct tasks indistinguis
   its literal one. Docket trims some of the text it builds - a loop item in a task name, for one -
   and substring replacement would otherwise miss the trimmed form, so both are masked everywhere
   they appear. Padding a secret therefore widens what masks rather than narrowing it.
+- A sensitive value that a generated name has to quote masks its escaped spelling as well as its
+  literal one, for the same reason. An address quotes a key value holding a comma, a `]`, or a `"`,
+  and quoting escapes what it wraps, so `sec"ret` reaches the name as `sec\"ret`. Both spellings
+  are masked everywhere they appear.
 
 ## Events
 

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -46,6 +46,11 @@ section of every [task reference page](tasks/README.md). A key you left empty is
 what distinguishes an app-scoped task from its global counterpart. A task with no key value at all
 is just its type: `dokku_domains`.
 
+A key value is quoted in the address only when a bare form would not parse back out of one - when
+it holds a comma, a `]`, or a `"`. Quoting escapes what it wraps, so an option carrying a quote
+reads `dokku_docker_options[app=api,phase=deploy,option="--label a\"b"]`. Everything else stays
+bare, which is what keeps an address full of `=`, spaces, and colons readable.
+
 Two properties follow, and both are the point:
 
 - **The same recipe produces the same names on every run.** A tool diffing one run against another -

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -64,15 +65,22 @@ func AddGlobalSensitive(values ...string) {
 // sorted by length descending so a longer secret is masked before any shorter
 // secret that is a substring of it would be.
 //
-// A value carrying leading or trailing whitespace registers its trimmed
-// spelling alongside the literal. Masking is literal substring replacement,
-// but docket renders some user-facing text through strings.TrimSpace - a loop
-// item in the `(item=<value>)` task-name suffix, most visibly - so without the
-// trimmed spelling a padded secret prints in the clear wherever it was
-// trimmed (#473). Registering both here rather than at each collection site
-// keeps the two spellings in step no matter when a value joins the registry:
-// a task-declared secret is added after the recipe has already parsed and
-// named its loop expansions.
+// Each value registers every spelling docket can print it in, not just the
+// literal it was given. Masking is literal substring replacement, and some of
+// the text docket builds transforms a value on the way in, so a transformed
+// value would otherwise reach the output in the clear. Two transforms apply:
+//
+//   - strings.TrimSpace, which renders a loop item in the `(item=<value>)`
+//     task-name suffix, so a value carrying leading or trailing whitespace
+//     registers its trimmed spelling as well (#473).
+//   - Go quoting, which tasks.quoteIdentityValue applies to an identity key
+//     value in a generated resource address - `dokku_stub[key="quo\"ted"]` -
+//     so a value whose escaped form differs from its literal registers that
+//     escaped form as well (#475).
+//
+// Deriving the spellings here rather than at each site that builds text keeps
+// them in step no matter when a value joins the registry: a task-declared
+// secret is added after the recipe has already parsed and named its tasks.
 func cleanSensitive(values []string) []string {
 	cleaned := make([]string, 0, len(values))
 	seen := make(map[string]struct{}, len(values))
@@ -86,14 +94,34 @@ func cleanSensitive(values []string) []string {
 		seen[v] = struct{}{}
 		cleaned = append(cleaned, v)
 	}
-	for _, v := range values {
+	addSpellings := func(v string) {
 		add(v)
-		add(strings.TrimSpace(v))
+		add(escapedSpelling(v))
+	}
+	for _, v := range values {
+		addSpellings(v)
+		addSpellings(strings.TrimSpace(v))
 	}
 	sort.SliceStable(cleaned, func(i, j int) bool {
 		return len(cleaned[i]) > len(cleaned[j])
 	})
 	return cleaned
+}
+
+// escapedSpelling returns v escaped the way Go quoting escapes it, without the
+// surrounding quotes. That escaped body is the spelling a resource address
+// carries for a key value holding a comma, a bracket, or a double quote, and
+// the spelling any `%q` rendering of the value carries. Returns v unchanged
+// when quoting escapes nothing, which is the common case; the caller
+// deduplicates the repeat.
+//
+// The escaping is reimplemented here rather than shared with
+// tasks.quoteIdentityValue because tasks imports subprocess, not the other way
+// round. TestIdentityAddressMasksQuotedSensitiveValue in package tasks - which
+// can see both - is what fails if the two ever drift apart.
+func escapedSpelling(v string) string {
+	quoted := strconv.Quote(v)
+	return quoted[1 : len(quoted)-1]
 }
 
 // GlobalSensitive returns a snapshot of the current sensitive value set.
@@ -145,8 +173,8 @@ func MaskString(s string) string {
 // `loop_item` field of `--list-tasks --json`, which carries whatever the
 // recipe's `loop:` resolved to: a scalar, a list, or a mapping. Masking the
 // value rather than the marshalled line is deliberate: a secret containing a
-// quote or a backslash is escaped in the serialised form, so MaskString would
-// no longer match it there.
+// quote or a backslash is escaped in the serialised form, and MaskString
+// cannot be relied on to match it there.
 func MaskValue(v interface{}) interface{} {
 	switch t := v.(type) {
 	case nil:

--- a/subprocess/mask_test.go
+++ b/subprocess/mask_test.go
@@ -217,6 +217,119 @@ func TestSensitiveUnpaddedValueRegistersOnce(t *testing.T) {
 	}
 }
 
+// TestSetGlobalSensitiveRegistersEscapedSpelling covers #475: a generated
+// resource address wraps a key value in strconv.Quote when a bare form would
+// not parse back, which escapes the double quote the value carries, so the
+// registered literal no longer matches inside the address it produced.
+func TestSetGlobalSensitiveRegistersEscapedSpelling(t *testing.T) {
+	SetGlobalSensitive([]string{`quo"ted`})
+	defer SetGlobalSensitive(nil)
+
+	if got := MaskString(`dokku_stub[key="quo\"ted"]`); got != `dokku_stub[key="***"]` {
+		t.Errorf("MaskString = %q, want the escaped spelling masked", got)
+	}
+	if got := MaskString(`raw:quo"ted.`); got != "raw:***." {
+		t.Errorf("MaskString = %q, want the literal spelling masked", got)
+	}
+}
+
+// TestAddGlobalSensitiveRegistersEscapedSpelling pins the same rule on the
+// late-registration path, which is how a task-declared secret joins the
+// registry - after the recipe has parsed and already named its tasks.
+func TestAddGlobalSensitiveRegistersEscapedSpelling(t *testing.T) {
+	SetGlobalSensitive(nil)
+	defer SetGlobalSensitive(nil)
+
+	AddGlobalSensitive(`la"te`)
+
+	if got := MaskString(`dokku_stub[key="la\"te"]`); got != `dokku_stub[key="***"]` {
+		t.Errorf("MaskString = %q, want the escaped spelling masked", got)
+	}
+}
+
+// TestSensitiveEscapedSpellingSortsBeforeLiteral pins the ordering the
+// length-descending sort gives the two spellings. The escaped form is the
+// longer one, so it is replaced first; the reverse order would leave the
+// escaping backslash stranded next to a `***`.
+func TestSensitiveEscapedSpellingSortsBeforeLiteral(t *testing.T) {
+	SetGlobalSensitive([]string{`a"b`})
+	defer SetGlobalSensitive(nil)
+
+	values := GlobalSensitive()
+	want := []string{`a\"b`, `a"b`}
+	if len(values) != len(want) {
+		t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+	}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+		}
+	}
+}
+
+// TestSensitiveBackslashValueRegistersEscapedSpelling covers the character
+// that only ever leaks in combination: a backslash needs no quoting of its
+// own, so it reaches an address escaped only when the value also carries a
+// comma, a bracket, or a quote. Both spellings register either way.
+func TestSensitiveBackslashValueRegistersEscapedSpelling(t *testing.T) {
+	SetGlobalSensitive([]string{`a,b\c`})
+	defer SetGlobalSensitive(nil)
+
+	if got := MaskString(`dokku_stub[key="a,b\\c"]`); got != `dokku_stub[key="***"]` {
+		t.Errorf("MaskString = %q, want the escaped spelling masked", got)
+	}
+	if got := MaskString(`raw:a,b\c.`); got != "raw:***." {
+		t.Errorf("MaskString = %q, want the literal spelling masked", got)
+	}
+}
+
+// TestSensitiveCommaValueRegistersOnce pins the boundary of the escaped
+// spelling: a comma forces an address to quote the value but needs no
+// escaping inside those quotes, so the literal still matches there and the
+// registry stays at one entry.
+func TestSensitiveCommaValueRegistersOnce(t *testing.T) {
+	SetGlobalSensitive([]string{"a,b"})
+	defer SetGlobalSensitive(nil)
+
+	if got := GlobalSensitive(); len(got) != 1 || got[0] != "a,b" {
+		t.Errorf("GlobalSensitive = %q, want a single entry", got)
+	}
+	if got := MaskString(`dokku_stub[key="a,b"]`); got != `dokku_stub[key="***"]` {
+		t.Errorf("MaskString = %q, want the quoted value masked", got)
+	}
+}
+
+// TestSensitivePaddedEscapedValueRegistersEverySpelling pins how the two
+// derivations compose. A value that is both padded and escape-bearing is
+// printed four ways, and every one of them masks.
+func TestSensitivePaddedEscapedValueRegistersEverySpelling(t *testing.T) {
+	SetGlobalSensitive([]string{` p"q `})
+	defer SetGlobalSensitive(nil)
+
+	values := GlobalSensitive()
+	want := []string{` p\"q `, ` p"q `, `p\"q`, `p"q`}
+	if len(values) != len(want) {
+		t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+	}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+		}
+	}
+}
+
+// TestSensitiveEscapedSpellingLeavesLookalikesAlone pins the boundary:
+// registering the escaped spelling must not widen masking to a value that
+// merely shares a prefix with a secret.
+func TestSensitiveEscapedSpellingLeavesLookalikesAlone(t *testing.T) {
+	SetGlobalSensitive([]string{`a"b`})
+	defer SetGlobalSensitive(nil)
+
+	if got := MaskString(`dokku_stub[key=keepzzz]`); got != `dokku_stub[key=keepzzz]` {
+		t.Errorf("MaskString = %q, want the non-secret value untouched", got)
+	}
+}
+
 func TestMaskStringConcurrent(t *testing.T) {
 	SetGlobalSensitive([]string{"secret"})
 	defer SetGlobalSensitive(nil)

--- a/tasks/identity.go
+++ b/tasks/identity.go
@@ -295,6 +295,15 @@ const identityQuoteChars = ",]\""
 // quoteIdentityValue renders one key value, quoting it only when a bare form
 // would not parse back. An empty value is quoted so it is distinguishable
 // from an omitted key.
+//
+// strconv.Quote also escapes what it wraps, so the value can reach the address
+// spelled differently from the literal it was rendered from. Masking is literal
+// substring replacement over the finished address, which is why
+// subprocess.cleanSensitive registers a secret's Go-escaped spelling alongside
+// its literal one; without that, a sensitive value carrying one of these
+// characters printed in the clear inside its own address (#475). The address
+// cannot be masked before it is quoted: it is generated while the recipe is
+// parsed, before the mask registry is populated.
 func quoteIdentityValue(value string) string {
 	if value == "" || strings.ContainsAny(value, identityQuoteChars) {
 		return strconv.Quote(value)

--- a/tasks/identity_test.go
+++ b/tasks/identity_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 // TestIdentityAddressRendersDeclaredKeys covers the rendering rules the whole
@@ -112,6 +114,44 @@ func TestIdentityAddressQuotesOnlyWhatItMust(t *testing.T) {
 			}
 			if keys["option"] != tt.task.Option {
 				t.Errorf("option = %q, want %q", keys["option"], tt.task.Option)
+			}
+		})
+	}
+}
+
+// TestIdentityAddressMasksQuotedSensitiveValue is the guard that keeps
+// quoteIdentityValue and subprocess.cleanSensitive in step (#475). Masking is
+// literal substring replacement over the finished address, and the address is
+// generated while the recipe is parsed - before the mask registry exists - so
+// the escaping done here has to be one of the spellings the registry holds.
+// The two live in different packages because tasks imports subprocess and not
+// the reverse; this test is the only place that sees both.
+func TestIdentityAddressMasksQuotedSensitiveValue(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		option string
+	}{
+		{name: "a double quote is escaped inside the quotes", option: `--label quo"tedzzz`},
+		{name: "a comma is quoted but not escaped", option: "--label com,mazzz"},
+		{name: "a closing bracket is quoted but not escaped", option: "--label brack]etzzz"},
+		{name: "a backslash is escaped once the value is quoted", option: `--label back\,slashzzz`},
+		{name: "a tab is escaped once the value is quoted", option: "--label tab,\tzzz"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			subprocess.SetGlobalSensitive([]string{tt.option})
+			defer subprocess.SetGlobalSensitive(nil)
+
+			address := IdentityAddress("dokku_docker_options", DockerOptionsTask{
+				App:    "api",
+				Phase:  "deploy",
+				Option: tt.option,
+			})
+			if !strings.Contains(address, "zzz") {
+				t.Fatalf("address %q does not carry the value under test", address)
+			}
+			masked := subprocess.MaskString(address)
+			if strings.Contains(masked, "zzz") {
+				t.Fatalf("MaskString(%q) = %q, want the sensitive option masked", address, masked)
 			}
 		})
 	}

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -434,6 +434,24 @@ EOF
   assert_output --partial '"name":"deploy (item=***)"'
 }
 
+@test "--list-tasks masks a quote-bearing sensitive identity value in the name" {
+  # #475: a generated address wraps a key value in Go quoting when a bare form
+  # would not parse back, which escapes the quote the value carries, so the
+  # secret stopped matching the literal registered in the mask registry and
+  # printed in the clear inside its own address.
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_app: { app: "{{ .secret_value | dq }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value='listquotedzzz"x' --list-tasks --json
+  assert_success
+  refute_output --partial "listquotedzzz"
+  assert_output --partial '"name":"dokku_app[app=\"***\"]"'
+}
+
 @test "--list-tasks masks a task-declared sensitive value" {
   # Nothing here is a sensitive *input*: dokku_config declares its whole
   # config: map sensitive, so the value reaches the mask registry only via
@@ -518,6 +536,23 @@ EOF
   assert_failure
   assert_output --partial "no task matched name"
   assert_output --partial '"first"'
+}
+
+@test "--start-at-task hint masks a quote-bearing sensitive identity value" {
+  # #475: the hint renders every available name through Go quoting, a second
+  # escaping layer on top of the one a generated address already carries, so
+  # the name is masked before it is quoted rather than after.
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_app: { app: "{{ .secret_value | dq }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value='hintquotedzzz"x' --start-at-task no-such-task
+  assert_failure
+  refute_output --partial "hintquotedzzz"
+  assert_output --partial 'dokku_app[app=\"***\"]'
 }
 
 @test "--start-at-task matching a block child runs from that child" {

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -151,6 +151,33 @@ EOF
   assert_output --partial "set padded secret config (item=***)"
 }
 
+@test "docket apply masks a quote-bearing sensitive identity value in the task name" {
+  # #475: an unnamed task is named after the resource it addresses, and the
+  # address wraps a key value in Go quoting when a bare form would not parse
+  # back. That escapes the quote the secret carries, so it stopped matching the
+  # registered literal and reached the run stream unmasked. The option is
+  # removed rather than added so the task is a no-op against the server while
+  # still rendering its address.
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - dokku_docker_options:
+        app: docket-test-mask
+        phase: deploy
+        option: "--label docket-test={{ .secret_value | dq }}"
+        state: absent
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value='quotedaddresszzz"x'
+  assert_success
+  refute_output --partial "quotedaddresszzz"
+  assert_output --partial 'option="--label docket-test=***"'
+}
+
 @test "docket apply masks a sensitive value interpolated into a play when:" {
   # A play predicate sigil-interpolates a sensitive input, so the recipe text
   # (and the skip line echoing it) contains the literal secret (#335).


### PR DESCRIPTION
A generated resource address wraps an identity key value in Go quoting when a bare form would not parse back out of it, and quoting escapes what it wraps, so a sensitive value carrying a `"` printed in the clear inside its own address on the `apply` and `plan` run streams and in `--list-tasks`. Both the literal and the escaped spelling of such a value now mask everywhere they appear, which widens masking rather than narrowing it in the same way padding a secret already does, and that is documented rather than avoided. The `--start-at-task` hint quotes every available name a second time on top of that escaping, so no registered spelling could reach it; it masks each name before quoting it instead. A sensitive play name in the `--play` hint is never masked at all, which is a missing mask rather than a mismatched spelling and is tracked separately as #477.

Closes #475.
