### PR TITLE
feat: expose the storage host directory mode and removal

### DIFF
--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -307,20 +307,32 @@ entry that does not exist yet, and `storage:set` plus the `storage:annotations:s
 | `create_host_dir: true` | `dokku_storage_entry` | `storage:create` creates the directory. Emit one entry task per distinct host directory, ahead of the `dokku_storage_mount` tasks that reference it. |
 | the host path itself | `dokku_storage_entry.path` | Omit it to get dokku's default, `/var/lib/dokku/data/storage/<name>`. |
 | `user` and `group` | `dokku_storage_entry.chown` | One value, not two: dokku's helper runs `chown -R <id>:<id>`, so a module call whose `user` and `group` differ cannot be expressed. The module's `"32767"` default is `chown: herokuish`. |
-| `os.chmod(host_dir, 0o777)` | **stays in the wrapper for now** | dokku creates the directory `0755`. `storage:create --mode` sets a different one as of dokku 0.38.27, but `dokku_storage_entry` has no `mode` field yet ([#480](https://github.com/dokku/docket/issues/480)). |
-| `destroy_host_dir: true` | **stays in the wrapper for now** | `dokku_storage_entry` with `state: absent` deregisters the entry and leaves the docker-local directory on disk. `storage:destroy --destroy-host-dir` removes it as of dokku 0.38.27, but the task does not pass the flag yet ([#480](https://github.com/dokku/docket/issues/480)). |
+| `os.chmod(host_dir, 0o777)` | `dokku_storage_entry.mode` | The module chmods unconditionally; docket leaves the directory at the `0755` dokku creates it with unless the recipe names a mode, so a wrapper reproducing the module sends `mode: "0777"` outright. Quote it, or send the 3 digit form - `755` and `0755` are the same value. |
+| `destroy_host_dir: true` | `dokku_storage_entry.destroy_host_dir` | Rides with `state: absent` and is refused anywhere else, since it is a flag on `storage:destroy`. Omit it and the directory survives the entry, which is the module's `destroy_host_dir: false`. Not quite equivalent: the module calls `os.rmdir`, which fails on a directory holding anything, where dokku removes the contents too. |
 | `os.lexists("/home/dokku/<app>")` | nothing to forward | The module stats the filesystem to decide whether the app exists. docket asks dokku, so a wrapper drops the probe rather than translating it. |
 
-One constraint on `chown` is worth knowing before a wrapper leans on it: dokku refuses the flag
-outright when the entry sits at a non-default `path`, and asks the operator to chown that path
-themselves. Ownership does converge, though. `dokku_storage_entry` compares `chown` against what
-the entry records and reaches for `storage:set` when the two disagree, which re-runs the chown on
-the docker-local directory - so a wrapper that changes `user` and `group` between runs gets the
-new ownership applied rather than recorded, the same as the module's own per-run `os.chown`.
+One constraint on `chown` and `mode` is worth knowing before a wrapper leans on either: dokku
+refuses both outright when the entry sits at a non-default `path`, and asks the operator to manage
+that path themselves. The same goes for `destroy_host_dir`, whose removal helper only ever operates
+on the default location. docket does not pre-empt any of the three, because the default path depends
+on the server's `DOKKU_LIB_ROOT` and docket may be driving that server over SSH - so a wrapper that
+sends a `path` gets the refusal from dokku at apply time.
 
-Everything else `storage:create` accepts other than `--mode` is a field on the task -
-`scheduler`, `size`, `access_mode`, `storage_class`, `namespace`, `reclaim_policy`,
-`annotations`, and `labels` - none of which the module has a counterpart for.
+Ownership and permissions do converge, though. `dokku_storage_entry` compares `chown` and `mode`
+against what the entry records and reaches for `storage:set` when they disagree, which re-runs the
+chown and the chmod on the docker-local directory - so a wrapper that changes `user`, `group`, or
+the mode between runs gets the new values applied rather than recorded, the same as the module's own
+per-run `os.chown` and `os.chmod`. dokku's chmod is not recursive, matching the module's; its chown
+is, which the `user` / `group` row above already notes.
+
+`docket plan` names the host directory in its mutation line whenever the destroy would take it -
+because the recipe set `destroy_host_dir`, or because the entry records `reclaim_policy: Delete`,
+which dokku honors on docker-local with or without the flag. A wrapper reporting `diff` in
+`check_mode` gets that for free.
+
+Everything else `storage:create` accepts is a field on the task - `scheduler`, `size`,
+`access_mode`, `storage_class`, `namespace`, `reclaim_policy`, `annotations`, and `labels` - none of
+which the module has a counterpart for.
 
 ## Required and optional fields disagree
 
@@ -364,11 +376,6 @@ task lands.
   plugin (`git-sync:set <app> remote`), which docket has no task for. Mind the name collision:
   docket's `dokku_git_sync` is core `git:sync`, which is what the `dokku_clone` module does. The two
   are unrelated.
-
-Separately, two pieces of `dokku_storage` stay in the wrapper for now: the `0o777` chmod and the
-`destroy_host_dir` removal. dokku 0.38.27 added a command for each, and exposing them on
-`dokku_storage_entry` is tracked in [#480](https://github.com/dokku/docket/issues/480). See
-[host directories](#host-directories).
 
 ## docket tasks with no ansible-dokku module
 

--- a/docs/tasks/dokku_storage_entry.md
+++ b/docs/tasks/dokku_storage_entry.md
@@ -6,11 +6,11 @@ Creates or destroys a named storage registry entry
 
 ## Export support
 
-Partial - every field the task accepts is exported; an entry's directory mode is not, since the task has no mode field yet (tracked in dokku/docket#480).
+Supported.
 
 ## Probe support
 
-Supported - every field is compared against what storage:list-entries records for the entry, which is the recorded chown rather than the host directory's ownership on disk; a directory chowned out of band is not detected.
+Supported - every attribute is compared against what storage:list-entries records for the entry, which is the recorded chown and mode rather than the host directory's ownership and permissions on disk; a directory chowned or chmodded out of band is not detected.
 
 ## Identity
 
@@ -28,9 +28,11 @@ Keyed by `name`.
 | `storage_class` | string | no |  |  | Storage class name (k3s scheduler; rejected on docker-local, and mutually exclusive with path). Cannot be changed on an entry that exists; a recipe that disagrees with the recorded value is reported as an error |
 | `namespace` | string | no |  |  | Namespace (scheduler-dependent). Converged on an entry that exists |
 | `chown` | string | no |  | heroku, herokuish, paketo, root, false | Ownership applied to the entry's host directory: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path. Converged on an entry that exists, which re-runs the chown on a docker-local directory |
+| `mode` | string | no |  |  | Octal permissions applied to the entry's host directory: a 3 or 4 digit mode, recorded in its 4 digit form so 755 and 0755 are the same value (docker-local scheduler; rejected on k3s). dokku refuses the value unless the entry sits at its default host path, and applies it non-recursively. Converged on an entry that exists, which re-runs the chmod on a docker-local directory. Omit it to leave the directory at the 0755 dokku creates it with |
 | `reclaim_policy` | string | no |  | Retain, Delete | Reclaim policy applied to the underlying volume (k3s scheduler). Converged on an entry that exists |
 | `annotations` | dict | no |  |  | Map of annotations set on the underlying volume (k3s scheduler). Converged one key at a time on an entry that exists, so a key the recipe omits is left alone |
 | `labels` | dict | no |  |  | Map of labels set on the underlying volume (k3s scheduler). Converged one key at a time on an entry that exists, so a key the recipe omits is left alone |
+| `destroy_host_dir` | bool | no |  |  | Remove the entry's host directory and its contents alongside deregistering the entry (docker-local scheduler). Only valid with state 'absent', and only where the entry sits at its default host path. An entry recording reclaim_policy 'Delete' loses its host directory whether or not this is set |
 | `state` | string | no | present | present, absent | Desired state of the storage entry |
 
 ## Examples
@@ -51,6 +53,14 @@ dokku_storage_entry:
     chown: root
 ```
 
