### PR TITLE
fix: leave an unappliable k3s profile out of the export

### DIFF
--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -678,3 +678,60 @@ func TestExportCommandResourceUnmatchedExitsNonZero(t *testing.T) {
 		t.Errorf("expected the unmatched address to be named; got %q", ui.ErrorWriter.String())
 	}
 }
+
+// TestExportOutputValidatesWithUnappliableK3sProfile is #483 as a regression:
+// a server carrying a scheduler-k3s profile whose name dokku accepted but
+// docket refuses for state 'present' used to export into a recipe that
+// `docket validate` rejected outright - and it rejects the whole file, so the
+// one bad profile made the entire export unusable. The profile is now reported
+// and left out, the profile that can be applied still comes back, and the pair
+// validates.
+func TestExportOutputValidatesWithUnappliableK3sProfile(t *testing.T) {
+	fixture := exportCommandFixture()
+	fixture["--quiet scheduler-k3s:profiles:list --format json"] = `[
+		{"name":"edge-pool","role":"worker"},
+		{"name":"EdgePool","role":"worker"}
+	]`
+	defer subprocess.SetExecRunner(fakeExecRunner(fixture))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+	vars := filepath.Join(dir, "tasks.vars.yml")
+
+	c, ui := newExportCommand()
+	if code := c.Run([]string{"--output", recipe}); code != 0 {
+		t.Fatalf("export exit = %d: %s", code, ui.ErrorWriter.String())
+	}
+
+	// The operator is told which profile is missing and why, rather than being
+	// handed a recipe that fails validation with no explanation.
+	out := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	for _, want := range []string{"dokku_scheduler_k3s_profile", "EdgePool", "state 'absent'"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("export output missing %q:\n%s", want, out)
+		}
+	}
+
+	recipeBytes, err := os.ReadFile(recipe)
+	if err != nil {
+		t.Fatalf("recipe not written: %v", err)
+	}
+	if !strings.Contains(string(recipeBytes), "edge-pool") {
+		t.Errorf("recipe dropped the appliable profile:\n%s", recipeBytes)
+	}
+	if strings.Contains(string(recipeBytes), "EdgePool") {
+		t.Errorf("recipe carries the unappliable profile:\n%s", recipeBytes)
+	}
+
+	valArgs := []string{"--tasks", recipe, "--vars-file", vars, "--strict"}
+	oldArgs := os.Args
+	os.Args = append([]string{"docket", "validate"}, valArgs...)
+	defer func() { os.Args = oldArgs }()
+
+	vui := cli.NewMockUi()
+	v := &ValidateCommand{Meta: command.Meta{Ui: vui}}
+	if code := v.Run(valArgs); code != 0 {
+		t.Fatalf("docket validate --strict exit = %d, want 0\n--- validate stderr ---\n%s\n--- recipe ---\n%s",
+			code, vui.ErrorWriter.String(), recipeBytes)
+	}
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -507,7 +507,11 @@ The output format follows `--format` when given, otherwise the `--output` extens
 reference page carries an **Export support** section stating whether it is supported, partial (for
 example a value that is lifted into the vars-file), or not exportable (write-only credentials such
 as `dokku_git_auth`, or `dokku_service_property`, which no datastore plugin can read back).
-Resources that cannot be read back are reported as warnings and left out of the recipe.
+Resources that cannot be read back are reported as warnings and left out of the recipe, as is a
+resource that reads back fine but could not be applied back - a `dokku_scheduler_k3s_profile`
+whose name dokku accepted but helm cannot turn into a release name, for example. Emitting one of
+those would fail `docket validate` for the whole recipe rather than for the single task, so the
+warning names the resource and what to do about it instead.
 
 ## docket schema
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -65,6 +65,13 @@ Some state cannot be read back and is left out with a warning - notably write-on
 and service properties (`dokku_service_property`), which you add by hand. Each task's
 [reference page](tasks/README.md) has an Export support section noting its limits.
 
+A scheduler-k3s node profile is left out for a different reason: dokku accepts a profile name that
+is too long or carries uppercase, but it cannot turn the derived node-sysctls helm release name into
+a legal one, so the profile is already broken on the old server. Carrying it into the recipe would
+make `docket validate` reject the whole file, so it is reported by name and omitted. Recreate it on
+the new server under a lowercase name of at most 26 characters, and remove the old one with a
+`dokku_scheduler_k3s_profile` task using `state: absent`.
+
 HTTP basic auth is reconstructed in full - whether it is serving, its users, allowed IPs and auth
 domains. The plugin never stores a password, only its htpasswd hash, and export carries those
 hashes across: each user is emitted as a `hash` referencing a value in `tasks.vars.yml`, so the new

