### PR TITLE
fix: reject a k3s profile name helm cannot release

### DIFF
--- a/docs/tasks/dokku_scheduler_k3s_profile.md
+++ b/docs/tasks/dokku_scheduler_k3s_profile.md
@@ -20,7 +20,7 @@ Keyed by `name`.
 
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
-| `name` | string | yes |  |  | Name of the node profile. |
+| `name` | string | yes |  |  | Name of the node profile. Creating one requires a lowercase name of at most 26 characters: dokku prepends dokku-node-sysctls-profile- to it to name the profile's node-sysctls helm release, and helm caps a release name at 53 characters. |
 | `role` | string | yes |  | server, worker | Role for nodes joined with this profile. |
 | `kubelet_args` | list | no |  |  | List of key=value kubelet arguments to forward to k3s. |
 | `taint_scheduling` | bool | no |  |  | Whether to taint the node so only workloads that tolerate the taint schedule on it. |

--- a/tasks/scheduler_k3s_profile_task.go
+++ b/tasks/scheduler_k3s_profile_task.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -18,7 +19,7 @@ import (
 type SchedulerK3sProfileTask struct {
 	// Name is the profile name. It is the lookup key both for the on-disk
 	// global property and for `scheduler-k3s:profiles:list --format json`.
-	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the node profile."`
+	Name string `required:"true" identity:"key" yaml:"name" description:"Name of the node profile. Creating one requires a lowercase name of at most 26 characters: dokku prepends dokku-node-sysctls-profile- to it to name the profile's node-sysctls helm release, and helm caps a release name at 53 characters."`
 
 	// Role is the k3s role nodes joined with this profile take. Required and
 	// validated up front; dokku also rejects unknown values but failing in the
@@ -131,12 +132,95 @@ func (t SchedulerK3sProfileTask) Plan() PlanResult {
 	})
 }
 
