### PR TITLE
feat: converge an existing storage entry's attributes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.27
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -91,7 +91,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.27
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -128,7 +128,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.27
           sudo dokku plugin:install-dependencies --core
       - name: initialize k3s cluster
         run: sudo dokku scheduler-k3s:initialize --server-ip 127.0.0.1
@@ -151,7 +151,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.27
           sudo dokku plugin:install-dependencies --core
       - name: stand up the pebble ACME server
         run: |
@@ -183,7 +183,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.27
           sudo dokku plugin:install-dependencies --core
       - name: install dokku http-auth plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git --committish 0.13.0 http-auth

--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -297,28 +297,30 @@ wrapper's own contract says a pin change should recreate the container.
 `dokku_storage` does raw filesystem work alongside its `storage:mount` calls, which it gets
 away with because Ansible has already connected to the dokku host and is running there.
 docket may be driving that host over SSH, where a local filesystem call would touch the wrong
-machine entirely, so everything it does goes through a `dokku` subcommand. That caps it at
-what `storage:create` expresses, and `storage:create` is exactly what `dokku_storage_entry`
-wraps.
+machine entirely, so everything it does goes through a `dokku` subcommand. That caps it at what
+the storage plugin expresses, which is what `dokku_storage_entry` wraps: `storage:create` for an
+entry that does not exist yet, and `storage:set` plus the `storage:annotations:set` /
+`storage:labels:set` pair to converge one that does.
 
 | `dokku_storage` | docket | Notes |
 |-----------------|--------|-------|
 | `create_host_dir: true` | `dokku_storage_entry` | `storage:create` creates the directory. Emit one entry task per distinct host directory, ahead of the `dokku_storage_mount` tasks that reference it. |
 | the host path itself | `dokku_storage_entry.path` | Omit it to get dokku's default, `/var/lib/dokku/data/storage/<name>`. |
 | `user` and `group` | `dokku_storage_entry.chown` | One value, not two: dokku's helper runs `chown -R <id>:<id>`, so a module call whose `user` and `group` differ cannot be expressed. The module's `"32767"` default is `chown: herokuish`. |