+### Set the permissions on an entry's host directory
+
+```yaml
+dokku_storage_entry:
+    name: node-js-app-data
+    mode: "0777"
+```
+
 ### Create a storage entry at an explicit host path
 
 ```yaml
@@ -64,6 +74,15 @@ dokku_storage_entry:
 ```yaml
 dokku_storage_entry:
     name: node-js-app-data
+    state: absent
+```
+
+### Destroy a storage entry and remove its host directory
+
+```yaml
+dokku_storage_entry:
+    name: node-js-app-data
+    destroy_host_dir: true
     state: absent
 ```
 

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -16,13 +16,17 @@ import (
 // exist independently of any single app, and an attachment created via
 // dokku_storage_mount references them by name.
 //
-// The entry name selects the entry; every other field is compared against
-// what `storage:list-entries` records for it, so a recipe that changes one
-// converges on the next apply rather than being applied once at create
-// time. A field the recipe omits is unmanaged: it is neither compared nor
-// cleared, which is what stops a recipe naming only `name` and `chown`
-// from dropping a `size` it never mentions. Clearing an attribute is a
-// manual `dokku storage:set <name> <property>` with no value.
+// The entry name selects the entry; every other attribute is compared
+// against what `storage:list-entries` records for it, so a recipe that
+// changes one converges on the next apply rather than being applied once at
+// create time. A field the recipe omits is unmanaged: it is neither
+// compared nor cleared, which is what stops a recipe naming only `name` and
+// `chown` from dropping a `size` it never mentions. Clearing an attribute is
+// a manual `dokku storage:set <name> <property>` with no value.
+//
+// `destroy_host_dir` is the one field that is not an attribute. It modifies
+// the `storage:destroy` the `absent` state issues, so there is nothing on
+// the entry to compare it against and nothing for an export to reconstruct.
 //
 // Four fields cannot be converged, because dokku cannot change them on an
 // entry that exists: `storage:set` refuses an access-mode or storage-class
@@ -57,6 +61,10 @@ type StorageEntryTask struct {
 	// creation and again whenever the recipe changes it.
 	Chown string `required:"false" yaml:"chown,omitempty" options:"heroku,herokuish,paketo,root,false" description:"Ownership applied to the entry's host directory: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path. Converged on an entry that exists, which re-runs the chown on a docker-local directory"`
 
+	// Mode is the octal permission set applied to the entry's host
+	// directory, on creation and again whenever the recipe changes it.
+	Mode string `required:"false" yaml:"mode,omitempty" description:"Octal permissions applied to the entry's host directory: a 3 or 4 digit mode, recorded in its 4 digit form so 755 and 0755 are the same value (docker-local scheduler; rejected on k3s). dokku refuses the value unless the entry sits at its default host path, and applies it non-recursively. Converged on an entry that exists, which re-runs the chmod on a docker-local directory. Omit it to leave the directory at the 0755 dokku creates it with"`
+
 	// ReclaimPolicy is the reclaim policy (k3s scheduler)
 	ReclaimPolicy string `required:"false" yaml:"reclaim_policy,omitempty" options:"Retain,Delete" description:"Reclaim policy applied to the underlying volume (k3s scheduler). Converged on an entry that exists"`
 
@@ -65,6 +73,10 @@ type StorageEntryTask struct {
 
 	// Labels are the volume labels (k3s scheduler)
 	Labels map[string]string `required:"false" yaml:"labels,omitempty" description:"Map of labels set on the underlying volume (k3s scheduler). Converged one key at a time on an entry that exists, so a key the recipe omits is left alone"`
+
+	// DestroyHostDir removes the host directory alongside the entry, and
+	// is only meaningful under state 'absent'.
+	DestroyHostDir bool `required:"false" yaml:"destroy_host_dir,omitempty" description:"Remove the entry's host directory and its contents alongside deregistering the entry (docker-local scheduler). Only valid with state 'absent', and only where the entry sits at its default host path. An entry recording reclaim_policy 'Delete' loses its host directory whether or not this is set"`
 
 	// State is the desired state of the storage entry
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage entry"`
@@ -91,12 +103,12 @@ func (t StorageEntryTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t StorageEntryTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "every field the task accepts is exported; an entry's directory mode is not, since the task has no mode field yet (tracked in dokku/docket#480)"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // ProbeSupport reports whether Plan() can read this task's current state.
 func (t StorageEntryTask) ProbeSupport() ProbeSupport {
-	return ProbeSupport{Status: ProbeSupported, Caveat: "every field is compared against what storage:list-entries records for the entry, which is the recorded chown rather than the host directory's ownership on disk; a directory chowned out of band is not detected"}
+	return ProbeSupport{Status: ProbeSupported, Caveat: "every attribute is compared against what storage:list-entries records for the entry, which is the recorded chown and mode rather than the host directory's ownership and permissions on disk; a directory chowned or chmodded out of band is not detected"}
 }
 
 // Examples returns the examples for the storage entry task
@@ -117,6 +129,13 @@ func (t StorageEntryTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
+			Name: "Set the permissions on an entry's host directory",
+			StorageEntryTask: StorageEntryTask{
+				Name: "node-js-app-data",
+				Mode: "0777",
+			},
+		},
+		{
 			Name: "Create a storage entry at an explicit host path",
 			StorageEntryTask: StorageEntryTask{
 				Name: "node-js-app-data",
@@ -128,6 +147,14 @@ func (t StorageEntryTask) Examples() ([]Doc, error) {
 			StorageEntryTask: StorageEntryTask{
 				Name:  "node-js-app-data",
 				State: StateAbsent,
+			},
+		},
+		{
+			Name: "Destroy a storage entry and remove its host directory",
+			StorageEntryTask: StorageEntryTask{
+				Name:           "node-js-app-data",
+				DestroyHostDir: true,
+				State:          StateAbsent,
 			},
 		},
 	})
@@ -162,6 +189,9 @@ func (t StorageEntryTask) createArgs() []string {
 	if t.Chown != "" {
 		args = append(args, "--chown", t.Chown)
 	}
+	if t.Mode != "" {
+		args = append(args, "--mode", normalizeDirectoryMode(t.Mode))
+	}
 	if t.ReclaimPolicy != "" {
 		args = append(args, "--reclaim-policy", t.ReclaimPolicy)
 	}
@@ -195,7 +225,10 @@ func kvFlags(flag string, values map[string]string) []string {
 // that renders a flag but is missing here would be silently accepted under
 // state 'absent', where storage:destroy has nowhere to put it. 'scheduler'
 // is deliberately absent - it carries a default, so it is never empty by
-// the time Validate runs.
+// the time Validate runs. So is 'destroy_host_dir', which renders a flag on
+// storage:destroy rather than storage:create and is therefore the one field
+// state 'absent' wants rather than refuses; Validate rejects it from the
+// other direction instead.
 func (t StorageEntryTask) setEntryOptions() []string {
 	var set []string
 	for _, opt := range []struct {
@@ -208,6 +241,7 @@ func (t StorageEntryTask) setEntryOptions() []string {
 		{"storage_class", t.StorageClass != ""},
 		{"namespace", t.Namespace != ""},
 		{"chown", t.Chown != ""},
+		{"mode", t.Mode != ""},
 		{"reclaim_policy", t.ReclaimPolicy != ""},
 		{"annotations", len(t.Annotations) > 0},
 		{"labels", len(t.Labels) > 0},
@@ -223,6 +257,25 @@ func (t StorageEntryTask) setEntryOptions() []string {
 // place of an absolute path on a docker-local entry. Mirrors the regexp in
 // dokku's plugins/storage/entry.go.
 var dockerNamedVolume = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
+
+// directoryMode matches the 3 or 4 digit octal directory mode dokku accepts
+// for --mode. Mirrors the regexp in dokku's plugins/storage/entry.go.
+var directoryMode = regexp.MustCompile(`^[0-7]{3,4}$`)
+
+// normalizeDirectoryMode canonicalizes a mode to the 4 digit form the
+// registry records, mirroring NormalizeDirectoryMode in dokku's
+// plugins/storage/entry.go. Convergence depends on it: dokku stores 0755
+// whether the caller wrote 755 or 0755, so comparing the raw recipe value
+// against the recorded one would report drift on every run for a recipe
+// that wrote three digits, and each apply would "fix" a mode that was
+// already correct. Callers validate the value first, so a mode that is
+// neither 3 nor 4 digits is returned unchanged rather than mangled.
+func normalizeDirectoryMode(mode string) string {
+	if len(mode) == 3 {
+		return "0" + mode
+	}
+	return mode
+}
 
 // storageAccessModes lists the values dokku accepts for --access-mode.
 var storageAccessModes = map[string]bool{
@@ -247,6 +300,13 @@ func (t StorageEntryTask) Validate() error {
 			return fmt.Errorf("'%s' must not be set for state 'absent'", strings.Join(set, "', '"))
 		}
 		return nil
+	}
+
+	// The mirror of the check above: storage:destroy is the only command
+	// that takes the flag, so a recipe asking for it under any other state
+	// is asking for a removal that will never happen.
+	if t.DestroyHostDir {
+		return errors.New("'destroy_host_dir' must not be set for state 'present'")
 	}
 
 	// An omitted scheduler is docker-local: createArgs drops the flag so
@@ -285,12 +345,19 @@ func (t StorageEntryTask) Validate() error {
 		if t.ReclaimPolicy != "" && t.ReclaimPolicy != "Retain" && t.ReclaimPolicy != "Delete" {
 			return errors.New("'reclaim_policy' must be one of Retain, Delete")
 		}
+		if t.Mode != "" {
+			return errors.New("'mode' must not be set for scheduler 'k3s'")
+		}
 	default:
 		return fmt.Errorf("'scheduler' must be one of docker-local, k3s, got %q", t.Scheduler)
 	}
 
 	if t.Chown != "" && !validChown(t.Chown) {
 		return errors.New("'chown' must be one of heroku, herokuish, paketo, root, false or a numeric uid (0-65535)")
+	}
+
+	if t.Mode != "" && !directoryMode.MatchString(t.Mode) {
+		return errors.New("'mode' must be a 3 or 4 digit octal directory mode, such as 0755")
 	}
 
 	for _, m := range []struct {
@@ -379,15 +446,28 @@ func (t StorageEntryTask) Plan() PlanResult {
 			if entry == nil {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
-			inputs := []subprocess.ExecCommandInput{{
-				Command: "dokku",
-				Args:    []string{"--quiet", "storage:destroy", "--force", t.Name},
-			}}
+			// dokku refuses the flag outright on anything but a docker-local
+			// entry, where the underlying volume follows the reclaim policy
+			// instead. Reporting it here fails the plan rather than the apply,
+			// the same way an immutable attribute mismatch does.
+			if t.DestroyHostDir && entry.Scheduler != "docker-local" {
+				return PlanResult{
+					Status: PlanStatusError,
+					Error: fmt.Errorf("storage entry %s records scheduler %q: 'destroy_host_dir' only applies to a docker-local entry, whose counterpart elsewhere is the entry's reclaim_policy",
+						t.Name, entry.Scheduler),
+				}
+			}
+			args := []string{"--quiet", "storage:destroy", "--force"}
+			if t.DestroyHostDir {
+				args = append(args, "--destroy-host-dir")
+			}
+			args = append(args, t.Name)
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "entry present",
-				Mutations: []string{fmt.Sprintf("destroy storage entry %s", t.Name)},
+				Mutations: []string{formatStorageEntryDestroy(t, *entry)},
 				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
 					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
@@ -442,15 +522,19 @@ func immutableStorageEntryAttributes(t StorageEntryTask, e storageEntry) []stora
 
 // mutableStorageEntryAttributes are the scalar fields `storage:set`
 // converges, in struct field order so plan and apply build byte-identical
-// argv across runs. dokku re-applies the host directory's ownership
-// whenever a storage:set touches chown, so setting it here changes the
-// directory on a docker-local entry rather than only the recorded value -
-// which is the whole reason attribute convergence is worth doing.
+// argv across runs. dokku re-applies the host directory's ownership and
+// permissions whenever a storage:set touches chown or mode, so setting
+// either here changes the directory on a docker-local entry rather than only
+// the recorded value - which is the whole reason attribute convergence is
+// worth doing. mode is normalized to the 4 digit form the registry records,
+// or a recipe writing three digits would drift forever against its own
+// applied value.
 func mutableStorageEntryAttributes(t StorageEntryTask, e storageEntry) []storageEntryAttribute {
 	return []storageEntryAttribute{
 		{Field: "size", Property: "size", Desired: t.Size, Current: e.Size},
 		{Field: "namespace", Property: "namespace", Desired: t.Namespace, Current: e.Namespace},
 		{Field: "chown", Property: "chown", Desired: t.Chown, Current: e.Chown},
+		{Field: "mode", Property: "mode", Desired: normalizeDirectoryMode(t.Mode), Current: e.Mode},
 		{Field: "reclaim_policy", Property: "reclaim-policy", Desired: t.ReclaimPolicy, Current: e.ReclaimPolicy},
 	}
 }
@@ -541,6 +625,28 @@ func formatStorageEntrySet(label, desired, current string) string {
 	return fmt.Sprintf("set %s=%s (was %q)", label, desired, current)
 }
 
+// formatStorageEntryDestroy renders the destroy mutation, naming the host
+// directory when the apply would take it with the entry. dokku removes it
+// either because the recipe asked or because the entry records a Delete
+// reclaim policy, so the recipe's flag alone does not answer the question -
+// a plan reporting only what the recipe asked for would stay silent about a
+// directory that is about to go.
+//
+// One case over-reports: dokku's removal helper only ever operates on the
+// default host path, so a Delete policy on a custom path is warned about and
+// skipped. dokku's own entry validation refuses to create that combination,
+// which leaves only entries written before it did - and docket cannot tell
+// them apart anyway, since the default path depends on the server's
+// DOKKU_LIB_ROOT.
+func formatStorageEntryDestroy(t StorageEntryTask, entry storageEntry) string {
+	removesHostDir := entry.Scheduler == "docker-local" &&
+		(t.DestroyHostDir || entry.ReclaimPolicy == "Delete")
+	if !removesHostDir {
+		return fmt.Sprintf("destroy storage entry %s", t.Name)
+	}
+	return fmt.Sprintf("destroy storage entry %s and its host directory %s", t.Name, entry.HostPath)
+}
+
 // ExportGlobal reads the named storage registry entries and returns a
 // dokku_storage_entry task per explicitly-created entry. Auto-generated
 // "legacy-" entries (created implicitly by legacy bind-mounts) are skipped
@@ -548,9 +654,11 @@ func formatStorageEntrySet(label, desired, current string) string {
 //
 // storage:list-entries marshals the whole entry, so every field the task
 // can set comes back from the one call. Reconstructing all of them is what
-// makes the export lossless: dropping chown would lose the host
-// directory's ownership, and dropping size would produce a k3s entry the
-// task's own validation rejects.
+// makes the export lossless: dropping chown or mode would lose the host
+// directory's ownership and permissions, and dropping size would produce a
+// k3s entry the task's own validation rejects. destroy_host_dir is not
+// exported because it is not state - it modifies a destroy the exported
+// recipe does not perform.
 func (t StorageEntryTask) ExportGlobal() ([]interface{}, error) {
 	entries, err := storageEntries()
 	if err != nil {
@@ -572,6 +680,7 @@ func (t StorageEntryTask) ExportGlobal() ([]interface{}, error) {
 			StorageClass:  e.StorageClass,
 			Namespace:     e.Namespace,
 			Chown:         e.Chown,
+			Mode:          e.Mode,
 			ReclaimPolicy: e.ReclaimPolicy,
 			Annotations:   e.Annotations,
 			Labels:        e.Labels,
@@ -590,6 +699,7 @@ type storageEntry struct {
 	StorageClass  string            `json:"storage_class"`
 	Namespace     string            `json:"namespace"`
 	Chown         string            `json:"chown"`
+	Mode          string            `json:"mode"`
 	ReclaimPolicy string            `json:"reclaim_policy"`
 	Annotations   map[string]string `json:"annotations"`
 	Labels        map[string]string `json:"labels"`

--- a/tasks/storage_entry_task_integration_test.go
+++ b/tasks/storage_entry_task_integration_test.go
@@ -1,9 +1,17 @@
 package tasks
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// dokkuStorageRoot is where dokku puts an entry's host directory when the
+// recipe names no path. The integration environment runs a stock install, so
+// DOKKU_LIB_ROOT is its default - the tests that stat a directory say so
+// rather than asking docket, which deliberately never computes this path.
+const dokkuStorageRoot = "/var/lib/dokku/data/storage"
 
 func TestIntegrationStorageEntry(t *testing.T) {
 	skipIfNoDokkuT(t)
@@ -212,6 +220,129 @@ func TestIntegrationStorageEntryConvergesChown(t *testing.T) {
 	}
 }
 
+func TestIntegrationStorageEntryConvergesMode(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-converge-mode"
+
+	destroy := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
+	destroy.Execute()
+	defer destroy.Execute()
+
+	create := StorageEntryTask{Name: name, Mode: "0750", State: StatePresent}
+	if result := create.Execute(); result.Error != nil {
+		t.Fatalf("failed to create entry: %v", result.Error)
+	}
+	hostDir := filepath.Join(dokkuStorageRoot, name)
+	assertDirModeT(t, hostDir, 0o750)
+
+	// The entry already exists, so the permission change goes through
+	// storage:set rather than a second storage:create - which is what re-runs
+	// the chmod on the host directory instead of only recording a new value.
+	converge := StorageEntryTask{Name: name, Mode: "0777", State: StatePresent}
+	plan := converge.Plan()
+	if plan.Status != PlanStatusModify {
+		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
+	}
+
+	result := converge.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to converge mode: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for a mode change")
+	}
+
+	if entry := findStorageEntryT(t, name); entry.Mode != "0777" {
+		t.Errorf("expected the registry to record mode '0777', got %q", entry.Mode)
+	}
+	assertDirModeT(t, hostDir, 0o777)
+
+	// A third run settles: the recipe now matches what the registry holds.
+	if result := converge.Execute(); result.Changed {
+		t.Error("expected changed=false once the mode matches")
+	}
+}
+
+func TestIntegrationStorageEntryNormalizesAThreeDigitMode(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-mode-normalize"
+
+	destroy := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
+	destroy.Execute()
+	defer destroy.Execute()
+
+	// dokku records the 4 digit form whatever the recipe wrote. docket has to
+	// compare the same way, or this recipe would report drift on every run and
+	// re-apply a mode that was already correct.
+	create := StorageEntryTask{Name: name, Mode: "700", State: StatePresent}
+	if result := create.Execute(); result.Error != nil {
+		t.Fatalf("failed to create entry: %v", result.Error)
+	}
+	if entry := findStorageEntryT(t, name); entry.Mode != "0700" {
+		t.Errorf("expected the registry to record mode '0700', got %q", entry.Mode)
+	}
+	assertDirModeT(t, filepath.Join(dokkuStorageRoot, name), 0o700)
+
+	if result := create.Execute(); result.Changed {
+		t.Error("expected changed=false for a three digit mode that is already applied")
+	}
+}
+
+func TestIntegrationStorageEntryDestroyHostDir(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-destroy-host-dir"
+	hostDir := filepath.Join(dokkuStorageRoot, name)
+
+	cleanup := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
+	cleanup.Execute()
+	defer cleanup.Execute()
+
+	create := StorageEntryTask{Name: name, State: StatePresent}
+	if result := create.Execute(); result.Error != nil {
+		t.Fatalf("failed to create entry: %v", result.Error)
+	}
+	if _, err := os.Stat(hostDir); err != nil {
+		t.Fatalf("expected %s to exist after create: %v", hostDir, err)
+	}
+
+	// A plain destroy deregisters the entry and leaves the directory, which is
+	// the half dokku_storage_entry has always covered.
+	if result := (StorageEntryTask{Name: name, State: StateAbsent}).Execute(); result.Error != nil {
+		t.Fatalf("failed to destroy entry: %v", result.Error)
+	}
+	if _, err := os.Stat(hostDir); err != nil {
+		t.Fatalf("expected a plain destroy to leave %s in place: %v", hostDir, err)
+	}
+
+	// The flag is the other half: re-create, then destroy the directory too.
+	if result := create.Execute(); result.Error != nil {
+		t.Fatalf("failed to re-create entry: %v", result.Error)
+	}
+
+	destroy := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
+	plan := destroy.Plan()
+	if plan.Status != PlanStatusDestroy {
+		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusDestroy, plan.Status, plan.Error)
+	}
+	if len(plan.Mutations) != 1 || !strings.Contains(plan.Mutations[0], hostDir) {
+		t.Errorf("expected the plan to name %s, got %v", hostDir, plan.Mutations)
+	}
+
+	result := destroy.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to destroy entry and host directory: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for destroy")
+	}
+	if _, err := os.Stat(hostDir); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat returned: %v", hostDir, err)
+	}
+}
+
 func TestIntegrationStorageEntryConvergesOneAnnotationKey(t *testing.T) {
 	skipIfNoDokkuT(t)
 
@@ -282,6 +413,21 @@ func TestIntegrationStorageEntryRefusesAPathChange(t *testing.T) {
 	}
 	if plan.Error == nil || !strings.Contains(plan.Error.Error(), "records path") {
 		t.Errorf("expected an immutable-path error, got: %v", plan.Error)
+	}
+}
+
+// assertDirModeT checks the host directory's permission bits on disk. It is
+// what separates a converge that re-runs the chmod from one that only
+// rewrites the registry's JSON - the registry cannot tell the two apart, and
+// neither can docket's own probe.
+func assertDirModeT(t *testing.T, dir string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("failed to stat %s: %v", dir, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Errorf("expected %s to have mode %04o, got %04o", dir, want, got)
 	}
 }
 

--- a/tasks/storage_entry_task_test.go
+++ b/tasks/storage_entry_task_test.go
@@ -123,6 +123,67 @@ func TestStorageEntryCreateArgsRepeatsMapFlagsInSortedOrder(t *testing.T) {
 	}
 }
 
+func TestStorageEntryCreateArgsCarriesMode(t *testing.T) {
+	// --mode sits between --chown and --reclaim-policy, matching dokku's own
+	// flag order, and is rendered in the 4 digit form the registry records so
+	// the create command reads the same as the storage:set a later converge
+	// would issue.
+	task := StorageEntryTask{
+		Name:  "app-data",
+		Chown: "herokuish",
+		Mode:  "755",
+		State: StatePresent,
+	}
+	want := []string{
+		"--quiet", "storage:create",
+		"--chown", "herokuish",
+		"--mode", "0755",
+		"app-data",
+	}
+	if got := task.createArgs(); !equalStrings(got, want) {
+		t.Errorf("expected args %v, got %v", want, got)
+	}
+}
+
+func TestStorageEntryCreateArgsKeepsAFourDigitMode(t *testing.T) {
+	task := StorageEntryTask{Name: "app-data", Mode: "0777", State: StatePresent}
+	want := []string{"--quiet", "storage:create", "--mode", "0777", "app-data"}
+	if got := task.createArgs(); !equalStrings(got, want) {
+		t.Errorf("expected args %v, got %v", want, got)
+	}
+}
+
+func TestStorageEntryValidModeValues(t *testing.T) {
+	// The same shape dokku's directoryModeRegexp accepts: 3 or 4 octal digits.
+	for _, mode := range []string{"000", "755", "777", "0000", "0755", "0777", "2775", "7777"} {
+		task := StorageEntryTask{Name: "app-data", Mode: mode, State: StatePresent}
+		if err := task.Validate(); err != nil {
+			t.Errorf("mode %q should be valid, got: %v", mode, err)
+		}
+	}
+}
+
+func TestStorageEntryInvalidModeValue(t *testing.T) {
+	for _, mode := range []string{"8", "99", "12345", "0888", "0o755", "-755", "+755", "07 5", "abc", "0x1ff", "u+rwx"} {
+		task := StorageEntryTask{Name: "app-data", Mode: mode, State: StatePresent}
+		err := task.Validate()
+		if err == nil {
+			t.Errorf("mode %q should be rejected", mode)
+			continue
+		}
+		if !strings.Contains(err.Error(), "'mode' must be a 3 or 4 digit octal directory mode") {
+			t.Errorf("mode %q: unexpected error %v", mode, err)
+		}
+	}
+}
+
+func TestStorageEntryOmittedModeAllowed(t *testing.T) {
+	task := StorageEntryTask{Name: "app-data", State: StatePresent}
+	if err := task.Validate(); err != nil {
+		t.Errorf("an omitted mode should be valid, got: %v", err)
+	}
+}
+
 func TestStorageEntryValidChownValues(t *testing.T) {
 	// The same value set dokku_storage_ensure accepts: the entry task now
 	// shares validChown rather than forwarding anything at all.
@@ -216,6 +277,15 @@ func TestStorageEntryValidateSchedulerRules(t *testing.T) {
 			wantErr: "'reclaim_policy' must be one of Retain, Delete",
 		},
 		{
+			name:    "k3s rejects mode",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi", Mode: "0777"},
+			wantErr: "'mode' must not be set for scheduler 'k3s'",
+		},
+		{
+			name: "docker-local accepts mode",
+			task: StorageEntryTask{Name: "app-data", Scheduler: "docker-local", Mode: "0777"},
+		},
+		{
 			name: "k3s full surface",
 			task: StorageEntryTask{
 				Name:          "app-data",
@@ -258,12 +328,13 @@ func TestStorageEntryValidateRejectsCreateOptionsWhenAbsent(t *testing.T) {
 	}{
 		{"path", StorageEntryTask{Name: "app-data", Path: "/mnt/data"}, "'path' must not be set for state 'absent'"},
 		{"chown", StorageEntryTask{Name: "app-data", Chown: "herokuish"}, "'chown' must not be set for state 'absent'"},
+		{"mode", StorageEntryTask{Name: "app-data", Mode: "0777"}, "'mode' must not be set for state 'absent'"},
 		{"annotations", StorageEntryTask{Name: "app-data", Annotations: map[string]string{"a": "b"}}, "'annotations' must not be set for state 'absent'"},
 		{"labels", StorageEntryTask{Name: "app-data", Labels: map[string]string{"a": "b"}}, "'labels' must not be set for state 'absent'"},
 		{
 			"several at once",
-			StorageEntryTask{Name: "app-data", Size: "2Gi", Chown: "root"},
-			"'size', 'chown' must not be set for state 'absent'",
+			StorageEntryTask{Name: "app-data", Size: "2Gi", Chown: "root", Mode: "0777"},
+			"'size', 'chown', 'mode' must not be set for state 'absent'",
 		},
 	}
 
@@ -287,6 +358,28 @@ func TestStorageEntryValidateAbsentWithOnlyNameIsValid(t *testing.T) {
 	task := StorageEntryTask{Name: "app-data", Scheduler: "docker-local", State: StateAbsent}
 	if err := task.Validate(); err != nil {
 		t.Errorf("expected a bare destroy to validate, got: %v", err)
+	}
+}
+
+func TestStorageEntryValidateRejectsDestroyHostDirWhenPresent(t *testing.T) {
+	// storage:destroy is the only command that takes the flag, so asking for
+	// it under 'present' asks for a removal that will never happen.
+	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StatePresent}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("expected destroy_host_dir under state 'present' to be rejected")
+	}
+	if !strings.Contains(err.Error(), "'destroy_host_dir' must not be set for state 'present'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestStorageEntryValidateAcceptsDestroyHostDirWhenAbsent(t *testing.T) {
+	// It is the one field state 'absent' wants rather than refuses, so it must
+	// not be swept up by the create-time option guard.
+	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
+	if err := task.Validate(); err != nil {
+		t.Errorf("expected destroy_host_dir to validate under state 'absent', got: %v", err)
 	}
 }
 
@@ -441,6 +534,7 @@ func storageEntriesFixture() map[string]string {
 				"scheduler": "docker-local",
 				"host_path": "/var/lib/dokku/data/storage/app-data",
 				"chown": "herokuish",
+				"mode": "0777",
 				"schema_version": 1
 			}
 		]`,
@@ -462,14 +556,18 @@ func TestStorageEntryExportGlobal(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected a StorageEntryTask, got %T", exported[0])
 	}
-	// Ownership is what makes the host directory's export lossless.
+	// Ownership and permissions are what make the host directory's export
+	// lossless: an entry re-applied elsewhere without them lands at dokku's
+	// default 0755 herokuish directory rather than the one it was exported from.
 	want := StorageEntryTask{
 		Name:      "app-data",
 		Path:      "/var/lib/dokku/data/storage/app-data",
 		Scheduler: "docker-local",
 		Chown:     "herokuish",
+		Mode:      "0777",
 	}
-	if first.Name != want.Name || first.Path != want.Path || first.Scheduler != want.Scheduler || first.Chown != want.Chown {
+	if first.Name != want.Name || first.Path != want.Path || first.Scheduler != want.Scheduler ||
+		first.Chown != want.Chown || first.Mode != want.Mode {
 		t.Errorf("expected %+v, got %+v", want, first)
 	}
 
@@ -579,6 +677,81 @@ func TestStorageEntryPlanConvergesChown(t *testing.T) {
 		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
 	}
 	if plan.Reason != "1 attribute(s) to set" {
+		t.Errorf("unexpected reason %q", plan.Reason)
+	}
+}
+
+// dockerLocalEntryWithModeJSON records a mode, for the convergence and
+// normalization tests that compare a recipe against it.
+const dockerLocalEntryWithModeJSON = `{
+	"name": "app-data",
+	"scheduler": "docker-local",
+	"host_path": "/var/lib/dokku/data/storage/app-data",
+	"chown": "herokuish",
+	"mode": "0755",
+	"schema_version": 1
+}`
+
+func TestStorageEntryPlanConvergesMode(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", Mode: "0777", State: StatePresent}
+	plan := task.Plan()
+	if plan.Status != PlanStatusModify {
+		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
+	}
+	want := []string{"dokku --quiet storage:set app-data mode 0777"}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+	wantMutations := []string{`set mode=0777 (was "0755")`}
+	if !equalStrings(plan.Mutations, wantMutations) {
+		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
+	}
+}
+
+func TestStorageEntryPlanReadsAThreeDigitModeAsItsFourDigitForm(t *testing.T) {
+	// dokku records 0755 whether the caller wrote 755 or 0755. Comparing the
+	// raw recipe value against the recorded one would report drift on every
+	// run and re-apply a mode that was already correct.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", Mode: "755", State: StatePresent}
+	plan := task.Plan()
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("expected an in-sync plan, got status %q mutations %v", plan.Status, plan.Mutations)
+	}
+}
+
+func TestStorageEntryPlanNormalizesAThreeDigitModeItSets(t *testing.T) {
+	// The other half of the same rule: a drifted three digit mode converges to
+	// the four digit form, so the next run settles rather than looping.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", Mode: "700", State: StatePresent}
+	plan := task.Plan()
+	want := []string{"dokku --quiet storage:set app-data mode 0700"}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+}
+
+func TestStorageEntryPlanConvergesChownBeforeMode(t *testing.T) {
+	// Struct field order, so plan and apply build byte-identical argv across
+	// runs. The k3s ordering test below cannot cover this pair: k3s rejects
+	// mode outright.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", Chown: "root", Mode: "0777", State: StatePresent}
+	plan := task.Plan()
+	want := []string{
+		"dokku --quiet storage:set app-data chown root",
+		"dokku --quiet storage:set app-data mode 0777",
+	}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands\n%v\ngot\n%v", want, plan.Commands)
+	}
+	if plan.Reason != "2 attribute(s) to set" {
 		t.Errorf("unexpected reason %q", plan.Reason)
 	}
 }
@@ -756,6 +929,92 @@ func TestStorageEntryPlanAbsentIgnoresAttributes(t *testing.T) {
 	want := []string{"dokku --quiet storage:destroy --force app-data"}
 	if !equalStrings(plan.Commands, want) {
 		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+}
+
+func TestStorageEntryPlanAbsentDestroysTheHostDirectoryOnRequest(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
+	plan := task.Plan()
+	if plan.Status != PlanStatusDestroy {
+		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusDestroy, plan.Status, plan.Error)
+	}
+	want := []string{"dokku --quiet storage:destroy --force --destroy-host-dir app-data"}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+	// The plan has to name the directory: it is the data the apply removes.
+	wantMutations := []string{"destroy storage entry app-data and its host directory /var/lib/dokku/data/storage/app-data"}
+	if !equalStrings(plan.Mutations, wantMutations) {
+		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
+	}
+}
+
+func TestStorageEntryPlanAbsentReportsAReclaimDeleteRemoval(t *testing.T) {
+	// dokku removes the host directory for a Delete entry with no flag at all,
+	// so a plan reporting only what the recipe asked for would stay silent
+	// about a directory that is about to go.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+		"name": "app-data",
+		"scheduler": "docker-local",
+		"host_path": "/var/lib/dokku/data/storage/app-data",
+		"reclaim_policy": "Delete",
+		"schema_version": 1
+	}`)))()
+
+	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
+	plan := task.Plan()
+	want := []string{"dokku --quiet storage:destroy --force app-data"}
+	if !equalStrings(plan.Commands, want) {
+		t.Errorf("expected commands %v, got %v", want, plan.Commands)
+	}
+	wantMutations := []string{"destroy storage entry app-data and its host directory /var/lib/dokku/data/storage/app-data"}
+	if !equalStrings(plan.Mutations, wantMutations) {
+		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
+	}
+}
+
+func TestStorageEntryPlanAbsentLeavesTheHostDirectoryAloneByDefault(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+
+	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
+	plan := task.Plan()
+	wantMutations := []string{"destroy storage entry app-data"}
+	if !equalStrings(plan.Mutations, wantMutations) {
+		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
+	}
+}
+
+func TestStorageEntryPlanAbsentRejectsDestroyHostDirOnANonDockerLocalEntry(t *testing.T) {
+	// dokku refuses the flag outright there, so the plan says so rather than
+	// letting the apply fail part way through.
+	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(
+		`{"name": "app-data", "scheduler": "k3s", "size": "2Gi", "reclaim_policy": "Delete", "schema_version": 1}`,
+	)))()
+
+	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
+	plan := task.Plan()
+	if plan.Status != PlanStatusError {
+		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
+	}
+	if plan.Error == nil || !strings.Contains(plan.Error.Error(), `records scheduler "k3s"`) {
+		t.Errorf("expected a scheduler error, got: %v", plan.Error)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("a refused plan must issue no commands, got %v", plan.Commands)
+	}
+}
+
+func TestStorageEntryPlanAbsentIgnoresDestroyHostDirWhenTheEntryIsGone(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet storage:list-entries --format json": `[]`,
+	}))()
+
+	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
+	plan := task.Plan()
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("expected an in-sync plan, got status %q (error %v)", plan.Status, plan.Error)
 	}
 }
 

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -690,6 +690,93 @@ func TestValidateStorageEntryAbsentRejectsCreateOptions(t *testing.T) {
 	}
 }
 