--- a/docs/tasks/dokku_scheduler_k3s_profile.md
+++ b/docs/tasks/dokku_scheduler_k3s_profile.md
@@ -6,7 +6,7 @@ Manages a global scheduler-k3s node profile used when joining nodes to a cluster
 
 ## Export support
 
-Supported.
+Partial - every profile dokku reports is exported; a profile whose name dokku accepted but the task refuses for state 'present' - longer than 26 characters, or carrying uppercase, so helm cannot release the derived `dokku-node-sysctls-profile-<name>` - is reported as a warning and left out, since emitting it would make the whole recipe fail docket validate. Remove such a profile with a hand-written task using state 'absent'.
 
 ## Probe support
 

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -95,7 +95,9 @@ A few conventions to follow:
 - Every task must implement `ExportSupport() ExportSupport`, declaring whether `docket export` can
   reconstruct it from a live server: `ExportSupported`, `ExportPartial`, or `ExportUnsupported`,
   with a `Caveat` explaining anything short of supported. The generator renders it in an Export
-  support section, and a coverage test fails the build if a task ships without a decision.
+  support section, and a coverage test fails the build if a task ships without a decision. To
+  actually export, implement `ExportApp` or `ExportGlobal` as well - see
+  [exporting a task](#exporting-a-task) below.
 - Every task must also implement `ProbeSupport() ProbeSupport`, declaring how much of its own state
   `Plan()` can read back: `ProbeSupported`, `ProbePartial` (some fields have no read command), or
   `ProbeUnsupported` (none do, so the task reports drift on every run and never converges). Name
@@ -181,6 +183,48 @@ func (t LollipopTask) Plan() PlanResult {
 command - `docket validate` calls the same method offline and surfaces any error as
 `invalid_task_input`, catching the mistake before a server is ever contacted. Keep the error strings
 identical to what `Plan()` used to return so `plan`, `apply`, and `validate` all read the same.
+
+## Exporting a task
+
+A task that declares itself exportable also implements one of two methods, and is listed in the
+matching order slice in `tasks/export.go`: `ExportApp(app string)` plus an entry in `appExportOrder`
+for app-scoped state, `ExportGlobal()` plus an entry in `globalExportOrder` for the rest. Both return
+task bodies - the task's own struct, populated from the server - and the engine handles
+vars-extraction and redaction afterwards. `TestExportSupportMatchesExportWiring` fails the build for
+an exporter no order list names, and for a task that claims to export without implementing one.
+
+Emit the desired `state` explicitly rather than leaning on the field's `default`, so the body is
+plannable exactly as the exporter returns it.
+
+When an exporter needs to say something about a particular resource - an asset it could not capture,
+a resource it read back but cannot emit as a task the loader would accept - implement the reporting
+form instead of logging: `ExportAppReport(app string, warn func(msg string))` or
+`ExportGlobalReport(warn func(msg string))`. The engine passes a `warn` callback wired to
+`ExportReport.Warnings`, so the message is rendered and masked like every other export diagnostic
+and reaches the operator with the run it belongs to.
+
+Implement the reporting form *alongside* the plain one, never instead of it. The engine asserts
+`AppExporter` / `GlobalExporter` before it looks for the reporter, so a task carrying only the
+reporting method exports nothing at all; `TestExportReportersAlsoImplementTheBaseExporter` catches
+that. The usual shape is a shared private method with two thin entry points, as
+`MaintenanceCustomPageTask` and `SchedulerK3sProfileTask` do:
+
+```go
+func (t LollipopTask) ExportGlobal() ([]interface{}, error) {
+  return t.exportGlobal(func(string) {})
+}
+
+func (t LollipopTask) ExportGlobalReport(warn func(msg string)) ([]interface{}, error) {
+  return t.exportGlobal(warn)
+}
+```
+
+Warn *and leave the resource out* when the body you would emit is one `docket validate` refuses.
+Validation rejects the whole recipe rather than the single task, so emitting it costs the operator
+every other resource on the server. `dokku_scheduler_k3s_profile` is the worked example: dokku
+accepts profile names its own node-sysctls helm release cannot be named after, so the exporter runs
+each candidate body through its own `Validate()` - the same method `docket validate` calls - and
+reports the ones it drops, naming the resource and the remedy.
 
 ## Toggle and property tasks
 

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -36,6 +36,20 @@ type appExportReporter interface {
 	ExportAppReport(app string, warn func(msg string)) ([]interface{}, error)
 }
 
+// globalExportReporter is the not-app-scoped counterpart of appExportReporter:
+// a global exporter that can surface a non-fatal diagnostic (for example a
+// resource it read back faithfully but cannot emit as a task the loader would
+// accept) implements it so the warning reaches ExportReport.Warnings instead of
+// a raw log line. exportGlobalPlay passes a warn callback wired to
+// res.Report.Warnings and prefers this method when the task implements it.
+//
+// Implement it alongside GlobalExporter, never instead of it: exportGlobalPlay
+// asserts GlobalExporter first, so a task carrying only the reporting form is
+// skipped entirely.
+type globalExportReporter interface {
+	ExportGlobalReport(warn func(msg string)) ([]interface{}, error)
+}
+
 // globalExportOrder is the fixed order in which not-app-scoped task types are
 // emitted into the leading global play. Adding a global resource means
 // implementing GlobalExporter on its task and adding its type-key here.
@@ -306,7 +320,16 @@ func (res *ExportResult) exportGlobalPlay(opts ExportOptions) map[string]interfa
 		if !ok {
 			continue
 		}
-		bodies, err := exporter.ExportGlobal()
+		var bodies []interface{}
+		var err error
+		if reporter, ok := proto.(globalExportReporter); ok {
+			bodies, err = reporter.ExportGlobalReport(func(msg string) {
+				res.Report.Warnings = append(res.Report.Warnings,
+					fmt.Sprintf("global: %s: %s", typeKey, msg))
+			})
+		} else {
+			bodies, err = exporter.ExportGlobal()
+		}
 		if err != nil {
 			res.Report.Warnings = append(res.Report.Warnings,
 				fmt.Sprintf("global: %s: %v", typeKey, err))

--- a/tasks/export_coverage_test.go
+++ b/tasks/export_coverage_test.go
@@ -89,3 +89,25 @@ func TestEveryTaskDeclaresExportSupport(t *testing.T) {
 		}
 	}
 }
+
+// TestExportReportersAlsoImplementTheBaseExporter asserts that a task carrying
+// one of the diagnostics-aware export forms also carries the plain one.
+// exportAppPlay and exportGlobalPlay both assert AppExporter / GlobalExporter
+// before they look for the reporting variant, so a task that implements only
+// ExportAppReport or ExportGlobalReport is skipped outright - it would export
+// nothing at all, silently, which is the opposite of what declaring the
+// reporting form was meant to achieve.
+func TestExportReportersAlsoImplementTheBaseExporter(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		if _, ok := task.(appExportReporter); ok {
+			if _, ok := task.(AppExporter); !ok {
+				t.Errorf("task %q implements ExportAppReport but not ExportApp, so exportAppPlay skips it entirely", name)
+			}
+		}
+		if _, ok := task.(globalExportReporter); ok {
+			if _, ok := task.(GlobalExporter); !ok {
+				t.Errorf("task %q implements ExportGlobalReport but not ExportGlobal, so exportGlobalPlay skips it entirely", name)
+			}
+		}
+	}
+}

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -3,6 +3,8 @@ package tasks
 import (
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 // TestIntegrationExportConfigRoundTrip verifies the config exporter reconstructs
@@ -217,10 +219,15 @@ func TestIntegrationExportGitPropertyGlobal(t *testing.T) {
 // TestIntegrationExportSchedulerK3sProfile verifies the global profile exporter
 // against a real dokku. scheduler-k3s is a core plugin and profiles are stored
 // on disk (no cluster or deploy needed), so only dokku itself is required.
+//
+// The fixture name is kept well inside schedulerK3sProfileNameHelmMaxLength on
+// purpose: a name sitting on that boundary would, one character later, be
+// dropped by the exporter rather than fail loudly, and this test would report
+// only that the profile is missing (#483).
 func TestIntegrationExportSchedulerK3sProfile(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	name := "docket-test-export-profile"
+	name := "docket-test-export-prof"
 	cleanup := SchedulerK3sProfileTask{Name: name, Role: "worker", State: StateAbsent}
 	cleanup.Execute()
 	defer cleanup.Execute()
@@ -247,11 +254,67 @@ func TestIntegrationExportSchedulerK3sProfile(t *testing.T) {
 	if found.Role != "worker" || found.TaintScheduling != true {
 		t.Errorf("exported profile mismatch: %+v", *found)
 	}
-	// The exporter omits state; set it as the recipe loader would before
-	// planning the body directly.
-	found.State = StatePresent
+	// The exporter states the desired state rather than leaning on the loader's
+	// default, so the body is plannable exactly as it comes back.
+	if found.State != StatePresent {
+		t.Errorf("exported state = %q, want %q", found.State, StatePresent)
+	}
 	if plan := found.Plan(); !plan.InSync {
 		t.Errorf("exported profile should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+// TestIntegrationExportSchedulerK3sProfileLeavesOutUnappliableName pins #483
+// against a real dokku: `scheduler-k3s:profiles:add` accepts an uppercase name
+// that the task refuses for state 'present', because dokku could not turn the
+// derived dokku-node-sysctls-profile-<name> into a helm release. Exporting such
+// a profile faithfully would produce a recipe `docket validate` rejects whole,
+// so the exporter reports it and leaves it out.
+//
+// The profile is created through raw dokku on purpose: docket itself will not
+// create one, so this is the only way to reproduce a server that already
+// carries it.
+func TestIntegrationExportSchedulerK3sProfileLeavesOutUnappliableName(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "DocketTestExportBad"
+	removeProfile := func() {
+		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "scheduler-k3s:profiles:remove", name},
+		})
+	}
+	removeProfile()
+	defer removeProfile()
+
+	if _, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "scheduler-k3s:profiles:add", name, "--role", "worker"},
+	}); err != nil {
+		t.Skipf("dokku refused the uppercase profile name, so the export gap cannot be reproduced: %v", err)
+	}
+
+	var warnings []string
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(func(msg string) {
+		warnings = append(warnings, msg)
+	})
+	if err != nil {
+		t.Fatalf("ExportGlobalReport: %v", err)
+	}
+
+	for i := range bodies {
+		if p, ok := bodies[i].(SchedulerK3sProfileTask); ok && p.Name == name {
+			t.Fatalf("exported an unappliable profile: %+v", p)
+		}
+	}
+	var warned bool
+	for _, w := range warnings {
+		if strings.Contains(w, name) {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("expected a warning naming %q, got %v", name, warnings)
 	}
 }
 

--- a/tasks/scheduler_k3s_export_test.go
+++ b/tasks/scheduler_k3s_export_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -276,5 +277,171 @@ func TestExportSchedulerK3sScopedAndAuthRecipe(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("recipe missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// globalExportReporter is satisfied by SchedulerK3sProfileTask so the export
+// engine prefers ExportGlobalReport and routes the left-out-profile diagnostic
+// into ExportReport.Warnings rather than dropping it silently. #483.
+var _ globalExportReporter = SchedulerK3sProfileTask{}
+
+// schedulerK3sProfileExportFixture is a profiles:list payload holding one
+// profile docket can express and three it cannot, one per rule the exported
+// body has to satisfy: a name helm could not turn into a release because of its
+// case, one it could not because of its length, and a profile dokku reports
+// with no role at all. All three would come back as a recipe `docket validate`
+// refuses, which fails the whole file rather than just the task.
+func schedulerK3sProfileExportFixture() map[string]string {
+	overLong := strings.Repeat("a", schedulerK3sProfileNameHelmMaxLength+1)
+	return map[string]string{
+		"--quiet apps:list": "",
+		"--quiet scheduler-k3s:profiles:list --format json": `[
+			{"name":"edge-pool","role":"worker","kubelet_args":["max-pods=64"],"taint_scheduling":true},
+			{"name":"EdgePool","role":"worker"},
+			{"name":"` + overLong + `","role":"worker"},
+			{"name":"no-role","role":""}
+		]`,
+	}
+}
+
+// TestSchedulerK3sProfileExportReportLeavesOutUnappliableProfiles pins #483: a
+// profile the server reports but the task would refuse is warned about and left
+// out, and the profiles that survive carry an explicit state so the body is
+// plannable straight out of the exporter.
+func TestSchedulerK3sProfileExportReportLeavesOutUnappliableProfiles(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+
+	var warnings []string
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(func(msg string) {
+		warnings = append(warnings, msg)
+	})
+	if err != nil {
+		t.Fatalf("ExportGlobalReport: %v", err)
+	}
+
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 body, got %d: %+v", len(bodies), bodies)
+	}
+	body, ok := bodies[0].(SchedulerK3sProfileTask)
+	if !ok {
+		t.Fatalf("body type = %T, want SchedulerK3sProfileTask", bodies[0])
+	}
+	if body.Name != "edge-pool" {
+		t.Errorf("exported profile = %q, want edge-pool", body.Name)
+	}
+	if body.State != StatePresent {
+		t.Errorf("exported state = %q, want %q", body.State, StatePresent)
+	}
+	// The emitted body is exactly what the loader would hand to plan, so it has
+	// to satisfy the same check `docket validate` runs.
+	if err := body.Validate(); err != nil {
+		t.Errorf("exported body does not validate: %v", err)
+	}
+
+	if len(warnings) != 3 {
+		t.Fatalf("expected 3 warnings, got %d (%v)", len(warnings), warnings)
+	}
+	// Every warning names its profile: the engine prefix says only which task
+	// type spoke, and Validate()'s role message never mentions the name.
+	for _, want := range []string{"EdgePool", "must be lowercase", "state 'absent'"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("uppercase warning = %q, want it to mention %q", warnings[0], want)
+		}
+	}
+	if !strings.Contains(warnings[1], "at most 26 characters") {
+		t.Errorf("over-long warning = %q, want the length rule", warnings[1])
+	}
+	if !strings.Contains(warnings[2], "no-role") || !strings.Contains(warnings[2], "role is required") {
+		t.Errorf("missing-role warning = %q, want the profile name and the role rule", warnings[2])
+	}
+}
+
+// TestSchedulerK3sProfileExportGlobalDropsWithoutDiagnostics pins that the
+// plain GlobalExporter form leaves out the same profiles; it only discards the
+// explanation, which is why the engine prefers ExportGlobalReport.
+func TestSchedulerK3sProfileExportGlobalDropsWithoutDiagnostics(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 body, got %d: %+v", len(bodies), bodies)
+	}
+	if got := bodies[0].(SchedulerK3sProfileTask).Name; got != "edge-pool" {
+		t.Errorf("exported profile = %q, want edge-pool", got)
+	}
+}
+
+// TestExportSchedulerK3sProfileRecipeOmitsUnappliableProfiles drives the full
+// engine: the warnings reach ExportReport.Warnings under the global prefix, and
+// the recipe that comes back carries only the profile that can be applied.
+func TestExportSchedulerK3sProfileRecipeOmitsUnappliableProfiles(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	// The other global exporters answer the empty fixture with their own
+	// unparseable-report warnings, so count only the ones this task produced -
+	// which is also what pins the engine prefix onto them.
+	var profileWarnings []string
+	for _, w := range res.Report.Warnings {
+		if strings.HasPrefix(w, "global: dokku_scheduler_k3s_profile: ") {
+			profileWarnings = append(profileWarnings, w)
+		}
+	}
+	if len(profileWarnings) != 3 {
+		t.Fatalf("expected 3 profile warnings, got %d (%v)", len(profileWarnings), profileWarnings)
+	}
+
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	out := string(recipe)
+	for _, want := range []string{"dokku_scheduler_k3s_profile", "name: edge-pool", "state: present"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"EdgePool", "no-role"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("recipe carries the unappliable profile %q:\n%s", unwanted, out)
+		}
+	}
+}
+
+// TestExportSchedulerK3sProfileResourceAddressReportsAMissingProfile pins the
+// consequence of leaving a profile out: an address pinning one matches nothing,
+// so export reports it as missing and the command exits non-zero. The warning
+// printed above it is what says the profile is on the server but unexportable.
+func TestExportSchedulerK3sProfileResourceAddressReportsAMissingProfile(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+
+	selectors, err := ParseResourceSelectors([]string{"dokku_scheduler_k3s_profile[name=EdgePool]"})
+	if err != nil {
+		t.Fatalf("ParseResourceSelectors: %v", err)
+	}
+	res, err := ExportRecipe(ExportOptions{Resources: selectors})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	if res.PlayCount() != 0 {
+		t.Errorf("expected no plays, got %d", res.PlayCount())
+	}
+	want := []string{"dokku_scheduler_k3s_profile[name=EdgePool]"}
+	if !reflect.DeepEqual(res.Report.MissingResources, want) {
+		t.Errorf("MissingResources = %v, want %v", res.Report.MissingResources, want)
+	}
+	if len(res.Report.Warnings) == 0 {
+		t.Fatal("expected the left-out warning to survive the empty play")
+	}
+	if !strings.Contains(res.Report.Warnings[0], "EdgePool") {
+		t.Errorf("warning = %q, want it to name EdgePool", res.Report.Warnings[0])
 	}
 }

