### PR TITLE
feat: report and optionally reconcile service image drift

### DIFF
--- a/commands/schema_test.go
+++ b/commands/schema_test.go
@@ -219,3 +219,92 @@ func TestValidateSchemaCodeEnumCoversEmittedCodes(t *testing.T) {
 			validateSchemaPath, len(stale), strings.Join(stale, ", "))
 	}
 }
+
+// warnReasonConst matches the `WarnReasonX = "..."` constants in the tasks
+// package, which is where every reason with a name behind it is declared.
+var warnReasonConst = regexp.MustCompile(`\bWarnReason[A-Za-z0-9]*\s*=\s*"([a-z0-9_]+)"`)
+
+// taskWarningLiteral matches a reason passed to EventEmitter.TaskWarning as a
+// bare string. Only "deprecated" is emitted that way today - the run loops
+// raise it from the task type rather than from a Plan(), so it has no
+// WarnReason constant to be found under.
+var taskWarningLiteral = regexp.MustCompile(`TaskWarning\([^,]+,\s*[^,]+,\s*"([a-z0-9_]+)"`)
+
+// TestEventsSchemaWarningReasonEnumCoversEmittedReasons is the
+// TestValidateSchemaCodeEnumCoversEmittedCodes of the events stream. The
+// `warning.reason` enum is closed, so a new reason that never reaches the
+// published schema fails validation in any consumer that trusts it - and
+// additionalProperties: false does not catch it, because `reason` is a value
+// rather than a field name. Same caveat as its sibling: the scan reads string
+// literals, so a reason routed through a variable would be missed.
+func TestEventsSchemaWarningReasonEnumCoversEmittedReasons(t *testing.T) {
+	emitted := map[string]bool{}
+	for dir, re := range map[string]*regexp.Regexp{"../tasks": warnReasonConst, ".": taskWarningLiteral} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			raw, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("read %s/%s: %v", dir, name, err)
+			}
+			for _, m := range re.FindAllStringSubmatch(string(raw), -1) {
+				emitted[m[1]] = true
+			}
+		}
+	}
+	if len(emitted) == 0 {
+		t.Fatal("found no warning reasons in the source; the scan patterns have drifted")
+	}
+
+	raw, err := os.ReadFile(eventsSchemaPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", eventsSchemaPath, err)
+	}
+	var schema struct {
+		Defs struct {
+			Warning struct {
+				Properties struct {
+					Reason struct {
+						Enum []string `json:"enum"`
+					} `json:"reason"`
+				} `json:"properties"`
+			} `json:"warning"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse %s: %v", eventsSchemaPath, err)
+	}
+	listed := map[string]bool{}
+	for _, reason := range schema.Defs.Warning.Properties.Reason.Enum {
+		listed[reason] = true
+	}
+
+	var missing, stale []string
+	for reason := range emitted {
+		if !listed[reason] {
+			missing = append(missing, reason)
+		}
+	}
+	for reason := range listed {
+		if !emitted[reason] {
+			stale = append(stale, reason)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(stale)
+
+	if len(missing) > 0 {
+		t.Errorf("%s omits %d emitted warning reason(s): %s\nAdd each to the warning.reason enum and to the table in docs/json-output.md.",
+			eventsSchemaPath, len(missing), strings.Join(missing, ", "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("%s lists %d warning reason(s) nothing emits: %s\nDrop them, or fix the typo.",
+			eventsSchemaPath, len(stale), strings.Join(stale, ", "))
+	}
+}

--- a/commands/stub_task_test.go
+++ b/commands/stub_task_test.go
@@ -70,10 +70,15 @@ func (t StubTask) Plan() tasks.PlanResult {
 		}
 	}
 	if !fixture.Changed && fixture.ExecuteError == nil {
+		// Warnings ride out on the in-sync result too. A task can read its
+		// state perfectly well, find a difference, and decline to reconcile
+		// it - dokku_service_create's image_drift does exactly that - so the
+		// stub has to be able to produce an in-sync-with-warning plan.
 		return tasks.PlanResult{
 			InSync:       true,
 			Status:       tasks.PlanStatusOK,
 			DesiredState: tasks.StatePresent,
+			Warnings:     fixture.Warnings,
 		}
 	}
 	return tasks.PlanResult{

--- a/commands/task_warning_test.go
+++ b/commands/task_warning_test.go
@@ -97,3 +97,89 @@ func assertWarningEventPrecedesTask(t *testing.T, jsonOut string) {
 		t.Errorf("warning event should precede task event; warnIdx=%d taskIdx=%d\n%s", warnIdx, taskIdx, jsonOut)
 	}
 }
+
+// A task can read its state, find a difference, and decline to reconcile it:
+// dokku_service_create warns when a service is running an image other than the
+// one the recipe pins, because dokku's only remedy recreates the container.
+// That is the first warning in the codebase to ride on an in-sync task, so the
+// run loops have to drain it from a plan that reports no drift and from an
+// apply that changes nothing.
+const imageDriftWarningMessage = "redis service cache is running redis:7.2.4, recipe pins redis:7.2.5"
+
+func stubWithInSyncWarning() StubFixture {
+	return StubFixture{
+		Changed: false,
+		Warnings: []tasks.PlanWarning{
+			{Reason: tasks.WarnReasonServiceImageDrift, Message: imageDriftWarningMessage},
+		},
+	}
+}
+
+func TestPlanSurfacesWarningOnInSyncTask(t *testing.T) {
+	defer stubReset()
+	stubSet("a", stubWithInSyncWarning())
+	path := writeTasksFile(t, warningRecipe)
+
+	stdout, _, _ := runPlan(t, path)
+	if !strings.Contains(stdout, "[warning]") || !strings.Contains(stdout, imageDriftWarningMessage) {
+		t.Errorf("expected the drift warning in plan output; got:\n%s", stdout)
+	}
+	// The task itself is in sync: the warning reports, it does not drift.
+	if wi, ti := strings.Index(stdout, "[warning]"), strings.Index(stdout, "[ok]"); wi < 0 || ti < 0 || wi > ti {
+		t.Errorf("warning should precede an [ok] task line; got:\n%s", stdout)
+	}
+
+	jsonOut, _, _ := runPlan(t, path, "--json")
+	assertImageDriftWarningPrecedesOKTask(t, jsonOut)
+}
+
+func TestApplySurfacesWarningOnInSyncTask(t *testing.T) {
+	defer stubReset()
+	stubSet("a", stubWithInSyncWarning())
+	path := writeTasksFile(t, warningRecipe)
+
+	stdout, _, _ := runApply(t, path)
+	if !strings.Contains(stdout, "[warning]") || !strings.Contains(stdout, imageDriftWarningMessage) {
+		t.Errorf("expected the drift warning in apply output; got:\n%s", stdout)
+	}
+	if wi, ti := strings.Index(stdout, "[warning]"), strings.Index(stdout, "[ok]"); wi < 0 || ti < 0 || wi > ti {
+		t.Errorf("warning should precede an [ok] task line; got:\n%s", stdout)
+	}
+
+	jsonOut, _, _ := runApply(t, path, "--json")
+	assertImageDriftWarningPrecedesOKTask(t, jsonOut)
+}
+
+// assertImageDriftWarningPrecedesOKTask mirrors assertWarningEventPrecedesTask
+// for the in-sync case. decodeLines validates every event against
+// events-v1.schema.json, so this also fails if the new reason was not added to
+// the schema's closed `reason` enum.
+func assertImageDriftWarningPrecedesOKTask(t *testing.T, jsonOut string) {
+	t.Helper()
+	warnIdx, taskIdx := -1, -1
+	for i, ev := range decodeLines(t, jsonOut) {
+		switch ev["type"] {
+		case "warning":
+			warnIdx = i
+			if ev["reason"] != tasks.WarnReasonServiceImageDrift {
+				t.Errorf("warning reason = %v, want %v", ev["reason"], tasks.WarnReasonServiceImageDrift)
+			}
+			if msg, _ := ev["message"].(string); !strings.Contains(msg, imageDriftWarningMessage) {
+				t.Errorf("warning message = %q, want to contain %q", msg, imageDriftWarningMessage)
+			}
+		case "task":
+			if taskIdx == -1 {
+				taskIdx = i
+				if ev["status"] != "ok" {
+					t.Errorf("task status = %v, want ok - the warning must not make the task drift", ev["status"])
+				}
+			}
+		}
+	}
+	if warnIdx == -1 {
+		t.Fatalf("no warning event in JSON stream:\n%s", jsonOut)
+	}
+	if taskIdx == -1 || warnIdx > taskIdx {
+		t.Errorf("warning event should precede task event; warnIdx=%d taskIdx=%d\n%s", warnIdx, taskIdx, jsonOut)
+	}
+}

--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -285,6 +285,13 @@ over SSH, where variables put in front of the local process never reach the remo
 remaining create-time options (`memory`, `shm_size`, the three network fields, `password`, and
 `root_password`) have no module counterpart.
 
+`image_drift` and `restart_apps` have no counterpart either, and are not create-time options at all:
+they say what docket should do when the service already exists on some other image, which is a
+question the module never asks because it stops at `<service>:exists`. A wrapper that translates
+`POSTGRES_IMAGE` into `image` is reproducing the module's behaviour exactly by leaving `image_drift`
+alone - the default reports the mismatch and changes nothing. Set it to `upgrade` only where the
+wrapper's own contract says a pin change should recreate the container.
+
 ### Host directories
 
 `dokku_storage` does raw filesystem work alongside its `storage:mount` calls, which it gets

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -77,6 +77,7 @@ ordering. The `reason` is a stable machine key so consumers can branch on the ca
 | `deprecated` | A task whose type implements `Deprecation()` is about to run; `message` carries the deprecation notice. |
 | `unknown_property` | A property task's probe found no matching key in the plugin's `:report --format json` payload (a stale key map or a dokku version that does not emit it). |
 | `probe_rejected` | An older plugin rejected `:report --format json` outright, so the property task could not probe current state. |
+| `service_image_drift` | A `dokku_service_create` task found the service running an image other than the one the recipe pins and left it alone, or could not read the running image to compare at all. See [dokku_service_create](tasks/dokku_service_create.md). |
 
 In every case `message` is masked, so a registered sensitive value that reaches the warning (for
 example server stderr echoed by a rejected probe) renders as `***`. `--list-tasks --json` does not
@@ -84,8 +85,12 @@ emit a separate `warning` event; instead, the `list_task` event for a deprecated
 `"deprecated": true` and a `deprecation` field with the message, masked the same way.
 
 `unknown_property` and `probe_rejected` are probe failures: this run could not read the state, and
-another run against a different server or a newer plugin might. A task type that can *never* read
-its state is a different thing, declared rather than discovered, and it is not a warning at all. The
+another run against a different server or a newer plugin might. `service_image_drift` is the other
+kind - the state was read, and the task is reporting a difference it is deliberately not
+reconciling, because dokku's only remedy recreates the service container. It rides on an `ok` task,
+not a `~` one, so a recipe carrying that mismatch still exits `0` under `--detailed-exitcode`; set
+`image_drift: error` on the task when a run should fail on it instead. A task type that can *never*
+read its state is a third thing, declared rather than discovered, and it is not a warning at all. The
 `list_task` event carries it as `"probe": "unsupported"` (the task reports drift on every run) or
 `"probe": "partial"` (only some of its fields are read), each with a `probe_caveat` naming what
 cannot be read. Both keys are absent for a task that probes everything it manages. `probe_caveat` is

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -99,6 +99,9 @@ code onto the new server with whichever deploy source your recipe uses:
 the old one was running, which export reads off the container so the new server does not silently
 pick up a different major version its plugin happens to default to. The other create-time options
 (`custom_env`, `memory`, the networks, and the passwords) cannot be read back and must be re-supplied.
+Re-supplying them matters beyond the first apply: `image_drift: upgrade` reconciles a later change to
+the image pin by recreating the container, and the plugin rebuilds `config_options` and `custom_env`
+from the recipe when it does, clearing whatever the recipe did not carry.
 [`dokku_service_backup`](tasks/dokku_service_backup.md) only configures the S3 backup schedule and
 auth - there is no restore task. Export carries the schedule, bucket, and `use_iam` flag but not the
 AWS credentials or encryption passphrase (they cannot be read back), so re-add those before the

--- a/docs/schemas/events-v1.schema.json
+++ b/docs/schemas/events-v1.schema.json
@@ -92,7 +92,7 @@
         "name": { "type": "string" },
         "reason": {
           "type": "string",
-          "enum": ["deprecated", "unknown_property", "probe_rejected"],
+          "enum": ["deprecated", "unknown_property", "probe_rejected", "service_image_drift"],
           "description": "Stable machine key for the warning category."
         },
         "message": { "type": "string" },

--- a/docs/tasks/dokku_service_create.md
+++ b/docs/tasks/dokku_service_create.md
@@ -14,7 +14,7 @@ Partial - the service and the image it is running are exported; the remaining cr
 
 ## Probe support
 
-Partial - the service's existence and image are probed; config_options, custom_env, memory, shm_size, the networks, and the passwords have no read command and are not drift-detected.
+Partial - the service's existence is probed, and the image it is running whenever the recipe pins one; config_options, custom_env, memory, shm_size, the networks, and the passwords have no read command and are not drift-detected.
 
 ## Identity
 
@@ -26,17 +26,19 @@ Keyed by `service` and `name`. Fields left empty are omitted from the address.
 | --- | --- | --- | --- | --- | --- |
 | `service` | string | yes |  |  | Type of service to create (e.g. redis, postgres, mysql) |
 | `name` | string | yes |  |  | Name of the service instance |
-| `image` | string | no |  |  | Image to start the service with, e.g. postgis/postgis. Applied only when the service is created. |
-| `image_version` | string | no |  |  | Image tag to start the service with. Applied only when the service is created. |
-| `config_options` | string | no |  |  | Extra arguments to pass to the container create command. Applied only when the service is created. |
-| `custom_env` | dict | no |  |  | Map of environment variables to start the service with. Applied only when the service is created. (sensitive) |
+| `image` | string | no |  |  | Image to start the service with, e.g. postgis/postgis. Applied when the service is created; image_drift decides what happens when an existing service is running something else. |
+| `image_version` | string | no |  |  | Image tag to start the service with. Applied when the service is created; image_drift decides what happens when an existing service is running something else. |
+| `config_options` | string | no |  |  | Extra arguments to pass to the container create command. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it. |
+| `custom_env` | dict | no |  |  | Map of environment variables to start the service with. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it. (sensitive) |
 | `memory` | int | no |  |  | Container memory limit in megabytes. Applied only when the service is created. |
-| `shm_size` | string | no |  |  | Shared memory size for the service container. Applied only when the service is created. |
-| `initial_network` | string | no |  |  | Network to attach the service to initially. Applied only when the service is created. |
-| `post_create_network` | list | no |  |  | Networks to attach the service container to after creation. Applied only when the service is created. |
-| `post_start_network` | list | no |  |  | Networks to attach the service container to after start. Applied only when the service is created. |
+| `shm_size` | string | no |  |  | Shared memory size for the service container. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it. |
+| `initial_network` | string | no |  |  | Network to attach the service to initially. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it. |
+| `post_create_network` | list | no |  |  | Networks to attach the service container to after creation. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it. |
+| `post_start_network` | list | no |  |  | Networks to attach the service container to after start. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it. |
 | `password` | string | no |  |  | Override the user-level service password. Applied only when the service is created. (sensitive) |
 | `root_password` | string | no |  |  | Override the root-level service password. Applied only when the service is created. (sensitive) |
+| `image_drift` | string | no | warn | ignore, warn, error, upgrade | What to do when the service already exists on an image other than the one pinned: 'ignore' it, 'warn' and leave it alone, 'error' out, or 'upgrade' the service to reconcile it. Upgrading recreates the container, which means downtime, no data migration across major versions, and it clears any config_options and custom_env the recipe does not declare. |
+| `restart_apps` | bool | no |  |  | Restart the apps linked to the service after an image_drift 'upgrade' recreates its container, so they reconnect to the new one. Only valid with image_drift 'upgrade', and only acted on when the service has linked apps. |
 | `state` | string | no | present | present, absent | Desired state of the service |
 
 ## Examples
@@ -65,6 +67,17 @@ dokku_service_create:
     name: my-pinned-redis
     image: redis
     image_version: 7.2.5
+```
+
+### Reconcile a changed image pin by upgrading the service
+
+```yaml
+dokku_service_create:
+    service: redis
+    name: my-upgraded-redis
+    image: redis
+    image_version: 7.2.5
+    image_drift: upgrade
 ```
 
 ### Destroy a redis service named my-redis

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -275,6 +275,10 @@ func TestBuildSshArgvQuotesInjection(t *testing.T) {
 // the argv assembled here crosses to the remote shell. The semicolon
 // delimiters inside a --custom-env token are the sharp edge - unquoted they
 // would be command separators on the remote login shell.
+//
+// The same flags are re-rendered onto `<service>:upgrade` when the task
+// reconciles an image pin, so this covers both call sites: the quoting is a
+// property of the argv, not of the subcommand carrying it.
 func TestBuildSshArgvQuotesServiceCreateFlags(t *testing.T) {
 	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
 	t.Setenv("DOKKU_SUDO", "")

--- a/tasks/example_integration_test.go
+++ b/tasks/example_integration_test.go
@@ -94,9 +94,9 @@ var exampleIntegrationPolicy = map[string]exampleReq{
 	},
 	"dokku_letsencrypt_property": {plugins: []string{"letsencrypt"}},
 
-	// service_create's examples create three services and destroy only one,
+	// service_create's examples create four services and destroy only one,
 	// so the survivors are torn down here.
-	"dokku_service_create": {cleanupServices: []string{"postgres:my-db", "redis:my-pinned-redis"}},
+	"dokku_service_create": {cleanupServices: []string{"postgres:my-db", "redis:my-pinned-redis", "redis:my-upgraded-redis"}},
 
 	// Deploy-dependent tasks.
 	"dokku_app_clone":    {deployApps: []string{"node-js-app"}, cleanupApps: []string{"node-js-app-staging"}},

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -195,6 +195,15 @@ const (
 	// WarnReasonProbeRejected marks a probe warning raised when an older plugin
 	// rejects `:report --format json` outright.
 	WarnReasonProbeRejected = "probe_rejected"
+	// WarnReasonServiceImageDrift marks a warning raised when a datastore
+	// service is running an image other than the one the recipe pins, and the
+	// task is leaving it alone. Unlike the two above it is not a probe failure:
+	// the state was read successfully and the task is declining to reconcile
+	// it, because dokku's only remedy recreates the container. It also covers
+	// the case where the running image could not be read at all, so a recipe
+	// that asked for drift to be caught is never silently told everything is
+	// fine.
+	WarnReasonServiceImageDrift = "service_image_drift"
 )
 
 // WithExecResult returns a copy of s with Stdout/Stderr/ExitCode populated

--- a/tasks/probe_support.go
+++ b/tasks/probe_support.go
@@ -49,6 +49,13 @@ type ProbeSupport struct {
 // raised per-run by the probe call site, and they never change a task's
 // declared status.
 //
+// Nor is it the same thing as a difference a task reads successfully and
+// declines to act on, which is also a PlanWarning (see
+// WarnReasonServiceImageDrift). A task can probe a field perfectly well and
+// still refuse to converge it because the only available remedy is worse than
+// the drift; that is a property of the remedy, not of the probe, and it does
+// not make the task partial for that field either.
+//
 // Nothing in the plan or apply path reads this: drift is decided entirely by
 // each Plan() implementation. What keeps the declaration honest is
 // TestProbeSupportMatchesPlanWiring, which fails when a task claims it can

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,11 +20,13 @@ import (
 // variable put in front of the local process never reaches the remote shell,
 // so the argv is the only carrier both transports share.
 //
-// They apply only when the service is created. The task probes
-// `<service>:exists`, so a service that already exists is in sync whatever
-// image it is running; changing that needs `<service>:upgrade`, which
-// recreates the container and is not something docket does implicitly
-// (tracked in #435).
+// They apply when the service is created. Once it exists dokku's only remedy
+// is `<service>:upgrade`, which removes and recreates the container, so the
+// task does not reach for it on its own: `image_drift` decides what happens
+// when the recipe's `image` / `image_version` pin no longer matches what the
+// service is running, and it defaults to reporting the mismatch rather than
+// acting on it. The remaining create-time options have no read command at all
+// (see ProbeSupport), so they are neither compared nor reconciled.
 type ServiceCreateTask struct {
 	// Service is the type of service to create (e.g. redis, postgres, mysql)
 	Service string `required:"true" identity:"key" yaml:"service" description:"Type of service to create (e.g. redis, postgres, mysql)"`
@@ -32,31 +35,31 @@ type ServiceCreateTask struct {
 	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the service instance"`
 
 	// Image is the image the service container is started from.
-	Image string `required:"false" yaml:"image,omitempty" description:"Image to start the service with, e.g. postgis/postgis. Applied only when the service is created."`
+	Image string `required:"false" yaml:"image,omitempty" description:"Image to start the service with, e.g. postgis/postgis. Applied when the service is created; image_drift decides what happens when an existing service is running something else."`
 
 	// ImageVersion is the tag of the image the service container is started from.
-	ImageVersion string `required:"false" yaml:"image_version,omitempty" description:"Image tag to start the service with. Applied only when the service is created."`
+	ImageVersion string `required:"false" yaml:"image_version,omitempty" description:"Image tag to start the service with. Applied when the service is created; image_drift decides what happens when an existing service is running something else."`
 
 	// ConfigOptions are extra arguments passed to the container create command.
-	ConfigOptions string `required:"false" yaml:"config_options,omitempty" description:"Extra arguments to pass to the container create command. Applied only when the service is created."`
+	ConfigOptions string `required:"false" yaml:"config_options,omitempty" description:"Extra arguments to pass to the container create command. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it."`
 
 	// CustomEnv is the environment the service container is started with.
-	CustomEnv map[string]string `required:"false" sensitive:"true" yaml:"custom_env,omitempty" description:"Map of environment variables to start the service with. Applied only when the service is created."`
+	CustomEnv map[string]string `required:"false" sensitive:"true" yaml:"custom_env,omitempty" description:"Map of environment variables to start the service with. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it."`
 
 	// Memory is the container memory limit in megabytes.
 	Memory int `required:"false" yaml:"memory,omitempty" description:"Container memory limit in megabytes. Applied only when the service is created."`
 
 	// ShmSize is the shared memory size of the service container.
-	ShmSize string `required:"false" yaml:"shm_size,omitempty" description:"Shared memory size for the service container. Applied only when the service is created."`
+	ShmSize string `required:"false" yaml:"shm_size,omitempty" description:"Shared memory size for the service container. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it."`
 
 	// InitialNetwork is the network the service is attached to on creation.
-	InitialNetwork string `required:"false" yaml:"initial_network,omitempty" description:"Network to attach the service to initially. Applied only when the service is created."`
+	InitialNetwork string `required:"false" yaml:"initial_network,omitempty" description:"Network to attach the service to initially. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it."`
 
 	// PostCreateNetwork are the networks attached after service creation.
-	PostCreateNetwork []string `required:"false" yaml:"post_create_network,omitempty" description:"Networks to attach the service container to after creation. Applied only when the service is created."`
+	PostCreateNetwork []string `required:"false" yaml:"post_create_network,omitempty" description:"Networks to attach the service container to after creation. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it."`
 
 	// PostStartNetwork are the networks attached after service start.
-	PostStartNetwork []string `required:"false" yaml:"post_start_network,omitempty" description:"Networks to attach the service container to after start. Applied only when the service is created."`
+	PostStartNetwork []string `required:"false" yaml:"post_start_network,omitempty" description:"Networks to attach the service container to after start. Applied when the service is created, and re-applied when image_drift 'upgrade' recreates it."`
 
 	// Password overrides the user-level service password.
 	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"Override the user-level service password. Applied only when the service is created."`
@@ -64,9 +67,34 @@ type ServiceCreateTask struct {
 	// RootPassword overrides the root-level service password.
 	RootPassword string `required:"false" sensitive:"true" yaml:"root_password,omitempty" description:"Override the root-level service password. Applied only when the service is created."`
 
+	// ImageDrift is what the task does when the service already exists on an
+	// image other than the one `image` / `image_version` pins. Read through
+	// imageDriftMode, never directly: the `default:` tag is only applied to a
+	// decoded recipe, so a task built in Go carries the empty string.
+	ImageDrift string `required:"false" yaml:"image_drift,omitempty" default:"warn" options:"ignore,warn,error,upgrade" description:"What to do when the service already exists on an image other than the one pinned: 'ignore' it, 'warn' and leave it alone, 'error' out, or 'upgrade' the service to reconcile it. Upgrading recreates the container, which means downtime, no data migration across major versions, and it clears any config_options and custom_env the recipe does not declare."`
+
+	// RestartApps forces the apps linked to the service to restart after an
+	// image_drift upgrade has recreated its container.
+	RestartApps bool `required:"false" yaml:"restart_apps,omitempty" description:"Restart the apps linked to the service after an image_drift 'upgrade' recreates its container, so they reconnect to the new one. Only valid with image_drift 'upgrade', and only acted on when the service has linked apps."`
+
 	// State is the desired state of the service
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the service"`
 }
+
+// The image_drift modes: what the task does when the service exists on an
+// image other than the one the recipe pins. `warn` is the default because
+// dokku's only remedy recreates the container, which is not something to do
+// to a datastore on the strength of a field moving in a recipe.
+const (
+	imageDriftIgnore  = "ignore"
+	imageDriftWarn    = "warn"
+	imageDriftError   = "error"
+	imageDriftUpgrade = "upgrade"
+)
+
+// imageDriftModes is the accepted set, in the order Validate names them and
+// the `options:` tag publishes them.
+var imageDriftModes = []string{imageDriftIgnore, imageDriftWarn, imageDriftError, imageDriftUpgrade}
 
 // ServiceCreateTaskExample contains an example of a ServiceCreateTask
 type ServiceCreateTaskExample struct {
@@ -94,7 +122,7 @@ func (t ServiceCreateTask) ExportSupport() ExportSupport {
 
 // ProbeSupport reports whether Plan() can read this task's current state.
 func (t ServiceCreateTask) ProbeSupport() ProbeSupport {
-	return ProbeSupport{Status: ProbePartial, Caveat: "the service's existence and image are probed; config_options, custom_env, memory, shm_size, the networks, and the passwords have no read command and are not drift-detected"}
+	return ProbeSupport{Status: ProbePartial, Caveat: "the service's existence is probed, and the image it is running whenever the recipe pins one; config_options, custom_env, memory, shm_size, the networks, and the passwords have no read command and are not drift-detected"}
 }
 
 // ExportGlobal reconstructs every datastore service instance on the server as a
@@ -157,6 +185,16 @@ func (t ServiceCreateTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
+			Name: "Reconcile a changed image pin by upgrading the service",
+			ServiceCreateTask: ServiceCreateTask{
+				Service:      "redis",
+				Name:         "my-upgraded-redis",
+				Image:        "redis",
+				ImageVersion: "7.2.5",
+				ImageDrift:   imageDriftUpgrade,
+			},
+		},
+		{
 			Name: "Destroy a redis service named my-redis",
 			ServiceCreateTask: ServiceCreateTask{
 				Service: "redis",
@@ -176,6 +214,10 @@ func (t ServiceCreateTask) Execute() TaskOutputState {
 // task supplied, in field order. Keep it in step with createFlags: an option
 // that renders a flag but is missing here would be silently accepted under
 // state 'absent', where dokku has nowhere to put it.
+//
+// image_drift and restart_apps are deliberately absent: they render no flag on
+// any subcommand, so createFlags is not the list they belong to. Validate
+// rejects them under state 'absent' on their own terms.
 func (t ServiceCreateTask) setCreateOptions() []string {
 	var set []string
 	for _, opt := range []struct {
@@ -242,6 +284,91 @@ func (t ServiceCreateTask) createFlags() []string {
 	return args
 }
 
+// imageDriftMode returns the drift policy in force. The `default:` tag is
+// applied by defaults.SetDefaults when a recipe is decoded, but a task built
+// in Go - by ExportGlobal, by an integration test, by Examples - never passes
+// through that, so the zero value has to mean the same thing as the default.
+func (t ServiceCreateTask) imageDriftMode() string {
+	if t.ImageDrift == "" {
+		return imageDriftWarn
+	}
+	return t.ImageDrift
+}
+
+// pinsImage reports whether the recipe named any part of the image the
+// service should run. Nothing is compared when it did not: the plugin's own
+// default is then the declared value, and docket cannot know what it is.
+func (t ServiceCreateTask) pinsImage() bool {
+	return t.Image != "" || t.ImageVersion != ""
+}
+
+// upgradeFlags renders the create-time options as the flags
+// `<service>:upgrade` accepts. Everything the recipe declares is re-passed
+// rather than left off, because the plugin's service_commit_config rewrites
+// CONFIG_OPTIONS and ENV from the flags it was given and blanks them when it
+// was given none - so an upgrade that omits them is a silent reset. memory,
+// password, and root_password are absent because `:upgrade` does not accept
+// them; the plugin keeps its own copies of those and reapplies them when it
+// rebuilds the container.
+func (t ServiceCreateTask) upgradeFlags(image string) []string {
+	args := []string{"--image", image, "--image-version", t.ImageVersion}
+	if t.ConfigOptions != "" {
+		args = append(args, "--config-options", t.ConfigOptions)
+	}
+	if env := formatCustomEnv(t.CustomEnv); env != "" {
+		args = append(args, "--custom-env", env)
+	}
+	if t.ShmSize != "" {
+		args = append(args, "--shm-size", t.ShmSize)
+	}
+	if t.InitialNetwork != "" {
+		args = append(args, "--initial-network", t.InitialNetwork)
+	}
+	if len(t.PostCreateNetwork) > 0 {
+		args = append(args, "--post-create-network", strings.Join(t.PostCreateNetwork, ","))
+	}
+	if len(t.PostStartNetwork) > 0 {
+		args = append(args, "--post-start-network", strings.Join(t.PostStartNetwork, ","))
+	}
+	return args
+}
+
+// upgradeResets names the create-time options `<service>:upgrade` will blank
+// because the recipe does not declare them and docket has no read command to
+// carry the server's values across. It is the one destructive thing an
+// upgrade does that nothing else in the plan would show: an option docket
+// never learned about renders as no flag at all, and no flag is what makes
+// the plugin write an empty value. Plan surfaces it as its own mutation line,
+// since text `docket plan` prints Mutations and never Commands.
+func (t ServiceCreateTask) upgradeResets() []string {
+	var reset []string
+	if t.ConfigOptions == "" {
+		reset = append(reset, "config_options")
+	}
+	if len(t.CustomEnv) == 0 {
+		reset = append(reset, "custom_env")
+	}
+	return reset
+}
+
+// pinnedDescription renders what the recipe asked the service to run, for the
+// human half of a drift report. A recipe that pins only the version is
+// describing the running image's name with a different tag, so the running
+// name is filled in; one that pins only the name has not said anything about
+// the tag, and the phrasing says so rather than inventing one.
+func (t ServiceCreateTask) pinnedDescription(runningImage string) string {
+	switch {
+	case t.Image != "" && t.ImageVersion != "":
+		return fmt.Sprintf("%s:%s", t.Image, t.ImageVersion)
+	case t.ImageVersion != "" && runningImage != "":
+		return fmt.Sprintf("%s:%s", runningImage, t.ImageVersion)
+	case t.ImageVersion != "":
+		return fmt.Sprintf("image version %s", t.ImageVersion)
+	default:
+		return fmt.Sprintf("image %s", t.Image)
+	}
+}
+
 // formatCustomEnv renders the custom_env map as the single semicolon-delimited
 // `KEY=value` token `--custom-env` expects. Keys are sorted so the rendered
 // command is stable across runs.
@@ -284,7 +411,39 @@ func (t ServiceCreateTask) Validate() error {
 		if set := t.setCreateOptions(); len(set) > 0 {
 			return fmt.Errorf("'%s' must not be set for state 'absent'", strings.Join(set, "', '"))
 		}
+		// Neither drift field renders a flag, so setCreateOptions does not
+		// carry them. A service being destroyed has no pin to drift from, so
+		// either one is a mistake worth naming rather than ignoring.
+		if t.imageDriftMode() != imageDriftWarn {
+			return fmt.Errorf("'image_drift' must not be set for state 'absent'")
+		}
+		if t.RestartApps {
+			return fmt.Errorf("'restart_apps' must not be set for state 'absent'")
+		}
 		return nil
+	}
+
+	mode := t.imageDriftMode()
+	if !slices.Contains(imageDriftModes, mode) {
+		return fmt.Errorf("'image_drift' must be one of %s, got %q", strings.Join(imageDriftModes, ", "), t.ImageDrift)
+	}
+	// Every mode but the default acts on a comparison, and there is nothing to
+	// compare against when the recipe has not said what the service should run.
+	if mode != imageDriftWarn && !t.pinsImage() {
+		return fmt.Errorf("'image_drift' requires 'image' or 'image_version'")
+	}
+	// `<service>:upgrade` needs both halves of the reference and falls back to
+	// the plugin's default for either one it is not given. docket can fill a
+	// missing name from the running container, because a recipe that pins only
+	// the version is asking for the same image on a new tag. It cannot fill a
+	// missing tag the same way: the running tag belongs to the image being
+	// replaced, and carrying it over would name a reference that may not exist
+	// - discovered only after the old container is gone.
+	if mode == imageDriftUpgrade && t.Image != "" && t.ImageVersion == "" {
+		return fmt.Errorf("'image_drift: upgrade' requires 'image_version' when 'image' is set")
+	}
+	if t.RestartApps && mode != imageDriftUpgrade {
+		return fmt.Errorf("'restart_apps' requires 'image_drift: upgrade'")
 	}
 
 	if t.Memory < 0 {
@@ -339,6 +498,9 @@ func (t ServiceCreateTask) Plan() PlanResult {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if exists {
+				if drift := planServiceImageDrift(t); drift != nil {
+					return *drift
+				}
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			args := append([]string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name}, t.createFlags()...)
@@ -381,6 +543,130 @@ func (t ServiceCreateTask) Plan() PlanResult {
 			}
 		},
 	})
+}
+
+// planServiceImageDrift reports what an existing service's image means for the
+// task, or nil when it means nothing and the caller should carry on to its own
+// in-sync result. nil covers three cases: the recipe pinned no image, the
+// recipe asked for the comparison to be skipped, and the running image already
+// matches.
+//
+// It is a package-level func rather than a method because
+// TestProbeSupportMatchesPlanWiring walks the tasks package for plan-returning
+// methods and allows exactly one per task, Plan itself.
+func planServiceImageDrift(t ServiceCreateTask) *PlanResult {
+	mode := t.imageDriftMode()
+	if mode == imageDriftIgnore || !t.pinsImage() {
+		return nil
+	}
+
+	ref, err := serviceImageRef(t.Service, t.Name)
+	if err != nil {
+		return &PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	running := strings.TrimSpace(ref)
+	if running == "" {
+		// dokku prints nothing here when the service's container is gone, and
+		// an older plugin may not answer `--version` at all. Either way the
+		// comparison did not happen, and a recipe that asked for drift to be
+		// caught should not be told everything is fine.
+		return &PlanResult{
+			InSync: true,
+			Status: PlanStatusOK,
+			Warnings: []PlanWarning{{
+				Reason: WarnReasonServiceImageDrift,
+				Message: fmt.Sprintf("%s service %s reports no running image, so the recipe's pin of %s was not checked",
+					t.Service, t.Name, t.pinnedDescription("")),
+			}},
+		}
+	}
+
+	image, version := splitImageRef(running)
+	if (t.Image == "" || t.Image == image) && (t.ImageVersion == "" || t.ImageVersion == version) {
+		return nil
+	}
+
+	switch mode {
+	case imageDriftError:
+		return &PlanResult{
+			Status: PlanStatusError,
+			Error: fmt.Errorf("%s service %s is running %s, recipe pins %s",
+				t.Service, t.Name, running, t.pinnedDescription(image)),
+		}
+	case imageDriftUpgrade:
+		return planServiceImageUpgrade(t, running, image)
+	}
+
+	return &PlanResult{
+		InSync: true,
+		Status: PlanStatusOK,
+		Warnings: []PlanWarning{{
+			Reason: WarnReasonServiceImageDrift,
+			Message: fmt.Sprintf("%s service %s is running %s, recipe pins %s; create-time options are not reconciled, set image_drift: upgrade to run %s:upgrade",
+				t.Service, t.Name, running, t.pinnedDescription(image), t.Service),
+		}},
+	}
+}
+
+// planServiceImageUpgrade builds the `<service>:upgrade` that reconciles the
+// pin. running is the reference the container reports and image is its name
+// half; Validate has already established that the recipe pins image_version,
+// so the only half that may need filling is the name.
+//
+// Package-level for the same reason as planServiceImageDrift.
+func planServiceImageUpgrade(t ServiceCreateTask, running, image string) *PlanResult {
+	if t.Image != "" {
+		image = t.Image
+	} else if image == "" || strings.Contains(running, "@") {
+		// A recipe pinning only the version needs the running name to build a
+		// reference. An untagged image gives one, but a digest reference does
+		// not: splitImageRef divides it on the digest's own colon, and half of
+		// a digest is not a name to hand back to dokku.
+		return &PlanResult{
+			Status: PlanStatusError,
+			Error: fmt.Errorf("cannot upgrade %s service %s: its running image %q gives no image name to keep, set 'image' alongside 'image_version'",
+				t.Service, t.Name, running),
+		}
+	}
+	target := fmt.Sprintf("%s:%s", image, t.ImageVersion)
+
+	restartApps := false
+	if t.RestartApps {
+		apps, err := serviceLinkedApps(t.Service, t.Name)
+		if err != nil {
+			return &PlanResult{Status: PlanStatusError, Error: err}
+		}
+		restartApps = len(apps) > 0
+	}
+
+	args := append([]string{"--quiet", fmt.Sprintf("%s:upgrade", t.Service), t.Name}, t.upgradeFlags(image)...)
+	if restartApps {
+		args = append(args, "--restart-apps", "true")
+	}
+	inputs := []subprocess.ExecCommandInput{{
+		Command: "dokku",
+		Args:    args,
+	}}
+
+	mutations := []string{fmt.Sprintf("%s:upgrade %s (image %s)", t.Service, t.Name, target)}
+	if reset := t.upgradeResets(); len(reset) > 0 {
+		mutations = append(mutations, fmt.Sprintf("reset %s, which the recipe does not declare", strings.Join(reset, " and ")))
+	}
+	if restartApps {
+		mutations = append(mutations, "restart the linked app(s)")
+	}
+
+	return &PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("image drift: %s -> %s", running, target),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StatePresent, inputs)
+		},
+	}
 }
 
 // serviceExists checks if a dokku service exists. Returns (false, err)

--- a/tasks/service_create_task_integration_test.go
+++ b/tasks/service_create_task_integration_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -107,5 +108,143 @@ func TestIntegrationServiceCreatePinnedImage(t *testing.T) {
 
 	if plan := task.Plan(); !plan.InSync {
 		t.Errorf("expected the pinned service to be in sync on re-plan, got %+v", plan)
+	}
+}
+
+// The image pair the drift tests move a service between. 7.2.5 is the tag
+// TestIntegrationServiceCreatePinnedImage and the documented examples already
+// pull, so the suite adds at most one image to what CI fetches anyway.
+const (
+	driftImage   = "redis"
+	driftOldTag  = "7.2.4"
+	driftNewTag  = "7.2.5"
+	driftService = "redis"
+)
+
+// createDriftService stands up a redis service on the given tag and registers
+// its teardown. Each test uses its own name so a sharded CI run cannot have two
+// of them fighting over one service.
+func createDriftService(t *testing.T, name, tag string) {
+	t.Helper()
+	destroyService(driftService, name)
+	t.Cleanup(func() { destroyService(driftService, name) })
+
+	task := ServiceCreateTask{
+		Service:      driftService,
+		Name:         name,
+		Image:        driftImage,
+		ImageVersion: tag,
+		State:        StatePresent,
+	}
+	if result := task.Execute(); result.Error != nil {
+		t.Fatalf("failed to create %s:%s: %v\n  commands: %v\n  stderr: %s", driftImage, tag, result.Error, result.Commands, result.Stderr)
+	}
+}
+
+// TestIntegrationServiceCreateImageDriftWarns pins the default: a service on
+// the wrong image is reported and left alone, so apply stays idempotent.
+func TestIntegrationServiceCreateImageDriftWarns(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceName := "docket-test-drift-warn"
+	createDriftService(t, serviceName, driftNewTag)
+
+	task := ServiceCreateTask{
+		Service:      driftService,
+		Name:         serviceName,
+		Image:        driftImage,
+		ImageVersion: driftOldTag,
+		State:        StatePresent,
+	}
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Errorf("warn mode must stay in sync, got InSync=%v status=%q", plan.InSync, plan.Status)
+	}
+	if len(plan.Warnings) != 1 || plan.Warnings[0].Reason != WarnReasonServiceImageDrift {
+		t.Fatalf("expected one %s warning, got %v", WarnReasonServiceImageDrift, plan.Warnings)
+	}
+	if result := task.Execute(); result.Error != nil || result.Changed {
+		t.Errorf("warn mode must not change the server, got changed=%v err=%v", result.Changed, result.Error)
+	}
+}
+
+// TestIntegrationServiceCreateImageDriftErrors covers the CI-gate mode.
+func TestIntegrationServiceCreateImageDriftErrors(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceName := "docket-test-drift-error"
+	createDriftService(t, serviceName, driftNewTag)
+
+	task := ServiceCreateTask{
+		Service:      driftService,
+		Name:         serviceName,
+		Image:        driftImage,
+		ImageVersion: driftOldTag,
+		ImageDrift:   imageDriftError,
+		State:        StatePresent,
+	}
+	plan := task.Plan()
+	if plan.Error == nil || plan.Status != PlanStatusError {
+		t.Fatalf("expected a plan error, got status=%q err=%v", plan.Status, plan.Error)
+	}
+	if !strings.Contains(plan.Error.Error(), driftNewTag) || !strings.Contains(plan.Error.Error(), driftOldTag) {
+		t.Errorf("error %q should name both the running and the pinned reference", plan.Error.Error())
+	}
+}
+
+// TestIntegrationServiceCreateImageDriftUpgrades is the convergence test. An
+// upgrade that leaves the task reporting drift on the next run would recreate
+// the container on every apply, so asserting the re-plan is in sync and a
+// second apply changes nothing is the part that matters most here.
+func TestIntegrationServiceCreateImageDriftUpgrades(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceName := "docket-test-drift-upgrade"
+	createDriftService(t, serviceName, driftOldTag)
+
+	task := ServiceCreateTask{
+		Service:      driftService,
+		Name:         serviceName,
+		Image:        driftImage,
+		ImageVersion: driftNewTag,
+		ImageDrift:   imageDriftUpgrade,
+		State:        StatePresent,
+	}
+
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusModify {
+		t.Fatalf("expected drift, got InSync=%v status=%q", plan.InSync, plan.Status)
+	}
+
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to upgrade: %v\n  commands: %v\n  stderr: %s", result.Error, result.Commands, result.Stderr)
+	}
+	if !result.Changed || result.State != StatePresent {
+		t.Fatalf("expected a changed, present service, got changed=%v state=%q", result.Changed, result.State)
+	}
+
+	image, version, err := serviceImage(driftService, serviceName)
+	if err != nil {
+		t.Fatalf("serviceImage: %v", err)
+	}
+	if image != driftImage || version != driftNewTag {
+		t.Errorf("service is running %q:%q, want %q:%q", image, version, driftImage, driftNewTag)
+	}
+
+	if plan := task.Plan(); !plan.InSync || len(plan.Warnings) != 0 {
+		t.Errorf("the upgraded service must re-plan in sync and silent, got %+v", plan)
+	}
+	if second := task.Execute(); second.Error != nil || second.Changed {
+		t.Errorf("a second apply must be a no-op, got changed=%v err=%v", second.Changed, second.Error)
 	}
 }

--- a/tasks/service_create_task_test.go
+++ b/tasks/service_create_task_test.go
@@ -2,7 +2,10 @@ package tasks
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -297,6 +300,38 @@ func TestServiceCreateTaskValidate(t *testing.T) {
 			task:    ServiceCreateTask{Service: "redis", Name: "cache", PostStartNetwork: []string{"a,b"}},
 			wantErr: `'post_start_network' entry "a,b" must not contain ','`,
 		},
+		{
+			name:    "unknown image drift mode",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", Image: "redis", ImageDrift: "sometimes"},
+			wantErr: `'image_drift' must be one of ignore, warn, error, upgrade, got "sometimes"`,
+		},
+		{
+			name:    "image drift without a pin",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", ImageDrift: imageDriftUpgrade},
+			wantErr: "'image_drift' requires 'image' or 'image_version'",
+		},
+		{
+			// The running tag belongs to the image being replaced, so there is
+			// no safe value to carry over.
+			name:    "upgrade with an image but no version",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", Image: "redis", ImageDrift: imageDriftUpgrade},
+			wantErr: "'image_drift: upgrade' requires 'image_version' when 'image' is set",
+		},
+		{
+			name:    "restart apps without an upgrade",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", Image: "redis", ImageVersion: "7.2.5", RestartApps: true},
+			wantErr: "'restart_apps' requires 'image_drift: upgrade'",
+		},
+		{
+			name:    "image drift under absent",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", ImageDrift: imageDriftUpgrade, State: StateAbsent},
+			wantErr: "'image_drift' must not be set for state 'absent'",
+		},
+		{
+			name:    "restart apps under absent",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", RestartApps: true, State: StateAbsent},
+			wantErr: "'restart_apps' must not be set for state 'absent'",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -375,9 +410,558 @@ func TestGetTasksServiceCreateCreateOptionsParsed(t *testing.T) {
 		PostStartNetwork:  []string{"started"},
 		Password:          "user-pw",
 		RootPassword:      "root-pw",
-		State:             StatePresent,
+		// The recipe says nothing about drift, so defaults.SetDefaults fills
+		// the `default:` tag in on the way through.
+		ImageDrift: imageDriftWarn,
+		State:      StatePresent,
 	}
 	if !reflect.DeepEqual(*scTask, want) {
 		t.Errorf("parsed task = %#v, want %#v", *scTask, want)
+	}
+}
+
+// TestGetTasksServiceCreateImageDriftParsed covers the drift fields a recipe
+// sets explicitly. The defaulted case is covered by the test above.
+func TestGetTasksServiceCreateImageDriftParsed(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: upgrade redis service
+      dokku_service_create:
+        service: redis
+        name: cache
+        image: redis
+        image_version: "7.2.5"
+        image_drift: upgrade
+        restart_apps: true
+`)
+
+	tasks, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+	task := tasks.Get("upgrade redis service")
+	if task == nil {
+		t.Fatal("task 'upgrade redis service' not found")
+	}
+	scTask, ok := task.(*ServiceCreateTask)
+	if !ok {
+		t.Fatalf("task is not a *ServiceCreateTask (type is %T)", task)
+	}
+
+	want := ServiceCreateTask{
+		Service:      "redis",
+		Name:         "cache",
+		Image:        "redis",
+		ImageVersion: "7.2.5",
+		ImageDrift:   imageDriftUpgrade,
+		RestartApps:  true,
+		State:        StatePresent,
+	}
+	if !reflect.DeepEqual(*scTask, want) {
+		t.Errorf("parsed task = %#v, want %#v", *scTask, want)
+	}
+}
+
+// recordingDokku wraps fakeDokku so a test can assert which dokku commands the
+// plan issued - specifically that a probe it should have skipped never ran,
+// which no assertion on the returned PlanResult can show.
+func recordingDokku(responses map[string]string, calls *[]string) func(context.Context, subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	inner := fakeDokku(responses)
+	return func(ctx context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		*calls = append(*calls, strings.Join(in.Args, " "))
+		return inner(ctx, in)
+	}
+}
+
+// driftFixture answers the two reads the present branch makes: the service
+// exists (fakeDokku always exits 0) and reports the given image reference.
+func driftFixture(service, name, runningRef string) map[string]string {
+	return map[string]string{
+		fmt.Sprintf("--quiet %s:info %s --version", service, name): runningRef,
+	}
+}
+
+// driftTask is a service pinned to redis:7.2.5, the shape most drift tests want.
+func driftTask() ServiceCreateTask {
+	return ServiceCreateTask{
+		Service:      "redis",
+		Name:         "cache",
+		Image:        "redis",
+		ImageVersion: "7.2.5",
+		State:        StatePresent,
+	}
+}
+
+// planImageWarning returns the single drift warning on a plan, failing the
+// test when the plan is not the in-sync-with-one-warning shape #435 describes.
+func planImageWarning(t *testing.T, plan PlanResult) PlanWarning {
+	t.Helper()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("expected an in-sync plan, got InSync=%v status=%q", plan.InSync, plan.Status)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("an in-sync plan must carry no commands, got %v", plan.Commands)
+	}
+	if len(plan.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d (%v)", len(plan.Warnings), plan.Warnings)
+	}
+	w := plan.Warnings[0]
+	if w.Reason != WarnReasonServiceImageDrift {
+		t.Errorf("warning reason = %q, want %q", w.Reason, WarnReasonServiceImageDrift)
+	}
+	if w.Message == "" {
+		// Both emitters drop an empty message on the floor, so an empty one
+		// is the same as no warning at all.
+		t.Error("warning message must not be empty")
+	}
+	return w
+}
+
+// TestServiceCreateTaskImageDriftDefaultsToWarn pins that the zero value of
+// ImageDrift behaves as "warn". The `default:` tag only reaches a decoded
+// recipe, so every task built in Go - ExportGlobal, Examples, the integration
+// tests - carries the empty string and depends on this.
+func TestServiceCreateTaskImageDriftDefaultsToWarn(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis:7.2.4")))()
+
+	task := driftTask()
+	if got := task.imageDriftMode(); got != imageDriftWarn {
+		t.Errorf("imageDriftMode() = %q, want %q", got, imageDriftWarn)
+	}
+	planImageWarning(t, task.Plan())
+}
+
+func TestServiceCreateTaskImageDriftInSyncWhenPinsMatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		task    ServiceCreateTask
+		running string
+	}{
+		{"both halves pinned", driftTask(), "redis:7.2.5"},
+		{
+			name:    "version only",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", State: StatePresent},
+			running: "redis:7.2.5",
+		},
+		{
+			name:    "image only",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", Image: "redis", State: StatePresent},
+			running: "redis:7.2.5",
+		},
+		{
+			name:    "registry port is not a tag",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", Image: "registry.example.com:5000/redis", ImageVersion: "7.2.5", State: StatePresent},
+			running: "registry.example.com:5000/redis:7.2.5",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", tc.running)))()
+			plan := tc.task.Plan()
+			if plan.Error != nil {
+				t.Fatalf("unexpected plan error: %v", plan.Error)
+			}
+			if !plan.InSync || plan.Status != PlanStatusOK {
+				t.Errorf("expected in sync, got InSync=%v status=%q", plan.InSync, plan.Status)
+			}
+			if len(plan.Warnings) != 0 {
+				t.Errorf("expected no warnings, got %v", plan.Warnings)
+			}
+		})
+	}
+}
+
+func TestServiceCreateTaskImageDriftWarnStaysInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis:7.2.4")))()
+
+	task := driftTask()
+	task.ImageDrift = imageDriftWarn
+	w := planImageWarning(t, task.Plan())
+	for _, want := range []string{"redis:7.2.4", "redis:7.2.5", "image_drift: upgrade"} {
+		if !strings.Contains(w.Message, want) {
+			t.Errorf("warning message %q does not mention %q", w.Message, want)
+		}
+	}
+
+	// ExecutePlan carries plan warnings out of the in-sync branch, so apply
+	// reports the same diagnostic plan did.
+	state := task.Execute()
+	if state.Error != nil {
+		t.Fatalf("unexpected execute error: %v", state.Error)
+	}
+	if state.Changed {
+		t.Error("a warn-mode drift must not change the server")
+	}
+	if len(state.Warnings) != 1 || state.Warnings[0].Reason != WarnReasonServiceImageDrift {
+		t.Errorf("expected the warning to survive onto the apply state, got %v", state.Warnings)
+	}
+}
+
+// TestServiceCreateTaskImageDriftWarnsOnUnreadableImage covers a service whose
+// container is gone: dokku prints nothing, so there is nothing to compare.
+// Reporting in sync silently would tell a recipe that asked for drift to be
+// caught that everything is fine.
+func TestServiceCreateTaskImageDriftWarnsOnUnreadableImage(t *testing.T) {
+	for _, mode := range []string{imageDriftWarn, imageDriftError, imageDriftUpgrade} {
+		t.Run(mode, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "")))()
+			task := driftTask()
+			task.ImageDrift = mode
+			w := planImageWarning(t, task.Plan())
+			if !strings.Contains(w.Message, "no running image") {
+				t.Errorf("warning message %q does not say the image could not be read", w.Message)
+			}
+		})
+	}
+}
+
+func TestServiceCreateTaskImageDriftIgnoreSkipsTheProbe(t *testing.T) {
+	var calls []string
+	defer subprocess.SetExecRunner(recordingDokku(driftFixture("redis", "cache", "redis:7.2.4"), &calls))()
+
+	task := driftTask()
+	task.ImageDrift = imageDriftIgnore
+	plan := task.Plan()
+	if !plan.InSync || len(plan.Warnings) != 0 {
+		t.Errorf("expected a silent in-sync plan, got InSync=%v warnings=%v", plan.InSync, plan.Warnings)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "redis:info") {
+			t.Errorf("ignore mode must not read the image, but issued %q", call)
+		}
+	}
+}
+
+// TestServiceCreateTaskImageDriftSkipsTheProbeWithoutAPin pins that an
+// unpinned recipe costs no extra round trip: with no declared image there is
+// nothing to compare the running one against.
+func TestServiceCreateTaskImageDriftSkipsTheProbeWithoutAPin(t *testing.T) {
+	var calls []string
+	defer subprocess.SetExecRunner(recordingDokku(driftFixture("redis", "cache", "redis:7.2.4"), &calls))()
+
+	task := ServiceCreateTask{Service: "redis", Name: "cache", State: StatePresent}
+	if plan := task.Plan(); !plan.InSync || len(plan.Warnings) != 0 {
+		t.Errorf("expected a silent in-sync plan, got InSync=%v warnings=%v", plan.InSync, plan.Warnings)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "redis:info") {
+			t.Errorf("an unpinned task must not read the image, but issued %q", call)
+		}
+	}
+}
+
+func TestServiceCreateTaskImageDriftErrorReportsMismatch(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis:7.2.4")))()
+
+	task := driftTask()
+	task.ImageDrift = imageDriftError
+	plan := task.Plan()
+	if plan.Error == nil {
+		t.Fatal("expected a plan error, got none")
+	}
+	if plan.Status != PlanStatusError {
+		t.Errorf("status = %q, want %q", plan.Status, PlanStatusError)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("a probe-error plan must carry no commands, got %v", plan.Commands)
+	}
+	want := `redis service cache is running redis:7.2.4, recipe pins redis:7.2.5`
+	if plan.Error.Error() != want {
+		t.Errorf("error = %q, want %q", plan.Error.Error(), want)
+	}
+}
+
+func TestServiceCreateTaskImageDriftUpgradeCommand(t *testing.T) {
+	cases := []struct {
+		name    string
+		task    ServiceCreateTask
+		running string
+		want    string
+	}{
+		{
+			name:    "both halves pinned",
+			task:    driftTask(),
+			running: "redis:7.2.4",
+			want:    "dokku --quiet redis:upgrade cache --image redis --image-version 7.2.5",
+		},
+		{
+			// The recipe named no image, so the running one is carried over
+			// rather than letting dokku fall back to its plugin default.
+			name:    "version only keeps the running image name",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", State: StatePresent},
+			running: "custom/redis:7.2.4",
+			want:    "dokku --quiet redis:upgrade cache --image custom/redis --image-version 7.2.5",
+		},
+		{
+			name:    "registry port in the running image",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", State: StatePresent},
+			running: "registry.example.com:5000/redis:7.2.4",
+			want:    "dokku --quiet redis:upgrade cache --image registry.example.com:5000/redis --image-version 7.2.5",
+		},
+		{
+			name:    "untagged running image",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", State: StatePresent},
+			running: "redis",
+			want:    "dokku --quiet redis:upgrade cache --image redis --image-version 7.2.5",
+		},
+		{
+			name: "every option the upgrade accepts is re-passed",
+			task: ServiceCreateTask{
+				Service:           "redis",
+				Name:              "cache",
+				Image:             "redis",
+				ImageVersion:      "7.2.5",
+				ConfigOptions:     "--cpus 2",
+				CustomEnv:         map[string]string{"B": "two", "A": "one"},
+				ShmSize:           "128m",
+				InitialNetwork:    "net-a",
+				PostCreateNetwork: []string{"net-b", "net-c"},
+				PostStartNetwork:  []string{"net-d"},
+				State:             StatePresent,
+			},
+			running: "redis:7.2.4",
+			want: "dokku --quiet redis:upgrade cache --image redis --image-version 7.2.5 " +
+				"--config-options --cpus 2 --custom-env A=one;B=two --shm-size 128m " +
+				"--initial-network net-a --post-create-network net-b,net-c --post-start-network net-d",
+		},
+		{
+			// `<service>:upgrade` accepts none of these three, and the plugin
+			// keeps its own copies across a container rebuild.
+			name: "options the upgrade does not accept are omitted",
+			task: ServiceCreateTask{
+				Service:      "redis",
+				Name:         "cache",
+				Image:        "redis",
+				ImageVersion: "7.2.5",
+				Memory:       512,
+				Password:     "hunter2",
+				RootPassword: "hunter3",
+				State:        StatePresent,
+			},
+			running: "redis:7.2.4",
+			want:    "dokku --quiet redis:upgrade cache --image redis --image-version 7.2.5",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", tc.running)))()
+			task := tc.task
+			task.ImageDrift = imageDriftUpgrade
+			plan := task.Plan()
+			if plan.Error != nil {
+				t.Fatalf("unexpected plan error: %v", plan.Error)
+			}
+			if plan.InSync || plan.Status != PlanStatusModify {
+				t.Errorf("expected drift, got InSync=%v status=%q", plan.InSync, plan.Status)
+			}
+			if len(plan.Commands) != 1 {
+				t.Fatalf("expected 1 command, got %v", plan.Commands)
+			}
+			if plan.Commands[0] != tc.want {
+				t.Errorf("command = %q, want %q", plan.Commands[0], tc.want)
+			}
+		})
+	}
+}
+
+// TestServiceCreateTaskImageDriftUpgradeReportsTheEffectiveTarget pins that
+// the plan's prose names the reference the upgrade will actually use, not the
+// half the recipe happened to write.
+func TestServiceCreateTaskImageDriftUpgradeReportsTheEffectiveTarget(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "custom/redis:7.2.4")))()
+
+	task := ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", ImageDrift: imageDriftUpgrade, State: StatePresent}
+	plan := task.Plan()
+	if want := "image drift: custom/redis:7.2.4 -> custom/redis:7.2.5"; plan.Reason != want {
+		t.Errorf("reason = %q, want %q", plan.Reason, want)
+	}
+	if len(plan.Mutations) == 0 || plan.Mutations[0] != "redis:upgrade cache (image custom/redis:7.2.5)" {
+		t.Errorf("mutations = %v, want the effective target first", plan.Mutations)
+	}
+}
+
+// TestServiceCreateTaskImageDriftUpgradeNamesWhatItResets pins the one
+// destructive thing an upgrade does that nothing else in the plan would show.
+// The plugin rewrites CONFIG_OPTIONS and ENV from the flags it is given and
+// blanks them when it is given none, and docket has no read command for either,
+// so an undeclared value is lost with no flag on the argv to hint at it.
+func TestServiceCreateTaskImageDriftUpgradeNamesWhatItResets(t *testing.T) {
+	cases := []struct {
+		name string
+		task ServiceCreateTask
+		want string
+	}{
+		{
+			name: "neither declared",
+			task: driftTask(),
+			want: "reset config_options and custom_env, which the recipe does not declare",
+		},
+		{
+			name: "config_options declared",
+			task: func() ServiceCreateTask { tk := driftTask(); tk.ConfigOptions = "--cpus 2"; return tk }(),
+			want: "reset custom_env, which the recipe does not declare",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis:7.2.4")))()
+			task := tc.task
+			task.ImageDrift = imageDriftUpgrade
+			plan := task.Plan()
+			if len(plan.Mutations) != 2 || plan.Mutations[1] != tc.want {
+				t.Errorf("mutations = %v, want %q as the second entry", plan.Mutations, tc.want)
+			}
+		})
+	}
+
+	t.Run("both declared", func(t *testing.T) {
+		defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis:7.2.4")))()
+		task := driftTask()
+		task.ImageDrift = imageDriftUpgrade
+		task.ConfigOptions = "--cpus 2"
+		task.CustomEnv = map[string]string{"A": "one"}
+		if plan := task.Plan(); len(plan.Mutations) != 1 {
+			t.Errorf("nothing is reset when the recipe declares both, got %v", plan.Mutations)
+		}
+	})
+}
+
+func TestServiceCreateTaskImageDriftUpgradeRestartsOnlyLinkedApps(t *testing.T) {
+	cases := []struct {
+		name        string
+		restartApps bool
+		links       string
+		wantFlag    bool
+	}{
+		{"asked for and linked", true, "my-app\nother-app\n", true},
+		{"asked for but nothing linked", true, "", false},
+		{"linked but not asked for", false, "my-app\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			responses := driftFixture("redis", "cache", "redis:7.2.4")
+			responses["--quiet redis:links cache"] = tc.links
+			defer subprocess.SetExecRunner(fakeDokku(responses))()
+
+			task := driftTask()
+			task.ImageDrift = imageDriftUpgrade
+			task.RestartApps = tc.restartApps
+			plan := task.Plan()
+			if plan.Error != nil {
+				t.Fatalf("unexpected plan error: %v", plan.Error)
+			}
+			if len(plan.Commands) != 1 {
+				t.Fatalf("expected 1 command, got %v", plan.Commands)
+			}
+			got := strings.Contains(plan.Commands[0], "--restart-apps true")
+			if got != tc.wantFlag {
+				t.Errorf("--restart-apps true present = %v, want %v (command %q)", got, tc.wantFlag, plan.Commands[0])
+			}
+			hasMutation := slices.Contains(plan.Mutations, "restart the linked app(s)")
+			if hasMutation != tc.wantFlag {
+				t.Errorf("restart mutation present = %v, want %v (%v)", hasMutation, tc.wantFlag, plan.Mutations)
+			}
+		})
+	}
+}
+
+func TestServiceCreateTaskImageDriftUpgradeMasksSecrets(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis:7.2.4")))()
+
+	task := driftTask()
+	task.ImageDrift = imageDriftUpgrade
+	task.CustomEnv = map[string]string{"GREETING": "s3cret"}
+	subprocess.SetGlobalSensitive(sensitiveValuesFromTask(&task))
+	defer subprocess.SetGlobalSensitive(nil)
+
+	plan := task.Plan()
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected 1 command, got %v", plan.Commands)
+	}
+	if strings.Contains(plan.Commands[0], "s3cret") {
+		t.Errorf("custom_env value leaked into the upgrade command: %q", plan.Commands[0])
+	}
+	if !strings.Contains(plan.Commands[0], "GREETING=") {
+		t.Errorf("custom_env key should stay legible: %q", plan.Commands[0])
+	}
+}
+
+// TestServiceCreateTaskImageDriftUpgradeRefusesADigestRef covers the one
+// running image splitImageRef cannot represent: it divides `redis@sha256:abc`
+// on the digest's own colon, and `redis@sha256` is not a name to hand back to
+// dokku. Refusing beats rendering a reference that fails only after the old
+// container has already been removed.
+func TestServiceCreateTaskImageDriftUpgradeRefusesADigestRef(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis@sha256:abc123")))()
+
+	task := ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", ImageDrift: imageDriftUpgrade, State: StatePresent}
+	plan := task.Plan()
+	if plan.Error == nil {
+		t.Fatal("expected a plan error, got none")
+	}
+	if plan.Status != PlanStatusError {
+		t.Errorf("status = %q, want %q", plan.Status, PlanStatusError)
+	}
+	if !strings.Contains(plan.Error.Error(), "set 'image' alongside 'image_version'") {
+		t.Errorf("error %q does not say how to resolve it", plan.Error.Error())
+	}
+}
+
+func TestServiceCreateTaskImageDriftAppliesUpgrade(t *testing.T) {
+	var calls []string
+	defer subprocess.SetExecRunner(recordingDokku(driftFixture("redis", "cache", "redis:7.2.4"), &calls))()
+
+	task := driftTask()
+	task.ImageDrift = imageDriftUpgrade
+	state := task.Execute()
+	if state.Error != nil {
+		t.Fatalf("unexpected execute error: %v", state.Error)
+	}
+	if !state.Changed || state.State != StatePresent {
+		t.Errorf("expected a changed, present service, got changed=%v state=%q", state.Changed, state.State)
+	}
+	if !slices.Contains(calls, "--quiet redis:upgrade cache --image redis --image-version 7.2.5") {
+		t.Errorf("the upgrade was not run; calls: %v", calls)
+	}
+}
+
+// TestServiceCreateTaskImageDriftPropagatesSSHErrors pins that a transport
+// failure on either read becomes a probe error rather than being mistaken for
+// "no image" or "no linked apps".
+func TestServiceCreateTaskImageDriftPropagatesSSHErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		fail string
+	}{
+		{"image read", "--quiet redis:info cache --version"},
+		{"links read", "--quiet redis:links cache"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			responses := driftFixture("redis", "cache", "redis:7.2.4")
+			responses["--quiet redis:links cache"] = "my-app\n"
+			inner := fakeDokku(responses)
+			defer subprocess.SetExecRunner(func(ctx context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+				if strings.Join(in.Args, " ") == tc.fail {
+					return subprocess.ExecCommandResponse{}, &subprocess.SSHError{}
+				}
+				return inner(ctx, in)
+			})()
+
+			task := driftTask()
+			task.ImageDrift = imageDriftUpgrade
+			task.RestartApps = true
+			plan := task.Plan()
+			var sshErr *subprocess.SSHError
+			if !errors.As(plan.Error, &sshErr) {
+				t.Fatalf("expected an SSHError, got %v", plan.Error)
+			}
+			if plan.Status != PlanStatusError {
+				t.Errorf("status = %q, want %q", plan.Status, PlanStatusError)
+			}
+		})
 	}
 }

--- a/tasks/service_export.go
+++ b/tasks/service_export.go
@@ -112,6 +112,23 @@ func serviceDSN(service, name string) (string, error) {
 // (`*subprocess.SSHError`) is propagated; any other failure yields no image, as
 // does a service whose container is gone - dokku prints nothing in that case.
 func serviceImage(service, name string) (string, string, error) {
+	ref, err := serviceImageRef(service, name)
+	if err != nil {
+		return "", "", err
+	}
+	image, version := splitImageRef(ref)
+	return image, version, nil
+}
+
+// serviceImageRef returns the image reference verbatim, before splitImageRef
+// has had a chance to lose anything in it. The drift probe in
+// dokku_service_create needs the raw form: splitImageRef cannot represent a
+// digest reference (`redis@sha256:...` splits on the digest's colon), and a
+// half of that split is not something the task may hand back to
+// `<service>:upgrade`. Error handling is serviceImage's: a transport-level
+// failure propagates, anything else - including a service whose container is
+// gone, where dokku prints nothing - yields the empty ref.
+func serviceImageRef(service, name string) (string, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", fmt.Sprintf("%s:info", service), name, "--version"},
@@ -119,12 +136,11 @@ func serviceImage(service, name string) (string, string, error) {
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
-			return "", "", err
+			return "", err
 		}
-		return "", "", nil
+		return "", nil
 	}
-	image, version := splitImageRef(result.StdoutContents())
-	return image, version, nil
+	return result.StdoutContents(), nil
 }
 
 // splitImageRef splits a docker image reference into its name and tag. The

--- a/tasks/service_export_test.go
+++ b/tasks/service_export_test.go
@@ -99,6 +99,12 @@ func TestSplitImageRef(t *testing.T) {
 		{"registry.example.com:5000/postgres:17.2", "registry.example.com:5000/postgres", "17.2"},
 		{"postgres", "postgres", ""},
 		{"", "", ""},
+		// A digest reference has no tag to find, and the colon the splitter
+		// lands on belongs to the digest. Neither half is usable, which is why
+		// the image-drift upgrade path refuses to build a reference out of one
+		// (see TestServiceCreateTaskImageDriftUpgradeRefusesADigestRef) rather
+		// than trusting this result.
+		{"postgres@sha256:abc123", "postgres@sha256", "abc123"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.ref, func(t *testing.T) {
@@ -334,6 +340,14 @@ func TestExportRecipeIncludesServiceTasks(t *testing.T) {
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+	// Drift policy is a recipe-authoring choice, not something a server has,
+	// so export must not put words in the operator's mouth about it. Both
+	// fields rely on `omitempty` and their zero values to stay out.
+	for _, unwanted := range []string{"image_drift", "restart_apps"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("recipe should not export %q:\n%s", unwanted, out)
 		}
 	}
 }

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -186,6 +186,96 @@ EOF
   assert_output --partial "'image' must not be set for state 'absent'"
 }
 
+@test "docket validate exits 1 on an unknown service_create image_drift" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: redis
+        name: cache
+        image_version: "7.2.5"
+        image_drift: sometimes
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'image_drift' must be one of ignore, warn, error, upgrade"
+}
+
+@test "docket validate exits 1 on service_create image_drift without an image pin" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: redis
+        name: cache
+        image_drift: upgrade
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'image_drift' requires 'image' or 'image_version'"
+}
+
+@test "docket validate exits 1 on service_create image_drift upgrade without an image_version" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: redis
+        name: cache
+        image: redis
+        image_drift: upgrade
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'image_drift: upgrade' requires 'image_version' when 'image' is set"
+}
+
+@test "docket validate exits 1 on service_create restart_apps without an upgrade" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: redis
+        name: cache
+        image: redis
+        image_version: "7.2.5"
+        restart_apps: true
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'restart_apps' requires 'image_drift: upgrade'"
+}
+
+@test "docket validate exits 1 on service_create image_drift under state absent" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: redis
+        name: cache
+        image_drift: upgrade
+        state: absent
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'image_drift' must not be set for state 'absent'"
+}
+
+@test "docket validate exits 1 on service_create restart_apps under state absent" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: redis
+        name: cache
+        restart_apps: true
+        state: absent
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'restart_apps' must not be set for state 'absent'"
+}
+
 @test "docket validate exits 1 on a service_create custom_env delimiter" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
`dokku_service_create` probed only `<service>:exists`, so a service that already existed was in sync whatever image it was running and a changed `image` or `image_version` pin was a silent no-op. The task now reads the running image back and compares the dimensions the recipe pins, reporting a mismatch as a `service_image_drift` warning while staying in sync, so `apply` remains idempotent. The new `image_drift` field selects `ignore`, `warn`, `error`, or `upgrade`, and `restart_apps` restarts linked apps after an upgrade when the service actually has any. Upgrading is opt-in because dokku's only remedy recreates the container, which means downtime, no data migration across major versions, and a reset of any `config_options` and `custom_env` the recipe does not declare; the plan names that reset on its own line since docket has no way to read those values back.

Two rules on the upgrade come from the plugin source rather than from the docs. The reference is always rendered whole, filling a name the recipe did not pin from the running container so dokku cannot fall back to its plugin default, and `image_drift: upgrade` alongside a bare `image` is rejected because the running tag belongs to the image being replaced and carrying it over would name a reference that may not exist, discovered only after the old container is gone.

The task's `ProbeSupport` caveat already claimed the image was probed, which was not true until now. Closes #435.