+func TestValidateStorageEntryInvalidMode(t *testing.T) {
+	// A YAML scalar decodes into the string field verbatim, so an unquoted
+	// 0888 reaches Validate as the four characters the recipe wrote rather
+	// than as a number YAML has already reinterpreted.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        mode: 0888
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'mode' must be a 3 or 4 digit octal directory mode") {
+		t.Errorf("expected message to name the octal rule, got: %q", p.Message)
+	}
+}
+
+func TestValidateStorageEntryModeAcceptsUnquotedOctal(t *testing.T) {
+	// The counterpart: an unquoted 0755 is a valid mode, and must not be
+	// mangled into a decimal on the way through the decoder.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        mode: 0755
+`)
+	if problems := Validate(data, ValidateOptions{}); len(problems) != 0 {
+		t.Errorf("expected an unquoted octal mode to validate, got: %+v", problems)
+	}
+}
+
+func TestValidateStorageEntryK3sRejectsMode(t *testing.T) {
+	// dokku's --mode is implemented by a sudo helper against a host
+	// directory, which a cluster-provisioned volume does not have.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        scheduler: k3s
+        size: 2Gi
+        mode: "0777"
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'mode' must not be set for scheduler 'k3s'") {
+		t.Errorf("expected message to name the scheduler, got: %q", p.Message)
+	}
+}
+
+func TestValidateStorageEntryPresentRejectsDestroyHostDir(t *testing.T) {
+	// The flag rides on storage:destroy, so asking for it under the default
+	// state asks for a removal that will never happen.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        destroy_host_dir: true
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'destroy_host_dir' must not be set for state 'present'") {
+		t.Errorf("expected message to name the state, got: %q", p.Message)
+	}
+}
+
+func TestValidateStorageEntryAbsentAcceptsDestroyHostDir(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        destroy_host_dir: true
+        state: absent
+`)
+	if problems := Validate(data, ValidateOptions{}); len(problems) != 0 {
+		t.Errorf("expected destroy_host_dir under state 'absent' to validate, got: %+v", problems)
+	}
+}
+
 func TestValidateStorageEntryAnnotationsValid(t *testing.T) {
 	// The annotations and labels maps reach dokku as repeated
 	// `--annotation key=value` flags; a clean map validates.

--- a/tests/bats/ansible.bats
+++ b/tests/bats/ansible.bats
@@ -154,6 +154,65 @@ EOF
   assert_output --partial "is valid"
 }
 