--- a/tasks/scheduler_k3s_profile_task.go
+++ b/tasks/scheduler_k3s_profile_task.go
@@ -65,7 +65,7 @@ func (t SchedulerK3sProfileTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t SchedulerK3sProfileTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportSupported}
+	return ExportSupport{Status: ExportPartial, Caveat: "every profile dokku reports is exported; a profile whose name dokku accepted but the task refuses for state 'present' - longer than 26 characters, or carrying uppercase, so helm cannot release the derived `dokku-node-sysctls-profile-<name>` - is reported as a warning and left out, since emitting it would make the whole recipe fail docket validate. Remove such a profile with a hand-written task using state 'absent'"}
 }
 
 // ProbeSupport reports whether Plan() can read this task's current state.
@@ -422,9 +422,38 @@ func formatProfileSetMutation(t SchedulerK3sProfileTask, current schedulerK3sPro
 	)
 }
 
-// ExportGlobal reconstructs every scheduler-k3s node profile from
-// profiles:list, which exposes the full profile definition.
+// ExportGlobal satisfies GlobalExporter by delegating to exportGlobal with a
+// no-op warn callback. The export engine prefers ExportGlobalReport when
+// present, so the left-out-profile diagnostic reaches ExportReport.Warnings
+// rather than being discarded here.
 func (t SchedulerK3sProfileTask) ExportGlobal() ([]interface{}, error) {
+	return t.exportGlobal(func(string) {})
+}
+
+// ExportGlobalReport is the diagnostics-aware form of ExportGlobal (the
+// globalExportReporter interface): it routes the "profile left out" warning
+// through the engine's warn callback (wired to ExportReport.Warnings) instead
+// of dropping the profile silently.
+func (t SchedulerK3sProfileTask) ExportGlobalReport(warn func(msg string)) ([]interface{}, error) {
+	return t.exportGlobal(warn)
+}
+
+// exportGlobal reconstructs every scheduler-k3s node profile from
+// profiles:list, which exposes the full profile definition.
+//
+// dokku accepts profiles docket cannot express as a valid task: `profiles:add`
+// caps a name at 32 characters and allows uppercase, while docket refuses, for
+// state 'present', anything helm could not turn into the derived
+// `dokku-node-sysctls-profile-<name>` release (#482). A server can therefore be
+// carrying a profile whose faithful export is a recipe `docket validate`
+// refuses - and it refuses the whole file, not just that task, so one such
+// profile would make the entire export unusable (#483). Each candidate body is
+// run through its own Validate() - the same method `docket validate` calls -
+// and one that would be refused is reported through warn and left out, so the
+// recipe that does come back applies. The warning names the profile and the
+// remedy, since a left-out profile is also one docket can no longer be asked to
+// remove.
+func (t SchedulerK3sProfileTask) exportGlobal(warn func(msg string)) ([]interface{}, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "scheduler-k3s:profiles:list", "--format", "json"},
@@ -445,13 +474,22 @@ func (t SchedulerK3sProfileTask) ExportGlobal() ([]interface{}, error) {
 
 	var out []interface{}
 	for _, e := range entries {
-		out = append(out, SchedulerK3sProfileTask{
+		body := SchedulerK3sProfileTask{
 			Name:              e.Name,
 			Role:              e.Role,
 			KubeletArgs:       e.KubeletArgs,
 			TaintScheduling:   e.TaintScheduling,
 			AllowUnknownHosts: e.AllowUnknownHosts,
-		})
+			// Explicit rather than left to the loader's default, so the body is
+			// plannable straight out of the exporter and Validate() below is
+			// asked the same question the loader will ask.
+			State: StatePresent,
+		}
+		if err := body.Validate(); err != nil {
+			warn(fmt.Sprintf("profile %q is left out of the recipe because the task would not validate: %v; remove it with a hand-written task using state 'absent'", e.Name, err))
+			continue
+		}
+		out = append(out, body)
 	}
 	return out, nil
 }

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -8,10 +8,14 @@ load test_helper
 setup() {
   docket_build
   dokku_clean_app docket-test-export
+  dokku_clean_scheduler_k3s_profile docket-test-good
+  dokku_clean_scheduler_k3s_profile DocketTestBad
 }
 
 teardown() {
   dokku_clean_app docket-test-export
+  dokku_clean_scheduler_k3s_profile docket-test-good
+  dokku_clean_scheduler_k3s_profile DocketTestBad
 }
 
 @test "docket export fails on a nonexistent --app and writes nothing" {
@@ -247,4 +251,34 @@ teardown() {
   assert_output --partial "secrets.yml"
   assert [ -f tasks.yml ]
   assert [ ! -f secrets.yml ]
+}
+
+# dokku's scheduler-k3s:profiles:add accepts any alphanumeric name up to 32
+# characters, but it derives each profile's node-sysctls helm release name as
+# dokku-node-sysctls-profile-<name>, and helm requires that to be lowercase and
+# at most 53 characters. docket refuses such a name for state present (#482), so
+# exporting the profile faithfully would hand back a recipe docket validate
+# rejects - and it rejects the whole file, not just that task (#483).
+@test "docket export leaves out a scheduler-k3s profile helm cannot release (#483)" {
+  require_dokku
+  dokku --quiet scheduler-k3s:profiles:add docket-test-good --role worker
+  if ! dokku --quiet scheduler-k3s:profiles:add DocketTestBad --role worker; then
+    skip "dokku refused the uppercase profile name, so the export gap cannot be reproduced"
+  fi
+
+  run "$(docket_bin)" export --resource dokku_scheduler_k3s_profile --output "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_success
+  assert_output --partial "DocketTestBad"
+  assert_output --partial "state 'absent'"
+
+  run cat "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_success
+  assert_output --partial "docket-test-good"
+  assert_output --partial "state: present"
+  refute_output --partial "DocketTestBad"
+
+  # The whole point: the recipe that comes back is one the user can actually
+  # apply, rather than one validate refuses with no explanation.
+  run "$(docket_bin)" validate --tasks "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_success
 }

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -102,6 +102,18 @@ dokku_clean_storage_entry() {
   dokku --quiet storage:destroy --force "$entry" >/dev/null 2>&1 || true
 }
 
+# dokku_clean_scheduler_k3s_profile removes a named scheduler-k3s node profile
+# if it exists. Same setup/teardown role as dokku_clean_app. Profiles are stored
+# on disk, so this works without a k3s cluster; removal of a profile whose name
+# helm cannot release fails on a clustered host, hence the tolerated failure.
+dokku_clean_scheduler_k3s_profile() {
+  local profile="$1"
+  if ! command -v dokku >/dev/null 2>&1; then
+    return 0
+  fi
+  dokku --quiet scheduler-k3s:profiles:remove "$profile" >/dev/null 2>&1 || true
+}
+
 # require_dokku skips the current test when no dokku binary is installed.
 require_dokku() {
   if ! command -v dokku >/dev/null 2>&1; then


### PR DESCRIPTION
`dokku scheduler-k3s:profiles:add` accepts a profile name up to 32 characters and allows uppercase, but docket refuses one longer than 26 or carrying uppercase for state `present` because dokku cannot name the derived node-sysctls helm release after it. A server can therefore already be carrying such a profile, and exporting it faithfully produced a recipe `docket validate` rejects - and it rejects the whole file, so one broken profile made the entire export unusable with no explanation of why. Each exported profile is now run through the same `Validate()` the loader calls, and one that would be refused is reported by name, with the reason and the `state: absent` remedy, and left out so the recipe that does come back applies. The bodies that survive carry an explicit `state: present` rather than leaning on the loader's default.

Global exporters had nowhere to put such a caveat, since `ExportGlobal()` takes no callback. They now have the counterpart of the app path's `ExportAppReport`: an optional `ExportGlobalReport(warn)` the engine prefers when a task implements it, which routes the message into `ExportReport.Warnings` to be rendered and masked like every other export diagnostic. Being optional, it leaves the other forty global exporters untouched.

Fixes #483.