+// nodeSysctlsReleasePrefix is what dokku prepends to a profile name to derive
+// the helm release backing that profile's node-sysctls DaemonSet. Mirrors
+// getNodeSysctlsReleaseName in dokku's plugins/scheduler-k3s/node_sysctls.go.
+const nodeSysctlsReleasePrefix = "dokku-node-sysctls-profile-"
+
+// helmReleaseNameMaxLength is helm's own ceiling on a release name
+// (maxReleaseNameLen in helm's pkg/chartutil/validate_name.go).
+const helmReleaseNameMaxLength = 53
+
+// schedulerK3sProfileNameMaxLength is dokku's own cap on a profile name, from
+// CommandProfilesAdd and CommandProfilesRemove. dokku's message reads "must be
+// less than 32 characters" but the check is `> 32`, so 32 itself is accepted;
+// mirror the behaviour rather than the message.
+const schedulerK3sProfileNameMaxLength = 32
+
+// schedulerK3sProfileNameHelmMaxLength is the longest profile name whose
+// derived node-sysctls release name still fits under helm's ceiling. Derived
+// rather than written as a literal so it stays correct if dokku renames the
+// prefix, and so the arithmetic is visible to the next reader.
+const schedulerK3sProfileNameHelmMaxLength = helmReleaseNameMaxLength - len(nodeSysctlsReleasePrefix)
+
+// schedulerK3sProfileName is the charset dokku accepts for a profile name, in
+// both CommandProfilesAdd and CommandProfilesRemove. Mirrors the regexp in
+// dokku's plugins/scheduler-k3s/subcommands.go.
+var schedulerK3sProfileName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$`)
+
+// helmReleaseName is helm's own release-name regexp (validName in helm's
+// pkg/chartutil/validate_name.go), which is lowercase-only. dokku's profile
+// regexp is not: it allows [a-zA-Z0-9], so a profile name dokku accepts can
+// still derive a release name helm refuses.
+var helmReleaseName = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
+// validateSchedulerK3sProfileName rejects a profile name the server would
+// refuse, or would accept and then choke on later.
+//
+// dokku's own rules - the charset and the 32-character cap - are enforced for
+// every state, because `profiles:remove` applies them just as `profiles:add`
+// does. The two derived rules are enforced only when creating: dokku builds a
+// node-sysctls helm release named `dokku-node-sysctls-profile-<name>`, and helm
+// caps a release name at 53 characters and requires it to be lowercase.
+// `profiles:add` checks neither, so a name of 27-32 characters, or any
+// uppercase name, is stored happily and only fails once something resolves the
+// release name: `profiles:remove`, `node-sysctls:set`, or a cluster bootstrap.
+// The last two reconcile every scope, so one bad name breaks node sysctls
+// server-wide.
+//
+// Holding the derived rules to state 'present' means docket refuses to create a
+// profile it could not later remove, but never refuses to try removing one. A
+// profile that predates the rule can still be cleaned up through docket, which
+// works on a server with no k3s cluster and fails with dokku's own error on one
+// where the removal genuinely cannot succeed. Upstream tracking for having
+// dokku reject these at `profiles:add`: dokku/dokku#8971.
+func validateSchedulerK3sProfileName(name string, state State) error {
+	if name == "" {
+		return errors.New("name is required")
+	}
+	if !schedulerK3sProfileName.MatchString(name) {
+		return fmt.Errorf("name must contain only alphanumeric characters and dashes and must not start or end with a dash, got %q", name)
+	}
+	if len(name) > schedulerK3sProfileNameMaxLength {
+		return fmt.Errorf("name must be at most %d characters, got %d", schedulerK3sProfileNameMaxLength, len(name))
+	}
+	if state == StateAbsent {
+		return nil
+	}
+
+	release := nodeSysctlsReleasePrefix + name
+	if len(name) > schedulerK3sProfileNameHelmMaxLength {
+		return fmt.Errorf("name must be at most %d characters for state 'present', got %d: dokku derives the node-sysctls helm release name %q from it, and helm caps a release name at %d characters",
+			schedulerK3sProfileNameHelmMaxLength, len(name), release, helmReleaseNameMaxLength)
+	}
+	// The charset check above has already ruled out everything helm's regexp
+	// rejects except case, so this can only fire on an uppercase name - which
+	// is why the message names that specifically. Running helm's real regexp
+	// rather than a case comparison keeps the check honest if dokku ever
+	// widens its own charset.
+	if !helmReleaseName.MatchString(release) {
+		return fmt.Errorf("name must be lowercase for state 'present', got %q: dokku derives the node-sysctls helm release name %q from it, and helm requires a lowercase release name",
+			name, release)
+	}
+	return nil
+}
+
 // validateSchedulerK3sProfile rejects malformed inputs before any subprocess
 // runs. Both states require name + role; absent state ignores the other
 // fields entirely but they are still rejected if obviously broken.
 func validateSchedulerK3sProfile(t SchedulerK3sProfileTask) error {
-	if t.Name == "" {
-		return errors.New("name is required")
+	if err := validateSchedulerK3sProfileName(t.Name, t.State); err != nil {
+		return err
 	}
 	if t.Role == "" {
 		return errors.New("role is required")

--- a/tasks/scheduler_k3s_profile_task_integration_test.go
+++ b/tasks/scheduler_k3s_profile_task_integration_test.go
@@ -1,14 +1,23 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 )
 
-// Profile names here are kept short on purpose. dokku 0.38.26 gave each
-// profile a node-sysctls helm release named `dokku-node-sysctls-profile-<name>`,
-// and helm caps a release name at 53 characters, so a profile name longer than
-// 26 is refused by `scheduler-k3s:profile:set` and its unset counterpart. The
-// task itself does not check the length yet (dokku/docket#482).
+// schedulerK3sProfileBoundaryName is a profile name of exactly
+// schedulerK3sProfileNameHelmMaxLength characters, built from the constant so
+// the fixture tracks it rather than needing a hand recount. Its derived
+// node-sysctls release name fills helm's 53-character ceiling exactly.
+var schedulerK3sProfileBoundaryName = "docket-test-" +
+	strings.Repeat("x", schedulerK3sProfileNameHelmMaxLength-len("docket-test-"))
+
+// Profile names here are kept short on purpose. dokku gives each profile a
+// node-sysctls helm release named `dokku-node-sysctls-profile-<name>` and helm
+// caps a release name at 53 characters, so the task refuses a name longer than
+// 26 for state 'present' (dokku/docket#482). dokku's own `profiles:add` does
+// not - it accepts up to 32 - so the ceiling is only felt on the unset, which
+// resolves the release name through helm.
 func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
@@ -39,6 +48,20 @@ func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
 				Name:        "docket-test-args",
 				Role:        "worker",
 				KubeletArgs: []string{"max-pods=100", "node-labels=tier=spot", "system-reserved=cpu=200m"},
+			},
+		},
+		{
+			// The only check of the derived cap against live helm rather
+			// than against docket's own arithmetic. This CI job runs
+			// `scheduler-k3s:initialize`, so isKubernetesAvailable() is
+			// true and the unset really does resolve
+			// dokku-node-sysctls-profile-<name>. If the cap were a
+			// character too generous, this unset would fail with
+			// "release name is invalid" instead of cleaning up.
+			name: "name-at-the-helm-cap",
+			task: SchedulerK3sProfileTask{
+				Name: schedulerK3sProfileBoundaryName,
+				Role: "worker",
 			},
 		},
 	}

--- a/tasks/scheduler_k3s_profile_task_test.go
+++ b/tasks/scheduler_k3s_profile_task_test.go
@@ -67,6 +67,117 @@ func TestSchedulerK3sProfileTaskInvalidKubeletArg(t *testing.T) {
 	}
 }
 
+// TestSchedulerK3sProfileTaskInvalidNameCharset covers the charset dokku
+// itself enforces in both profiles:add and profiles:remove, so it applies to
+// either state.
+func TestSchedulerK3sProfileTaskInvalidNameCharset(t *testing.T) {
+	names := []struct {
+		label string
+		name  string
+	}{
+		{label: "leading dash", name: "-edge-pool"},
+		{label: "trailing dash", name: "edge-pool-"},
+		{label: "underscore", name: "edge_pool"},
+		{label: "space", name: "edge pool"},
+		{label: "dot", name: "edge.pool"},
+	}
+	for _, tc := range names {
+		for _, state := range []State{StatePresent, StateAbsent} {
+			t.Run(tc.label+"/"+string(state), func(t *testing.T) {
+				err := SchedulerK3sProfileTask{Name: tc.name, Role: "worker", State: state}.Validate()
+				if err == nil {
+					t.Fatalf("expected error for name %q", tc.name)
+				}
+				if !strings.Contains(err.Error(), "only alphanumeric characters and dashes") {
+					t.Errorf("unexpected error: %v", err)
+				}
+			})
+		}
+	}
+}
+
+// TestSchedulerK3sProfileTaskNameLength walks the two caps that bind at
+// different points. dokku's own 32 applies to either state; the derived 26
+// applies only when creating, so a name between the two validates under
+// 'absent' and not under 'present'.
+func TestSchedulerK3sProfileTaskNameLength(t *testing.T) {
+	cases := []struct {
+		label   string
+		length  int
+		state   State
+		wantErr string
+	}{
+		{label: "over dokku cap, present", length: 33, state: StatePresent, wantErr: "at most 32 characters"},
+		{label: "over dokku cap, absent", length: 33, state: StateAbsent, wantErr: "at most 32 characters"},
+		{label: "at dokku cap, absent", length: 32, state: StateAbsent},
+		{label: "at dokku cap, present", length: 32, state: StatePresent, wantErr: "at most 26 characters for state 'present'"},
+		{label: "one over the derived cap, present", length: 27, state: StatePresent, wantErr: "at most 26 characters for state 'present'"},
+		{label: "one over the derived cap, absent", length: 27, state: StateAbsent},
+		{label: "at the derived cap, present", length: 26, state: StatePresent},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			name := strings.Repeat("a", tc.length)
+			err := SchedulerK3sProfileTask{Name: name, Role: "worker", State: tc.state}.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected a %d-character name to validate, got %v", tc.length, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error for a %d-character name", tc.length)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestSchedulerK3sProfileTaskUppercaseName locks in the other half of the
+// derived rule: dokku's charset allows uppercase, helm's release name does
+// not, so the name is refused when creating and left alone when removing.
+func TestSchedulerK3sProfileTaskUppercaseName(t *testing.T) {
+	err := SchedulerK3sProfileTask{Name: "EdgePool", Role: "worker", State: StatePresent}.Validate()
+	if err == nil {
+		t.Fatal("expected an error for an uppercase name under state 'present'")
+	}
+	if !strings.Contains(err.Error(), "must be lowercase for state 'present'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "dokku-node-sysctls-profile-EdgePool") {
+		t.Errorf("error should name the derived release name, got: %v", err)
+	}
+
+	if err := (SchedulerK3sProfileTask{Name: "EdgePool", Role: "worker", State: StateAbsent}).Validate(); err != nil {
+		t.Errorf("expected an uppercase name to validate under state 'absent', got %v", err)
+	}
+}
+
+// TestSchedulerK3sProfileNameHelmLimitDerivation pins the arithmetic itself, so
+// a change to the prefix or to helm's ceiling cannot silently leave the limit
+// wrong. A name at the derived cap must fill the release name exactly to helm's
+// ceiling and still satisfy helm's own regexp.
+func TestSchedulerK3sProfileNameHelmLimitDerivation(t *testing.T) {
+	if got := len(nodeSysctlsReleasePrefix) + schedulerK3sProfileNameHelmMaxLength; got != helmReleaseNameMaxLength {
+		t.Errorf("prefix plus a max-length name is %d characters, want helm's ceiling of %d", got, helmReleaseNameMaxLength)
+	}
+	release := nodeSysctlsReleasePrefix + strings.Repeat("a", schedulerK3sProfileNameHelmMaxLength)
+	if len(release) != helmReleaseNameMaxLength {
+		t.Errorf("derived release name is %d characters, want %d", len(release), helmReleaseNameMaxLength)
+	}
+	if !helmReleaseName.MatchString(release) {
+		t.Errorf("derived release name %q does not satisfy helm's release name regexp", release)
+	}
+	// The derived cap has to be the stricter of the two, or holding it to
+	// state 'present' would be pointless.
+	if schedulerK3sProfileNameHelmMaxLength >= schedulerK3sProfileNameMaxLength {
+		t.Errorf("derived cap %d should be stricter than dokku's own cap %d",
+			schedulerK3sProfileNameHelmMaxLength, schedulerK3sProfileNameMaxLength)
+	}
+}
+
 func TestSchedulerK3sProfileTaskInvalidState(t *testing.T) {
 	task := SchedulerK3sProfileTask{Name: "edge-pool", Role: "worker", State: "invalid"}
 	result := task.Execute()

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -337,6 +337,39 @@ EOF
   assert_output --partial "dokku reads an empty value as a delete"
 }
 
+@test "docket validate exits 1 on a scheduler-k3s profile name too long for its helm release (#482)" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_scheduler_k3s_profile:
+        name: docket-test-profile-name-27
+        role: worker
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "at most 26 characters for state 'present'"
+  assert_output --partial "dokku-node-sysctls-profile-docket-test-profile-name-27"
+  assert_output --partial "helm caps a release name at 53 characters"
+}
+
+# The derived limit is deliberately asymmetric: docket refuses to create a
+# profile whose node-sysctls release name helm would reject, but never refuses
+# to try removing one, so a profile created before the rule can still be
+# cleaned up. dokku's own 32-character cap still applies to both states.
+@test "docket validate accepts an over-long scheduler-k3s profile name for state absent (#482)" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_scheduler_k3s_profile:
+        name: docket-test-profile-name-27
+        role: worker
+        state: absent
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+}
+
 @test "docket validate names the replacement task for a rejected property family (#458)" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
dokku names each profile's node-sysctls helm release `dokku-node-sysctls-profile-<name>`, and helm caps a release name at 53 characters and requires it to be lowercase, but `scheduler-k3s:profiles:add` checks neither and accepts any alphanumeric name up to 32 characters. A name of 27 to 32 characters, or one carrying uppercase, is stored without complaint and then breaks the `profiles:remove` that would clean it up, along with every later `node-sysctls:set`, which reconciles all scopes at once. The task now refuses such a name for state `present` so `docket validate` catches it offline, and leaves state `absent` to dokku's own rules so a profile that predates the check can still be removed. Filed upstream as dokku/dokku#8971; the related export gap is tracked in #483.

Fixes #482.