+# The other two pieces of a dokku_storage module call the wrapper used to do
+# with raw filesystem calls: the unconditional `os.chmod(host_dir, 0o777)`
+# becomes `mode`, and `destroy_host_dir: true` becomes the field of the same
+# name on the `state: absent` branch.
+@test "a storage host-directory mode and removal payload validates" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >storage.json <<'EOF'
+[
+  {
+    "name": "dokku_storage",
+    "tasks": [
+      {
+        "name": "create the host directory for hello-world",
+        "dokku_storage_entry": {
+          "name": "hello-world-data",
+          "chown": "herokuish",
+          "mode": "0777",
+          "state": "present"
+        }
+      },
+      {
+        "name": "remove the host directory for hello-world",
+        "dokku_storage_entry": {
+          "name": "hello-world-scratch",
+          "destroy_host_dir": true,
+          "state": "absent"
+        }
+      }
+    ]
+  }
+]
+EOF
+  run bash -c "\"$(docket_bin)\" validate --tasks-format json5 - <storage.json"
+  assert_success
+  assert_output --partial "is valid"
+}
+
+@test "a bad storage mode reports a validate_problem a wrapper can branch on" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >storage.json <<'EOF'
+[{"tasks": [{"name": "bad mode", "dokku_storage_entry": {"name": "hello-world-data", "mode": "0888"}}]}]
+EOF
+  run bash -c "\"$(docket_bin)\" validate --tasks-format json5 --json - <storage.json"
+  assert_failure
+  echo "$output" | jq -e '.code == "invalid_task_input"' >/dev/null || fail "expected invalid_task_input: $output"
+  echo "$output" | jq -e '.message | test("mode")' >/dev/null || fail "expected the message to name mode: $output"
+}
+
+@test "destroy_host_dir outside state absent reports a validate_problem" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >storage.json <<'EOF'
+[{"tasks": [{"name": "misplaced flag", "dokku_storage_entry": {"name": "hello-world-data", "destroy_host_dir": true}}]}]
+EOF
+  run bash -c "\"$(docket_bin)\" validate --tasks-format json5 --json - <storage.json"
+  assert_failure
+  echo "$output" | jq -e '.code == "invalid_task_input"' >/dev/null || fail "expected invalid_task_input: $output"
+  echo "$output" | jq -e '.message | test("destroy_host_dir")' >/dev/null || fail "expected the message to name destroy_host_dir: $output"
+}
+
 @test "a bad storage chown reports a validate_problem a wrapper can branch on" {
   cd "$BATS_TEST_TMPDIR"
   cat >storage.json <<'EOF'

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -7,11 +7,14 @@ setup() {
   docket_build
   dokku_clean_app docket-test-plan
   dokku_clean_storage_entry docket-test-plan-data
+  dokku_clean_storage_entry docket-test-plan-hostdir
 }
 
 teardown() {
   dokku_clean_app docket-test-plan
   dokku_clean_storage_entry docket-test-plan-data
+  dokku_clean_storage_entry docket-test-plan-hostdir
+  rm -rf /var/lib/dokku/data/storage/docket-test-plan-hostdir
 }
 
 @test "docket plan reports drift on a missing app" {
@@ -146,6 +149,127 @@ EOF
   assert_success
   assert_output --partial "[ok]"
   assert_output --partial "0 would change"
+}
+
+@test "docket plan reports drift when a storage entry's mode changes" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-data
+      dokku_storage_entry:
+        name: docket-test-plan-data
+        mode: "0750"
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "0 would change"
+
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-data
+      dokku_storage_entry:
+        name: docket-test-plan-data
+        mode: "0777"
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[~]"
+  assert_output --partial "set mode=0777"
+  assert_output --partial "1 would change"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+
+  # The converge re-runs the chmod on the directory rather than only
+  # recording a new value, which is the whole point of routing it through
+  # storage:set.
+  run stat -c '%a' /var/lib/dokku/data/storage/docket-test-plan-data
+  assert_success
+  assert_output "777"
+
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[ok]"
+  assert_output --partial "0 would change"
+}
+
+@test "docket plan settles on a three digit storage entry mode" {
+  # dokku records 0755 whether the recipe wrote 755 or 0755, so a recipe
+  # naming three digits has to read as already applied on the second run.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-data
+      dokku_storage_entry:
+        name: docket-test-plan-data
+        mode: "755"
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "0 would change"
+}
+
+@test "docket apply removes the host directory when a storage entry asks for it" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-hostdir
+      dokku_storage_entry:
+        name: docket-test-plan-hostdir
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run test -d /var/lib/dokku/data/storage/docket-test-plan-hostdir
+  assert_success
+
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: remove docket-test-plan-hostdir
+      dokku_storage_entry:
+        name: docket-test-plan-hostdir
+        destroy_host_dir: true
+        state: absent
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[-]"
+  assert_output --partial "and its host directory /var/lib/dokku/data/storage/docket-test-plan-hostdir"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run test -e /var/lib/dokku/data/storage/docket-test-plan-hostdir
+  assert_failure
+}
+
+@test "docket apply leaves the host directory when a storage entry does not ask" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan-hostdir
+      dokku_storage_entry:
+        name: docket-test-plan-hostdir
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: remove docket-test-plan-hostdir
+      dokku_storage_entry:
+        name: docket-test-plan-hostdir
+        state: absent
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  refute_output --partial "and its host directory"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run test -d /var/lib/dokku/data/storage/docket-test-plan-hostdir
+  assert_success
 }
 
 @test "docket plan errors on a storage entry attribute dokku cannot change" {

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -337,6 +337,65 @@ EOF
   assert_output --partial "dokku reads an empty value as a delete"
 }
 