-| `os.chmod(host_dir, 0o777)` | **stays in the wrapper** | dokku creates the directory `0755` and has no mode flag ([dokku/dokku#8913](https://github.com/dokku/dokku/issues/8913)). |
-| `destroy_host_dir: true` | **stays in the wrapper** | `storage:destroy` deregisters the entry and leaves the docker-local directory on disk; nothing in dokku removes it ([dokku/dokku#8913](https://github.com/dokku/dokku/issues/8913)). `dokku_storage_entry` with `state: absent` covers the deregistration half. |
+| `os.chmod(host_dir, 0o777)` | **stays in the wrapper for now** | dokku creates the directory `0755`. `storage:create --mode` sets a different one as of dokku 0.38.27, but `dokku_storage_entry` has no `mode` field yet ([#480](https://github.com/dokku/docket/issues/480)). |
+| `destroy_host_dir: true` | **stays in the wrapper for now** | `dokku_storage_entry` with `state: absent` deregisters the entry and leaves the docker-local directory on disk. `storage:destroy --destroy-host-dir` removes it as of dokku 0.38.27, but the task does not pass the flag yet ([#480](https://github.com/dokku/docket/issues/480)). |
 | `os.lexists("/home/dokku/<app>")` | nothing to forward | The module stats the filesystem to decide whether the app exists. docket asks dokku, so a wrapper drops the probe rather than translating it. |
 
-Two constraints on `chown` are worth knowing before a wrapper leans on it. dokku refuses the
-flag outright when the entry sits at a non-default `path`, and asks the operator to chown that
-path themselves. And it is applied when the entry is created, not on every run: an entry that
-already exists is left alone, so changing `chown` in a recipe is currently a no-op
-([#439](https://github.com/dokku/docket/issues/439)).
+One constraint on `chown` is worth knowing before a wrapper leans on it: dokku refuses the flag
+outright when the entry sits at a non-default `path`, and asks the operator to chown that path
+themselves. Ownership does converge, though. `dokku_storage_entry` compares `chown` against what
+the entry records and reaches for `storage:set` when the two disagree, which re-runs the chown on
+the docker-local directory - so a wrapper that changes `user` and `group` between runs gets the
+new ownership applied rather than recorded, the same as the module's own per-run `os.chown`.
 
-Everything else `storage:create` accepts is a field on the task - `scheduler`, `size`,
-`access_mode`, `storage_class`, `namespace`, `reclaim_policy`, `annotations`, and `labels` -
-none of which the module has a counterpart for.
+Everything else `storage:create` accepts other than `--mode` is a field on the task -
+`scheduler`, `size`, `access_mode`, `storage_class`, `namespace`, `reclaim_policy`,
+`annotations`, and `labels` - none of which the module has a counterpart for.
 
 ## Required and optional fields disagree
 
@@ -363,9 +365,10 @@ task lands.
   docket's `dokku_git_sync` is core `git:sync`, which is what the `dokku_clone` module does. The two
   are unrelated.
 
-Separately, two pieces of `dokku_storage` stay in the wrapper permanently rather than pending a task:
-the `0o777` chmod and the `destroy_host_dir` removal, neither of which dokku exposes a command for.
-See [host directories](#host-directories).
+Separately, two pieces of `dokku_storage` stay in the wrapper for now: the `0o777` chmod and the
+`destroy_host_dir` removal. dokku 0.38.27 added a command for each, and exposing them on
+`dokku_storage_entry` is tracked in [#480](https://github.com/dokku/docket/issues/480). See
+[host directories](#host-directories).
 
 ## docket tasks with no ansible-dokku module
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.22.**
+- **Dokku >= 0.38.27.**
 - **dokku-letsencrypt >= 0.25.0.**
 - **dokku-http-auth >= 0.13.0**, if your recipe uses the `dokku_http_auth*` tasks.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -32,7 +32,7 @@ once DNS points at it.
 
 ## Before you start
 
-Provision the new server first. docket needs [Dokku >= 0.38.22 and dokku-letsencrypt >=
+Provision the new server first. docket needs [Dokku >= 0.38.27 and dokku-letsencrypt >=
 0.25.0](getting-started.md#prerequisites), plus any datastore plugins your services rely on
 (dokku-postgres, dokku-redis, dokku-mysql, and so on) already installed. The
 [`dokku_plugin`](tasks/dokku_plugin.md) task can install third-party plugins as part of the

--- a/docs/tasks/dokku_storage_entry.md
+++ b/docs/tasks/dokku_storage_entry.md
@@ -35,7 +35,7 @@ Keyed by `name`.
 
 ## Examples
 
-### Create a docker-local storage entry owned by the herokuish user, and keep it owned by that user
+### Create a docker-local storage entry owned by the herokuish user
 
 ```yaml
 dokku_storage_entry:
@@ -43,15 +43,12 @@ dokku_storage_entry:
     chown: herokuish
 ```
 
-### Resize a k3s entry and add a label, leaving the attributes the recipe does not name alone
+### Change an entry's ownership, leaving the attributes the recipe does not name alone
 
 ```yaml
 dokku_storage_entry:
     name: node-js-app-data
-    scheduler: k3s
-    size: 8Gi
-    labels:
-        tier: data
+    chown: root
 ```
 
 ### Create a storage entry at an explicit host path

--- a/docs/tasks/dokku_storage_entry.md
+++ b/docs/tasks/dokku_storage_entry.md
@@ -6,11 +6,11 @@ Creates or destroys a named storage registry entry
 
 ## Export support
 
-Supported.
+Partial - every field the task accepts is exported; an entry's directory mode is not, since the task has no mode field yet (tracked in dokku/docket#480).
 
 ## Probe support
 
-Partial - idempotency is keyed on the entry name; scheduler, size, and chown changes to an existing entry are not drift-detected (tracked in dokku/docket#439).
+Supported - every field is compared against what storage:list-entries records for the entry, which is the recorded chown rather than the host directory's ownership on disk; a directory chowned out of band is not detected.
 
 ## Identity
 
@@ -21,26 +21,37 @@ Keyed by `name`.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `name` | string | yes |  |  | Name of the storage entry |
-| `path` | string | no |  |  | Host path for the entry: an absolute path, or a docker named volume on docker-local. Defaults to the dokku storage root joined with the entry name |
-| `scheduler` | string | no | docker-local | docker-local, k3s | Scheduler that backs the entry |
-| `size` | string | no |  |  | Volume size (k3s scheduler; required there and rejected on docker-local) |
-| `access_mode` | string | no |  | ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod | Volume access mode (k3s scheduler; rejected on docker-local) |
-| `storage_class` | string | no |  |  | Storage class name (k3s scheduler; rejected on docker-local, and mutually exclusive with path) |
-| `namespace` | string | no |  |  | Namespace (scheduler-dependent) |
-| `chown` | string | no |  | heroku, herokuish, paketo, root, false | Ownership applied when the entry's host directory is created: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path |
-| `reclaim_policy` | string | no |  | Retain, Delete | Reclaim policy applied to the underlying volume (k3s scheduler) |
-| `annotations` | dict | no |  |  | Map of annotations set on the underlying volume (k3s scheduler) |
-| `labels` | dict | no |  |  | Map of labels set on the underlying volume (k3s scheduler) |
+| `path` | string | no |  |  | Host path for the entry: an absolute path, or a docker named volume on docker-local. Defaults to the dokku storage root joined with the entry name. Cannot be changed on an entry that exists; a recipe that disagrees with the recorded path is reported as an error |
+| `scheduler` | string | no | docker-local | docker-local, k3s | Scheduler that backs the entry. Cannot be changed on an entry that exists; a recipe that disagrees with the recorded scheduler is reported as an error |
+| `size` | string | no |  |  | Volume size (k3s scheduler; required there and rejected on docker-local). Converged on an entry that exists |
+| `access_mode` | string | no |  | ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod | Volume access mode (k3s scheduler; rejected on docker-local). Cannot be changed on an entry that exists, since kubernetes cannot rebind a bound claim; a recipe that disagrees with the recorded value is reported as an error |
+| `storage_class` | string | no |  |  | Storage class name (k3s scheduler; rejected on docker-local, and mutually exclusive with path). Cannot be changed on an entry that exists; a recipe that disagrees with the recorded value is reported as an error |
+| `namespace` | string | no |  |  | Namespace (scheduler-dependent). Converged on an entry that exists |
+| `chown` | string | no |  | heroku, herokuish, paketo, root, false | Ownership applied to the entry's host directory: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path. Converged on an entry that exists, which re-runs the chown on a docker-local directory |
+| `reclaim_policy` | string | no |  | Retain, Delete | Reclaim policy applied to the underlying volume (k3s scheduler). Converged on an entry that exists |
+| `annotations` | dict | no |  |  | Map of annotations set on the underlying volume (k3s scheduler). Converged one key at a time on an entry that exists, so a key the recipe omits is left alone |
+| `labels` | dict | no |  |  | Map of labels set on the underlying volume (k3s scheduler). Converged one key at a time on an entry that exists, so a key the recipe omits is left alone |
 | `state` | string | no | present | present, absent | Desired state of the storage entry |
 
 ## Examples
 
-### Create a docker-local storage entry owned by the herokuish user
+### Create a docker-local storage entry owned by the herokuish user, and keep it owned by that user
 
 ```yaml
 dokku_storage_entry:
     name: node-js-app-data
     chown: herokuish
+```
+
+### Resize a k3s entry and add a label, leaving the attributes the recipe does not name alone
+
+```yaml
+dokku_storage_entry:
+    name: node-js-app-data
+    scheduler: k3s
+    size: 8Gi
+    labels:
+        tier: data
 ```
 
 ### Create a storage entry at an explicit host path

--- a/tasks/scheduler_k3s_profile_task_integration_test.go
+++ b/tasks/scheduler_k3s_profile_task_integration_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 )
 
+// Profile names here are kept short on purpose. dokku 0.38.26 gave each
+// profile a node-sysctls helm release named `dokku-node-sysctls-profile-<name>`,
+// and helm caps a release name at 53 characters, so a profile name longer than
+// 26 is refused by `scheduler-k3s:profile:set` and its unset counterpart. The
+// task itself does not check the length yet (dokku/docket#482).
 func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
@@ -14,14 +19,14 @@ func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
 		{
 			name: "minimal-worker",
 			task: SchedulerK3sProfileTask{
-				Name: "docket-test-profile-minimal",
+				Name: "docket-test-minimal",
 				Role: "worker",
 			},
 		},
 		{
 			name: "full-server",
 			task: SchedulerK3sProfileTask{
-				Name:              "docket-test-profile-full",
+				Name:              "docket-test-full",
 				Role:              "server",
 				KubeletArgs:       []string{"max-pods=64", "eviction-hard=memory.available<5%"},
 				TaintScheduling:   true,
@@ -31,7 +36,7 @@ func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
 		{
 			name: "multiple-kubelet-args",
 			task: SchedulerK3sProfileTask{
-				Name:        "docket-test-profile-args",
+				Name:        "docket-test-args",
 				Role:        "worker",
 				KubeletArgs: []string{"max-pods=100", "node-labels=tier=spot", "system-reserved=cpu=200m"},
 			},
@@ -61,7 +66,7 @@ func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
 func TestIntegrationSchedulerK3sProfileFieldDrift(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
-	profileName := "docket-test-profile-drift"
+	profileName := "docket-test-drift"
 
 	seed := SchedulerK3sProfileTask{
 		Name:              profileName,

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -103,19 +103,17 @@ func (t StorageEntryTask) ProbeSupport() ProbeSupport {
 func (t StorageEntryTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]StorageEntryTaskExample{
 		{
-			Name: "Create a docker-local storage entry owned by the herokuish user, and keep it owned by that user",
+			Name: "Create a docker-local storage entry owned by the herokuish user",
 			StorageEntryTask: StorageEntryTask{
 				Name:  "node-js-app-data",
 				Chown: "herokuish",
 			},
 		},
 		{
-			Name: "Resize a k3s entry and add a label, leaving the attributes the recipe does not name alone",
+			Name: "Change an entry's ownership, leaving the attributes the recipe does not name alone",
 			StorageEntryTask: StorageEntryTask{
-				Name:      "node-js-app-data",
-				Scheduler: "k3s",
-				Size:      "8Gi",
-				Labels:    map[string]string{"tier": "data"},
+				Name:  "node-js-app-data",
+				Chown: "root",
 			},
 		},
 		{

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -16,49 +16,55 @@ import (
 // exist independently of any single app, and an attachment created via
 // dokku_storage_mount references them by name.
 //
-// Idempotency is keyed on the entry name: when an entry with the given
-// name exists, the task is in sync regardless of the other field
-// values. Attribute changes are therefore not drift-detected; to change
-// scheduler, size, or any other attribute, the recipe must destroy and
-// re-create the entry. Converging them in place is tracked in
-// https://github.com/dokku/docket/issues/439 - it needs a different
-// command per scheduler, since `storage:set --chown` records a new
-// ownership value without re-running the chown on a docker-local
-// directory.
+// The entry name selects the entry; every other field is compared against
+// what `storage:list-entries` records for it, so a recipe that changes one
+// converges on the next apply rather than being applied once at create
+// time. A field the recipe omits is unmanaged: it is neither compared nor
+// cleared, which is what stops a recipe naming only `name` and `chown`
+// from dropping a `size` it never mentions. Clearing an attribute is a
+// manual `dokku storage:set <name> <property>` with no value.
+//
+// Four fields cannot be converged, because dokku cannot change them on an
+// entry that exists: `storage:set` refuses an access-mode or storage-class
+// swap outright, and there is no command at all for the scheduler or the
+// host path. A recipe that disagrees with the entry on one of them is
+// reported as a plan error naming both values, so it fails before an apply
+// starts rather than part way through one.
 type StorageEntryTask struct {
 	// Name is the name of the storage entry
 	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the storage entry"`
 
 	// Path is the host path for the entry. Optional; on docker-local it
 	// defaults to the dokku storage root + name.
-	Path string `required:"false" yaml:"path,omitempty" description:"Host path for the entry: an absolute path, or a docker named volume on docker-local. Defaults to the dokku storage root joined with the entry name"`
+	Path string `required:"false" yaml:"path,omitempty" description:"Host path for the entry: an absolute path, or a docker named volume on docker-local. Defaults to the dokku storage root joined with the entry name. Cannot be changed on an entry that exists; a recipe that disagrees with the recorded path is reported as an error"`
 
 	// Scheduler is the scheduler that backs the entry
-	Scheduler string `required:"false" yaml:"scheduler,omitempty" default:"docker-local" options:"docker-local,k3s" description:"Scheduler that backs the entry"`
+	Scheduler string `required:"false" yaml:"scheduler,omitempty" default:"docker-local" options:"docker-local,k3s" description:"Scheduler that backs the entry. Cannot be changed on an entry that exists; a recipe that disagrees with the recorded scheduler is reported as an error"`
 
 	// Size is the volume size (k3s scheduler; required there, rejected on docker-local)
-	Size string `required:"false" yaml:"size,omitempty" description:"Volume size (k3s scheduler; required there and rejected on docker-local)"`
+	Size string `required:"false" yaml:"size,omitempty" description:"Volume size (k3s scheduler; required there and rejected on docker-local). Converged on an entry that exists"`
 
 	// AccessMode is the volume access mode (k3s scheduler)
-	AccessMode string `required:"false" yaml:"access_mode,omitempty" options:"ReadWriteOnce,ReadOnlyMany,ReadWriteMany,ReadWriteOncePod" description:"Volume access mode (k3s scheduler; rejected on docker-local)"`
+	AccessMode string `required:"false" yaml:"access_mode,omitempty" options:"ReadWriteOnce,ReadOnlyMany,ReadWriteMany,ReadWriteOncePod" description:"Volume access mode (k3s scheduler; rejected on docker-local). Cannot be changed on an entry that exists, since kubernetes cannot rebind a bound claim; a recipe that disagrees with the recorded value is reported as an error"`
 
 	// StorageClass is the storage class name (k3s scheduler)
-	StorageClass string `required:"false" yaml:"storage_class,omitempty" description:"Storage class name (k3s scheduler; rejected on docker-local, and mutually exclusive with path)"`
+	StorageClass string `required:"false" yaml:"storage_class,omitempty" description:"Storage class name (k3s scheduler; rejected on docker-local, and mutually exclusive with path). Cannot be changed on an entry that exists; a recipe that disagrees with the recorded value is reported as an error"`
 
 	// Namespace is the namespace (scheduler-dependent)
-	Namespace string `required:"false" yaml:"namespace,omitempty" description:"Namespace (scheduler-dependent)"`
+	Namespace string `required:"false" yaml:"namespace,omitempty" description:"Namespace (scheduler-dependent). Converged on an entry that exists"`
 
-	// Chown is the chown value applied when the entry's host directory is created
-	Chown string `required:"false" yaml:"chown,omitempty" options:"heroku,herokuish,paketo,root,false" description:"Ownership applied when the entry's host directory is created: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path"`
+	// Chown is the ownership applied to the entry's host directory, on
+	// creation and again whenever the recipe changes it.
+	Chown string `required:"false" yaml:"chown,omitempty" options:"heroku,herokuish,paketo,root,false" description:"Ownership applied to the entry's host directory: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path. Converged on an entry that exists, which re-runs the chown on a docker-local directory"`
 
 	// ReclaimPolicy is the reclaim policy (k3s scheduler)
-	ReclaimPolicy string `required:"false" yaml:"reclaim_policy,omitempty" options:"Retain,Delete" description:"Reclaim policy applied to the underlying volume (k3s scheduler)"`
+	ReclaimPolicy string `required:"false" yaml:"reclaim_policy,omitempty" options:"Retain,Delete" description:"Reclaim policy applied to the underlying volume (k3s scheduler). Converged on an entry that exists"`
 
 	// Annotations are the volume annotations (k3s scheduler)
-	Annotations map[string]string `required:"false" yaml:"annotations,omitempty" description:"Map of annotations set on the underlying volume (k3s scheduler)"`
+	Annotations map[string]string `required:"false" yaml:"annotations,omitempty" description:"Map of annotations set on the underlying volume (k3s scheduler). Converged one key at a time on an entry that exists, so a key the recipe omits is left alone"`
 
 	// Labels are the volume labels (k3s scheduler)
-	Labels map[string]string `required:"false" yaml:"labels,omitempty" description:"Map of labels set on the underlying volume (k3s scheduler)"`
+	Labels map[string]string `required:"false" yaml:"labels,omitempty" description:"Map of labels set on the underlying volume (k3s scheduler). Converged one key at a time on an entry that exists, so a key the recipe omits is left alone"`
 
 	// State is the desired state of the storage entry
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage entry"`
@@ -85,22 +91,31 @@ func (t StorageEntryTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t StorageEntryTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportSupported}
+	return ExportSupport{Status: ExportPartial, Caveat: "every field the task accepts is exported; an entry's directory mode is not, since the task has no mode field yet (tracked in dokku/docket#480)"}
 }
 
 // ProbeSupport reports whether Plan() can read this task's current state.
 func (t StorageEntryTask) ProbeSupport() ProbeSupport {
-	return ProbeSupport{Status: ProbePartial, Caveat: "idempotency is keyed on the entry name; scheduler, size, and chown changes to an existing entry are not drift-detected (tracked in dokku/docket#439)"}
+	return ProbeSupport{Status: ProbeSupported, Caveat: "every field is compared against what storage:list-entries records for the entry, which is the recorded chown rather than the host directory's ownership on disk; a directory chowned out of band is not detected"}
 }
 
 // Examples returns the examples for the storage entry task
 func (t StorageEntryTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]StorageEntryTaskExample{
 		{
-			Name: "Create a docker-local storage entry owned by the herokuish user",
+			Name: "Create a docker-local storage entry owned by the herokuish user, and keep it owned by that user",
 			StorageEntryTask: StorageEntryTask{
 				Name:  "node-js-app-data",
 				Chown: "herokuish",
+			},
+		},
+		{
+			Name: "Resize a k3s entry and add a label, leaving the attributes the recipe does not name alone",
+			StorageEntryTask: StorageEntryTask{
+				Name:      "node-js-app-data",
+				Scheduler: "k3s",
+				Size:      "8Gi",
+				Labels:    map[string]string{"tier": "data"},
 			},
 		},
 		{
@@ -301,6 +316,14 @@ func (t StorageEntryTask) Validate() error {
 // a pflag string slice, which comma-splits its argument through a CSV
 // reader before dokku ever sees it, so a comma or a double quote on either
 // side of the pair breaks the parse rather than the value.
+//
+// An empty value is refused for a different reason: it is what
+// `storage:annotations:set` and `storage:labels:set` read as "delete this
+// key", so a pair the recipe declares empty is one the server can never
+// hold, and the convergence pass would clear it and find it missing again
+// on every run. Same rule the scheduler-k3s pair tasks carry (#358).
+// Callers reach this only under state 'present'; Validate returns before it
+// for state 'absent', where no pair is dispatched at all.
 func validateKVFlag(name string, values map[string]string) error {
 	keys := mapKeys(values)
 	sort.Strings(keys)
@@ -317,6 +340,9 @@ func validateKVFlag(name string, values map[string]string) error {
 		if strings.ContainsAny(values[k], `,"`) {
 			return fmt.Errorf("'%s' value for %q must not contain ',' or '\"'", name, k)
 		}
+		if values[k] == "" {
+			return fmt.Errorf("'%s' value for %q must not be empty; dokku reads an empty value as a delete", name, k)
+		}
 	}
 	return nil
 }
@@ -328,12 +354,12 @@ func (t StorageEntryTask) Plan() PlanResult {
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := storageEntryExists(t.Name)
+			entry, err := lookupStorageEntry(t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			if exists {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
+			if entry != nil {
+				return planStorageEntryAttributes(t, *entry)
 			}
 			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: t.createArgs()}}
 			return PlanResult{
@@ -348,11 +374,11 @@ func (t StorageEntryTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := storageEntryExists(t.Name)
+			entry, err := lookupStorageEntry(t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			if !exists {
+			if entry == nil {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			inputs := []subprocess.ExecCommandInput{{
@@ -371,6 +397,150 @@ func (t StorageEntryTask) Plan() PlanResult {
 			}
 		},
 	})
+}
+
+// storageEntryAttribute is one recipe field paired with what the registry
+// records for it. Property is the `storage:set` property that converges the
+// field, and is empty for a field dokku cannot change once the entry
+// exists.
+type storageEntryAttribute struct {
+	Field    string
+	Property string
+	Desired  string
+	Current  string
+}
+
+// drifted reports whether the recipe declared the field and the entry holds
+// something else. A field the recipe omits is unmanaged: docket neither
+// compares it nor clears it, so a recipe naming only `name` and `chown`
+// leaves a `size` it never mentions alone.
+func (a storageEntryAttribute) drifted() bool {
+	return a.Desired != "" && a.Desired != a.Current
+}
+
+// immutableStorageEntryAttributes are the fields no dokku command changes
+// once the entry exists. `storage:set` refuses an access-mode or a
+// storage-class swap outright, since Kubernetes cannot rebind a bound PVC,
+// and neither the scheduler nor the host path is a settable property at
+// all - `storage:create` on an existing entry refuses a scheduler
+// redefinition rather than honoring it.
+//
+// The scheduler is always compared. It carries a `default:` tag, so a
+// decoded recipe always names one, and an empty value on a task built in Go
+// means docker-local everywhere else: createArgs drops the flag so dokku
+// applies the same default, and Validate reads it the same way.
+func immutableStorageEntryAttributes(t StorageEntryTask, e storageEntry) []storageEntryAttribute {
+	scheduler := t.Scheduler
+	if scheduler == "" {
+		scheduler = "docker-local"
+	}
+	return []storageEntryAttribute{
+		{Field: "scheduler", Desired: scheduler, Current: e.Scheduler},
+		{Field: "path", Desired: t.Path, Current: e.HostPath},
+		{Field: "access_mode", Desired: t.AccessMode, Current: e.AccessMode},
+		{Field: "storage_class", Desired: t.StorageClass, Current: e.StorageClass},
+	}
+}
+
+// mutableStorageEntryAttributes are the scalar fields `storage:set`
+// converges, in struct field order so plan and apply build byte-identical
+// argv across runs. dokku re-applies the host directory's ownership
+// whenever a storage:set touches chown, so setting it here changes the
+// directory on a docker-local entry rather than only the recorded value -
+// which is the whole reason attribute convergence is worth doing.
+func mutableStorageEntryAttributes(t StorageEntryTask, e storageEntry) []storageEntryAttribute {
+	return []storageEntryAttribute{
+		{Field: "size", Property: "size", Desired: t.Size, Current: e.Size},
+		{Field: "namespace", Property: "namespace", Desired: t.Namespace, Current: e.Namespace},
+		{Field: "chown", Property: "chown", Desired: t.Chown, Current: e.Chown},
+		{Field: "reclaim_policy", Property: "reclaim-policy", Desired: t.ReclaimPolicy, Current: e.ReclaimPolicy},
+	}
+}
+
+// planStorageEntryAttributes reports the drift between the recipe and an
+// entry that already exists. An immutable mismatch short-circuits to an
+// error before any mutation is planned, so an apply never gets half way
+// through a set of changes it was always going to be refused for.
+//
+// It is a package-level func rather than a method because
+// TestProbeSupportMatchesPlanWiring walks the tasks package for
+// plan-returning methods and allows exactly one per task, Plan itself.
+func planStorageEntryAttributes(t StorageEntryTask, entry storageEntry) PlanResult {
+	for _, attr := range immutableStorageEntryAttributes(t, entry) {
+		if !attr.drifted() {
+			continue
+		}
+		return PlanResult{
+			Status: PlanStatusError,
+			Error: fmt.Errorf("storage entry %s records %s %q, recipe declares %q: dokku cannot change it on an entry that exists, so destroy and re-create the entry to apply it",
+				t.Name, attr.Field, attr.Current, attr.Desired),
+		}
+	}
+
+	var inputs []subprocess.ExecCommandInput
+	var mutations []string
+
+	for _, attr := range mutableStorageEntryAttributes(t, entry) {
+		if !attr.drifted() {
+			continue
+		}
+		inputs = append(inputs, subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "storage:set", t.Name, attr.Property, attr.Desired},
+		})
+		mutations = append(mutations, formatStorageEntrySet(attr.Field, attr.Desired, attr.Current))
+	}
+
+	// The map fields converge one key at a time. dokku's wholesale
+	// `storage:set --annotation` replaces the entire map, which would clear
+	// every key the recipe does not name; the per-key subcommands leave
+	// their siblings in place, which is what makes an omitted key unmanaged
+	// here the same way an omitted scalar is.
+	for _, m := range []struct {
+		noun    string
+		command string
+		desired map[string]string
+		current map[string]string
+	}{
+		{"annotation", "storage:annotations:set", t.Annotations, entry.Annotations},
+		{"label", "storage:labels:set", t.Labels, entry.Labels},
+	} {
+		drifted, _ := driftedKeys(m.desired, m.current)
+		for _, key := range drifted {
+			inputs = append(inputs, subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    []string{"--quiet", m.command, t.Name, key, m.desired[key]},
+			})
+			mutations = append(mutations, formatStorageEntrySet(m.noun+" "+key, m.desired[key], m.current[key]))
+		}
+	}
+
+	if len(inputs) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d attribute(s) to set", len(inputs)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StatePresent, inputs)
+		},
+	}
+}
+
+// formatStorageEntrySet renders one mutation line in the shape
+// formatSetMutations produces for the map-pair tasks. An entry that records
+// nothing for the field reads as new: the registry marshals an unset
+// attribute and an empty one identically, so there is no third case to
+// distinguish.
+func formatStorageEntrySet(label, desired, current string) string {
+	if current == "" {
+		return fmt.Sprintf("set %s=%s (new)", label, desired)
+	}
+	return fmt.Sprintf("set %s=%s (was %q)", label, desired, current)
 }
 
 // ExportGlobal reads the named storage registry entries and returns a
@@ -451,20 +621,23 @@ func storageEntries() ([]storageEntry, error) {
 	return entries, nil
 }
 
-// storageEntryExists reports whether a named storage registry entry
-// exists. A transport-level failure (`*subprocess.SSHError`) is
-// propagated; a dokku-level non-zero exit is treated as "no entry."
-func storageEntryExists(name string) (bool, error) {
+// lookupStorageEntry returns the named storage registry entry, or nil when
+// the registry holds no entry by that name. Plan needs the whole entry
+// rather than a yes/no answer, since every field the recipe declares is
+// compared against what the registry records. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit is
+// treated as "no entry."
+func lookupStorageEntry(name string) (*storageEntry, error) {
 	entries, err := storageEntries()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	for _, entry := range entries {
-		if entry.Name == name {
-			return true, nil
+	for i := range entries {
+		if entries[i].Name == name {
+			return &entries[i], nil
 		}
 	}
-	return false, nil
+	return nil, nil
 }
 
 // init registers the StorageEntryTask with the task registry

--- a/tasks/storage_entry_task_integration_test.go
+++ b/tasks/storage_entry_task_integration_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -159,4 +160,141 @@ func TestIntegrationStorageEntryAnnotationsAndLabels(t *testing.T) {
 	if task.Labels["docket-managed"] != "true" {
 		t.Errorf("expected exported labels to carry docket-managed, got %v", task.Labels)
 	}
+}
+
+func TestIntegrationStorageEntryConvergesChown(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-converge-chown"
+
+	destroy := StorageEntryTask{Name: name, State: StateAbsent}
+	destroy.Execute()
+	defer destroy.Execute()
+
+	create := StorageEntryTask{Name: name, Chown: "herokuish", State: StatePresent}
+	if result := create.Execute(); result.Error != nil {
+		t.Fatalf("failed to create entry: %v", result.Error)
+	}
+
+	// The entry already exists, so the ownership change goes through
+	// storage:set rather than a second storage:create - which is what
+	// re-runs the chown on the host directory instead of only recording a
+	// new value.
+	converge := StorageEntryTask{Name: name, Chown: "root", State: StatePresent}
+	plan := converge.Plan()
+	if plan.Status != PlanStatusModify {
+		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
+	}
+
+	result := converge.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to converge chown: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for a chown change")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	entry := findStorageEntryT(t, name)
+	if entry.Chown != "root" {
+		t.Errorf("expected the registry to record chown 'root', got %q", entry.Chown)
+	}
+
+	// A third run settles: the recipe now matches what the registry holds.
+	result = converge.Execute()
+	if result.Error != nil {
+		t.Fatalf("re-applying the converged entry failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false once the chown matches")
+	}
+}
+
+func TestIntegrationStorageEntryConvergesOneAnnotationKey(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-converge-metadata"
+
+	destroy := StorageEntryTask{Name: name, State: StateAbsent}
+	destroy.Execute()
+	defer destroy.Execute()
+
+	create := StorageEntryTask{
+		Name:        name,
+		Annotations: map[string]string{"docket.io/team": "platform", "docket.io/tier": "data"},
+		State:       StatePresent,
+	}
+	if result := create.Execute(); result.Error != nil {
+		t.Fatalf("failed to create entry: %v", result.Error)
+	}
+
+	// Only the declared key moves. The sibling the recipe does not name
+	// survives, which is what the per-key subcommand buys over the
+	// wholesale --annotation flag.
+	converge := StorageEntryTask{
+		Name:        name,
+		Annotations: map[string]string{"docket.io/team": "sre"},
+		State:       StatePresent,
+	}
+	result := converge.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to converge the annotation: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for an annotation change")
+	}
+
+	entry := findStorageEntryT(t, name)
+	if entry.Annotations["docket.io/team"] != "sre" {
+		t.Errorf("expected the declared annotation to converge, got %v", entry.Annotations)
+	}
+	if entry.Annotations["docket.io/tier"] != "data" {
+		t.Errorf("expected the undeclared annotation to survive, got %v", entry.Annotations)
+	}
+
+	if result := converge.Execute(); result.Changed {
+		t.Error("expected changed=false once the annotation matches")
+	}
+}
+
+func TestIntegrationStorageEntryRefusesAPathChange(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-immutable-path"
+
+	destroy := StorageEntryTask{Name: name, State: StateAbsent}
+	destroy.Execute()
+	defer destroy.Execute()
+
+	create := StorageEntryTask{Name: name, State: StatePresent}
+	if result := create.Execute(); result.Error != nil {
+		t.Fatalf("failed to create entry: %v", result.Error)
+	}
+
+	// dokku has no command that moves an entry's host path, so the plan
+	// says so rather than reporting a change it could never apply.
+	move := StorageEntryTask{Name: name, Path: "/mnt/docket-test-entry-elsewhere", State: StatePresent}
+	plan := move.Plan()
+	if plan.Status != PlanStatusError {
+		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
+	}
+	if plan.Error == nil || !strings.Contains(plan.Error.Error(), "records path") {
+		t.Errorf("expected an immutable-path error, got: %v", plan.Error)
+	}
+}
+
+// findStorageEntryT reads one entry back out of the registry, failing the
+// test when the server does not report it.
+func findStorageEntryT(t *testing.T, name string) storageEntry {
+	t.Helper()
+	entry, err := lookupStorageEntry(name)
+	if err != nil {
+		t.Fatalf("failed to read storage entries: %v", err)
+	}
+	if entry == nil {
+		t.Fatalf("expected %s in storage:list-entries", name)
+	}
+	return *entry
 }

--- a/tasks/storage_entry_task_test.go
+++ b/tasks/storage_entry_task_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -334,6 +335,19 @@ func TestStorageEntryValidateMapKeysAndValues(t *testing.T) {
 			wantErr: `'labels' value for "tier" must not contain ',' or '"'`,
 		},
 		{
+			// storage:annotations:set reads an empty value as a delete, so a
+			// pair declared empty could never be stored and the convergence
+			// pass would clear it and miss it again on every run.
+			name:    "empty annotation value",
+			task:    StorageEntryTask{Annotations: map[string]string{"team": ""}},
+			wantErr: `'annotations' value for "team" must not be empty`,
+		},
+		{
+			name:    "empty label value",
+			task:    StorageEntryTask{Labels: map[string]string{"tier": ""}},
+			wantErr: `'labels' value for "tier" must not be empty`,
+		},
+		{
 			name: "an equals in a value is fine",
 			task: StorageEntryTask{Annotations: map[string]string{"team": "a=b"}},
 		},
@@ -477,5 +491,297 @@ func TestStorageEntryExportGlobal(t *testing.T) {
 	// recipe export writes would not apply.
 	if err := second.Validate(); err != nil {
 		t.Errorf("exported k3s entry does not validate: %v", err)
+	}
+}
+
+// singleStorageEntryFixture is a storage:list-entries payload holding one
+// entry, for the convergence tests that compare a recipe against what the
+// registry records.
+func singleStorageEntryFixture(entryJSON string) map[string]string {
+	return map[string]string{
+		"--quiet storage:list-entries --format json": "[" + entryJSON + "]",
+	}
+}
+
+const dockerLocalEntryJSON = `{
+	"name": "app-data",
+	"scheduler": "docker-local",
+	"host_path": "/var/lib/dokku/data/storage/app-data",
+	"chown": "herokuish",
+	"schema_version": 1
+}`
+
+func TestStorageEntryPlanInSyncWhenEveryDeclaredFieldMatches(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+
+	task := StorageEntryTask{
+		Name:      "app-data",
+		Scheduler: "docker-local",
+		Path:      "/var/lib/dokku/data/storage/app-data",
+		Chown:     "herokuish",
+		State:     StatePresent,
+	}
+	plan := task.Plan()
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("expected an in-sync plan, got status %q reason %q", plan.Status, plan.Reason)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("an in-sync plan must issue no commands, got %v", plan.Commands)
+	}
+}
+
+func TestStorageEntryPlanLeavesUndeclaredAttributesAlone(t *testing.T) {
+	// The recipe names only the fields it manages. A size, namespace and
+	// annotation it never mentions are neither compared nor cleared, which
+	// is what stops a partially-declared recipe from destroying attributes
+	// set elsewhere.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+		"name": "app-data",
+		"scheduler": "k3s",
+		"size": "2Gi",
+		"namespace": "apps",
+		"chown": "herokuish",
+		"annotations": {"team": "platform"},
+		"labels": {"tier": "data"},
+		"schema_version": 1
+	}`)))()
+
+	task := StorageEntryTask{
+		Name:      "app-data",
+		Scheduler: "k3s",
+		Size:      "2Gi",
+		Chown:     "herokuish",
+		State:     StatePresent,
+	}
+	plan := task.Plan()
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("expected an in-sync plan, got status %q reason %q mutations %v", plan.Status, plan.Reason, plan.Mutations)
+	}
+}
+
+func TestStorageEntryPlanConvergesChown(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", Chown: "root", State: StatePresent}
+	plan := task.Plan()
+	if plan.Status != PlanStatusModify {
+		t.Fatalf("expected plan status %q, got %q", PlanStatusModify, plan.Status)
+	}
+	if plan.InSync {
+		t.Error("a chown change must not report in sync")
+	}
+	want := []string{"dokku --quiet storage:set app-data chown root"}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+	wantMutations := []string{`set chown=root (was "herokuish")`}
+	if !equalStrings(plan.Mutations, wantMutations) {
+		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
+	}
+	if plan.Reason != "1 attribute(s) to set" {
+		t.Errorf("unexpected reason %q", plan.Reason)
+	}
+}
+
+func TestStorageEntryPlanConvergesEveryMutableAttributeInFieldOrder(t *testing.T) {
+	// One command per drifted field, in struct field order with sorted map
+	// keys, so plan and apply build byte-identical argv across runs.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+		"name": "app-data",
+		"scheduler": "k3s",
+		"size": "2Gi",
+		"namespace": "apps",
+		"chown": "herokuish",
+		"reclaim_policy": "Retain",
+		"annotations": {"team": "infra"},
+		"schema_version": 1
+	}`)))()
+
+	task := StorageEntryTask{
+		Name:          "app-data",
+		Scheduler:     "k3s",
+		Size:          "4Gi",
+		Namespace:     "data",
+		Chown:         "root",
+		ReclaimPolicy: "Delete",
+		Annotations:   map[string]string{"zeta": "1", "team": "platform"},
+		Labels:        map[string]string{"tier": "data"},
+		State:         StatePresent,
+	}
+	plan := task.Plan()
+	if plan.Status != PlanStatusModify {
+		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
+	}
+	want := []string{
+		"dokku --quiet storage:set app-data size 4Gi",
+		"dokku --quiet storage:set app-data namespace data",
+		"dokku --quiet storage:set app-data chown root",
+		"dokku --quiet storage:set app-data reclaim-policy Delete",
+		"dokku --quiet storage:annotations:set app-data team platform",
+		"dokku --quiet storage:annotations:set app-data zeta 1",
+		"dokku --quiet storage:labels:set app-data tier data",
+	}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands\n%v\ngot\n%v", want, plan.Commands)
+	}
+	if plan.Reason != "7 attribute(s) to set" {
+		t.Errorf("unexpected reason %q", plan.Reason)
+	}
+	wantMutations := []string{
+		`set size=4Gi (was "2Gi")`,
+		`set namespace=data (was "apps")`,
+		`set chown=root (was "herokuish")`,
+		`set reclaim_policy=Delete (was "Retain")`,
+		`set annotation team=platform (was "infra")`,
+		"set annotation zeta=1 (new)",
+		"set label tier=data (new)",
+	}
+	if !equalStrings(plan.Mutations, wantMutations) {
+		t.Errorf("expected mutations\n%v\ngot\n%v", wantMutations, plan.Mutations)
+	}
+}
+
+func TestStorageEntryPlanConvergesMapKeysWithoutDisturbingSiblings(t *testing.T) {
+	// The per-key subcommands are what make an omitted key unmanaged; the
+	// wholesale --annotation flag would replace the entire map and drop the
+	// key the recipe does not name.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+		"name": "app-data",
+		"scheduler": "docker-local",
+		"host_path": "/var/lib/dokku/data/storage/app-data",
+		"annotations": {"team": "platform", "owner": "sre"},
+		"schema_version": 1
+	}`)))()
+
+	task := StorageEntryTask{
+		Name:        "app-data",
+		Annotations: map[string]string{"team": "data"},
+		State:       StatePresent,
+	}
+	plan := task.Plan()
+	want := []string{"dokku --quiet storage:annotations:set app-data team data"}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+	for _, command := range plan.Commands {
+		if strings.Contains(command, "owner") {
+			t.Errorf("an undeclared annotation must be left alone, got %q", command)
+		}
+	}
+}
+
+func TestStorageEntryPlanRejectsImmutableDrift(t *testing.T) {
+	// dokku refuses an access-mode or storage-class swap in place, and has
+	// no command at all for the scheduler or the host path, so the plan
+	// errors rather than reporting a change it could never apply.
+	tests := []struct {
+		name    string
+		entry   string
+		task    StorageEntryTask
+		wantErr string
+	}{
+		{
+			name:    "scheduler",
+			entry:   dockerLocalEntryJSON,
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi"},
+			wantErr: `records scheduler "docker-local", recipe declares "k3s"`,
+		},
+		{
+			name:    "path",
+			entry:   dockerLocalEntryJSON,
+			task:    StorageEntryTask{Name: "app-data", Path: "/mnt/app-data"},
+			wantErr: `records path "/var/lib/dokku/data/storage/app-data", recipe declares "/mnt/app-data"`,
+		},
+		{
+			name:    "access_mode",
+			entry:   `{"name": "app-data", "scheduler": "k3s", "size": "2Gi", "access_mode": "ReadWriteOnce", "schema_version": 1}`,
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi", AccessMode: "ReadWriteMany"},
+			wantErr: `records access_mode "ReadWriteOnce", recipe declares "ReadWriteMany"`,
+		},
+		{
+			name:    "storage_class",
+			entry:   `{"name": "app-data", "scheduler": "k3s", "size": "2Gi", "schema_version": 1}`,
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi", StorageClass: "longhorn"},
+			wantErr: `records storage_class "", recipe declares "longhorn"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(test.entry)))()
+
+			test.task.State = StatePresent
+			plan := test.task.Plan()
+			if plan.Status != PlanStatusError {
+				t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
+			}
+			if plan.Error == nil || !strings.Contains(plan.Error.Error(), test.wantErr) {
+				t.Errorf("expected an error containing %q, got: %v", test.wantErr, plan.Error)
+			}
+			if len(plan.Commands) != 0 {
+				t.Errorf("a refused plan must issue no commands, got %v", plan.Commands)
+			}
+		})
+	}
+}
+
+func TestStorageEntryPlanReadsAnOmittedSchedulerAsDockerLocal(t *testing.T) {
+	// createArgs drops the flag when the scheduler is empty and dokku
+	// applies docker-local, so the comparison has to read it the same way
+	// rather than treating an empty scheduler as unmanaged.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(
+		`{"name": "app-data", "scheduler": "k3s", "size": "2Gi", "schema_version": 1}`,
+	)))()
+
+	task := StorageEntryTask{Name: "app-data", State: StatePresent}
+	plan := task.Plan()
+	if plan.Status != PlanStatusError {
+		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
+	}
+	if plan.Error == nil || !strings.Contains(plan.Error.Error(), `recipe declares "docker-local"`) {
+		t.Errorf("expected the omitted scheduler to read as docker-local, got: %v", plan.Error)
+	}
+}
+
+func TestStorageEntryPlanAbsentIgnoresAttributes(t *testing.T) {
+	// Attributes are rejected by Validate under state 'absent', so the
+	// destroy branch never compares them - it plans on presence alone.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
+	plan := task.Plan()
+	if plan.Status != PlanStatusDestroy {
+		t.Fatalf("expected plan status %q, got %q", PlanStatusDestroy, plan.Status)
+	}
+	want := []string{"dokku --quiet storage:destroy --force app-data"}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+}
+
+func TestStorageEntryExecuteAppliesAttributeDrift(t *testing.T) {
+	// The apply path runs what the plan rendered, and reports the entry as
+	// still present afterwards rather than newly created.
+	responses := singleStorageEntryFixture(dockerLocalEntryJSON)
+	var dispatched [][]string
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		dispatched = append(dispatched, in.Args)
+		return subprocess.ExecCommandResponse{Stdout: responses[strings.Join(in.Args, " ")]}, nil
+	})()
+
+	task := StorageEntryTask{Name: "app-data", Chown: "root", State: StatePresent}
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("expected the apply to succeed, got: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for an attribute change")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state %q, got %q", StatePresent, result.State)
+	}
+	want := []string{"--quiet", "storage:set", "app-data", "chown", "root"}
+	if len(dispatched) != 2 || !equalStrings(dispatched[1], want) {
+		t.Errorf("expected the probe then %v, got %v", want, dispatched)
 	}
 }

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -6,10 +6,12 @@ setup() {
   require_dokku
   docket_build
   dokku_clean_app docket-test-plan
+  dokku_clean_storage_entry docket-test-plan-data
 }
 
 teardown() {
   dokku_clean_app docket-test-plan
+  dokku_clean_storage_entry docket-test-plan-data
 }
 
 @test "docket plan reports drift on a missing app" {
@@ -104,4 +106,68 @@ EOF
   assert_success
   run dokku apps:exists docket-test-plan
   assert_success
+}
+
+@test "docket plan reports drift when a storage entry's chown changes" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-data
+      dokku_storage_entry:
+        name: docket-test-plan-data
+        chown: herokuish
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "0 would change"
+
+  # Changing an attribute on an entry that already exists is drift, not a
+  # silent no-op, and applying it settles.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-data
+      dokku_storage_entry:
+        name: docket-test-plan-data
+        chown: root
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[~]"
+  assert_output --partial "1 attribute(s) to set"
+  assert_output --partial "set chown=root"
+  assert_output --partial "1 would change"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[ok]"
+  assert_output --partial "0 would change"
+}
+
+@test "docket plan errors on a storage entry attribute dokku cannot change" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-data
+      dokku_storage_entry:
+        name: docket-test-plan-data
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-data
+      dokku_storage_entry:
+        name: docket-test-plan-data
+        path: /mnt/docket-test-plan-elsewhere
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "records path"
+  assert_output --partial "destroy and re-create the entry"
 }

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -90,6 +90,18 @@ dokku_clean_app() {
   fi
 }
 
+# dokku_clean_storage_entry destroys a named storage registry entry if it
+# exists. Same setup/teardown role as dokku_clean_app; storage:destroy
+# refuses an entry any app still mounts, so unmount first if a test ever
+# attaches one.
+dokku_clean_storage_entry() {
+  local entry="$1"
+  if ! command -v dokku >/dev/null 2>&1; then
+    return 0
+  fi
+  dokku --quiet storage:destroy --force "$entry" >/dev/null 2>&1 || true
+}
+
 # require_dokku skips the current test when no dokku binary is installed.
 require_dokku() {
   if ! command -v dokku >/dev/null 2>&1; then

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -321,6 +321,22 @@ EOF
   assert_output --partial "label values must not be empty for state 'present'"
 }
 
+@test "docket validate exits 1 on an empty storage entry annotation value" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_storage_entry:
+        name: docket-test-validate-data
+        annotations:
+          docket.io/team: ""
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'annotations' value for \"docket.io/team\" must not be empty"
+  assert_output --partial "dokku reads an empty value as a delete"
+}
+
 @test "docket validate names the replacement task for a rejected property family (#458)" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
`dokku_storage_entry` keyed idempotency on the entry name, so an entry that already existed was in sync whatever the recipe said and a changed `chown`, `size`, `namespace`, `reclaim_policy`, annotation, or label was a silent no-op. Every field the recipe declares is now compared against what the registry records and converged through `storage:set` and the per-key `storage:annotations:set` / `storage:labels:set` subcommands, which re-run the chown on a docker-local directory rather than only recording a new value. A field the recipe omits stays unmanaged, so a partially-declared recipe never clears an attribute it does not name, and the four fields dokku cannot change on an entry that exists - `scheduler`, `path`, `access_mode`, and `storage_class` - are reported as a plan error instead of a change that could never be applied. An empty annotation or label value is now refused, since dokku reads one as a delete and the pair could never be stored. The commands this relies on landed in dokku 0.38.27, which is now the documented floor.

The issue anticipated needing a different command per scheduler per field, because `storage:set --chown` recorded a new ownership value without re-running the chown and the only command that did re-chown rewrote every attribute from whatever the task supplied. dokku 0.38.27 closed that gap: `storage:set` moved to a property form that converges the host directory whenever the change touches ownership, and the wholesale `--annotation` / `--label` flags gained per-key subcommands that leave their siblings alone. That is what makes the omitted-field rule expressible at all.

Two consequences worth knowing before merging. A recipe whose `scheduler` disagrees with the entry now fails rather than reporting in sync; `scheduler` carries a default, so a recipe managing a k3s entry that forgets `scheduler: k3s` was already broken under `docket validate` and this surfaces it earlier. And an operator on dokku 0.38.22 through 0.38.26 has to upgrade, since the property form parses as nothing on those versions and would leave the recipe drifting forever without saying so.

Moving the pin turned up one unrelated break, since dokku 0.38.26 gave every scheduler-k3s profile a node-sysctls helm release named after it and helm caps a release name at 53 characters. One of the profile task's own test fixtures was a character over that ceiling and its `scheduler-k3s:profile:set` was refused; the fixtures are shortened here, and encoding the limit in the task's validation is a question of its own, tracked in #482.

Exposing the rest of dokku 0.38.27's host directory surface on the task - the `mode` field and `storage:destroy --destroy-host-dir` - is out of scope here and tracked in #480.

Fixes #439