+@test "docket validate exits 1 on a storage entry mode that is not octal" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_storage_entry:
+        name: docket-test-validate-data
+        mode: "0888"
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'mode' must be a 3 or 4 digit octal directory mode"
+}
+
+@test "docket validate exits 1 on a storage entry mode under the k3s scheduler" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_storage_entry:
+        name: docket-test-validate-data
+        scheduler: k3s
+        size: 2Gi
+        mode: "0777"
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'mode' must not be set for scheduler 'k3s'"
+}
+
+@test "docket validate exits 1 on destroy_host_dir outside state absent" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_storage_entry:
+        name: docket-test-validate-data
+        destroy_host_dir: true
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'destroy_host_dir' must not be set for state 'present'"
+}
+
+@test "docket validate accepts an unquoted octal storage entry mode" {
+  # A YAML scalar reaches the string field verbatim, so 0755 is the mode the
+  # recipe wrote rather than a number YAML has reinterpreted as decimal.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_storage_entry:
+        name: docket-test-validate-data
+        mode: 0755
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+}
+
 @test "docket validate exits 1 on a scheduler-k3s profile name too long for its helm release (#482)" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
dokku 0.38.27 added `storage:create --mode`, `storage:set <name> mode <value>`, and `storage:destroy --destroy-host-dir`, so the two pieces of `ansible-dokku`'s `dokku_storage` that `docs/ansible-dokku.md` said stay in the wrapper no longer have to. `mode` is a docker-local attribute that converges the way `chown` does, re-running the chmod on the host directory rather than only recording a value, and it is recorded in its 4 digit form so a recipe writing `755` settles against the `0755` dokku stores. `destroy_host_dir` rides with `state: absent` and is refused anywhere else; `docket plan` names the host directory it removes, including when the entry's own `reclaim_policy` is what removes it. Decoding `mode` also closes the export gap, so an exported entry reproduces its directory's permissions instead of landing at dokku's default.

Closes #480.