### PR TITLE
fix: mask the play names in the --play hint

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -234,11 +234,18 @@ func (c *ApplyCommand) Run(args []string) int {
 	// declared inputs the surviving play's when: depends on.
 	fileLevelKeys := tasks.FileLevelInputNames(plays)
 
-	plays, err = filterPlaysByName(plays, c.play)
+	selected, err := filterPlaysByName(plays, c.play)
 	if err != nil {
+		// The hint names every play in the file, so a value any of their tasks
+		// declares sensitive is in scope for this message - unlike the filtered
+		// collection below, which deliberately leaves out a play --play
+		// excluded. Registering the whole file costs nothing here: this branch
+		// prints one line and returns.
+		subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 		c.Ui.Error(err.Error())
 		return 1
 	}
+	plays = selected
 
 	// Task-declared sensitive values join the input-level ones registered
 	// above, ahead of anything that renders a task name. Both branches below
@@ -246,7 +253,9 @@ func (c *ApplyCommand) Run(args []string) int {
 	// --start-at-task hint lists every available name, and --list-tasks
 	// renders the whole resolved plan. Collecting from the filtered play
 	// list rather than the whole file keeps a value that is only secret in a
-	// play --play excluded from masking output it never appears in.
+	// play --play excluded from masking output it never appears in. The
+	// unmatched --play branch above is the one place that collects from the
+	// whole file, and says why.
 	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if c.startAtTask != "" {
@@ -895,6 +904,43 @@ func formatStartAtTaskNames(plays []*tasks.Play) string {
 	return strings.Join(quoted, ", ")
 }
 
+// formatAvailablePlayNames builds the "available plays: ..." hint for an
+// unmatched --play error. Names render in source order, quoted so the user can
+// copy one verbatim back onto the CLI.
+//
+// Each name is masked before it is quoted, for the reason
+// formatStartAtTaskNames gives: `%q` escapes what it wraps, so masking the
+// finished message would be matching a registered literal against text that
+// carries the secret escaped (#477).
+func formatAvailablePlayNames(plays []*tasks.Play) string {
+	quoted := make([]string, 0, len(plays))
+	for _, play := range plays {
+		if play == nil {
+			continue
+		}
+		quoted = append(quoted, fmt.Sprintf("%q", subprocess.MaskString(play.Name)))
+	}
+	if len(quoted) == 0 {
+		return "(none)"
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// unknownPlayError is what filterPlaysByName returns for an unmatched --play.
+// It formats lazily rather than at construction so the caller can finish
+// populating the mask registry with the recipe's task-declared sensitive
+// values first: those are collected from the play list only after the filter
+// runs, and a message built eagerly would already have missed them (#477).
+type unknownPlayError struct {
+	target string
+	plays  []*tasks.Play
+}
+
+func (e *unknownPlayError) Error() string {
+	return fmt.Sprintf("--play %q: no play with that name; available plays: %s",
+		subprocess.MaskString(e.target), formatAvailablePlayNames(e.plays))
+}
+
 // filterPlaysByName narrows plays to the single play whose Name matches
 // target. An empty target returns plays unchanged. An unmatched target
 // returns an error so the user sees a clear "no such play" diagnostic
@@ -904,15 +950,11 @@ func filterPlaysByName(plays []*tasks.Play, target string) ([]*tasks.Play, error
 		return plays, nil
 	}
 	for _, play := range plays {
-		if play.Name == target {
+		if play != nil && play.Name == target {
 			return []*tasks.Play{play}, nil
 		}
 	}
-	names := make([]string, 0, len(plays))
-	for _, play := range plays {
-		names = append(names, fmt.Sprintf("%q", play.Name))
-	}
-	return nil, fmt.Errorf("--play %q: no play with that name; available plays: %v", target, names)
+	return nil, &unknownPlayError{target: target, plays: plays}
 }
 
 // newEmitter constructs the EventEmitter for this run. --json builds a

--- a/commands/apply_test.go
+++ b/commands/apply_test.go
@@ -136,6 +136,16 @@ func TestFilterPlaysByName(t *testing.T) {
 			t.Errorf("error missing %q\nfull: %v", want, err)
 		}
 	}
+
+	// An empty recipe has no name to suggest, so the hint says so rather
+	// than trailing off after the colon.
+	_, err = filterPlaysByName(nil, "missing")
+	if err == nil {
+		t.Fatal("expected error for unknown play in an empty list")
+	}
+	if !strings.Contains(err.Error(), "available plays: (none)") {
+		t.Errorf("expected the (none) hint\nfull: %v", err)
+	}
 }
 
 func playNames(plays []*tasks.Play) []string {

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -224,18 +224,26 @@ func (c *PlanCommand) Run(args []string) int {
 	// declared inputs the surviving play's when: depends on.
 	fileLevelKeys := tasks.FileLevelInputNames(plays)
 
-	plays, err = filterPlaysByName(plays, c.play)
+	selected, err := filterPlaysByName(plays, c.play)
 	if err != nil {
+		// The hint names every play in the file, so a value any of their tasks
+		// declares sensitive is in scope for this message - unlike the filtered
+		// collection below, which deliberately leaves out a play --play
+		// excluded. Registering the whole file costs nothing here: this branch
+		// prints one line and returns.
+		subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 		c.Ui.Error(err.Error())
 		return 1
 	}
+	plays = selected
 
 	// Task-declared sensitive values join the input-level ones registered
 	// above, ahead of the --list-tasks branch below: it renders the whole
 	// resolved plan and returns without reaching the run loop. Collecting
 	// from the filtered play list rather than the whole file keeps a value
 	// that is only secret in a play --play excluded from masking output it
-	// never appears in.
+	// never appears in. The unmatched --play branch above is the one place
+	// that collects from the whole file, and says why.
 	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if c.listTasks {

--- a/commands/play_name_masking_test.go
+++ b/commands/play_name_masking_test.go
@@ -1,0 +1,160 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// play_name_masking_test.go covers #477: the "available plays" hint for an
+// unmatched --play was the one diagnostic on the apply and plan paths that
+// never masked. Unlike #473 and #475 the value is not transformed on its way
+// into the message - it is simply printed in the clear - so no registered
+// spelling reaches it and the hint has to mask each play name itself.
+//
+// Two leaks are covered. A sensitive *input* interpolated into a play name is
+// registered well before the filter runs, so masking the names is enough. A
+// *task-declared* value is not: it joins the registry only after the filter
+// narrows the play list, which is why the error path registers it from the
+// unfiltered list before the message renders.
+
+// playNameRecipe interpolates a sensitive input into the first play's name and
+// keeps a second, unrelated play so the hint has more than one name to list.
+const playNameRecipe = `---
+- name: "play-{{ .secret_value }}"
+  inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_app: { app: api }
+- name: keepzzz
+  tasks:
+    - dokku_app: { app: worker }
+`
+
+// playNameSecret is the flag value the input cases pass. The `zzz` suffix
+// keeps it from colliding with anything docket prints of its own.
+const playNameSecret = "playleakzzz"
+
+func TestApplyPlayHintMasksSensitiveInputInPlayName(t *testing.T) {
+	path := writeTasksFile(t, playNameRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+playNameSecret, "--play", "nozzz")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stderr, playNameSecret) {
+		t.Errorf("the --play hint leaked the sensitive input; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, `"play-***"`) {
+		t.Errorf("expected a masked play name in the hint; got:\n%s", stderr)
+	}
+}
+
+func TestPlanPlayHintMasksSensitiveInputInPlayName(t *testing.T) {
+	path := writeTasksFile(t, playNameRecipe)
+
+	stdout, stderr, exit := runPlan(t, path, "--secret_value="+playNameSecret, "--play", "nozzz")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stderr, playNameSecret) {
+		t.Errorf("the plan --play hint leaked the sensitive input; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, `"play-***"`) {
+		t.Errorf("expected a masked play name in the hint; got:\n%s", stderr)
+	}
+}
+
+// TestPlayHintLeavesNonSensitivePlayNamesAlone is the boundary: the second
+// play in the recipe carries no secret and must still print in full, so the
+// fix cannot be passed by masking the whole message.
+func TestPlayHintLeavesNonSensitivePlayNamesAlone(t *testing.T) {
+	path := writeTasksFile(t, playNameRecipe)
+
+	stdout, stderr, exit := runApply(t, path, "--secret_value="+playNameSecret, "--play", "nozzz")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stderr, `"keepzzz"`) {
+		t.Errorf("expected the non-sensitive play name to print in full; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, `--play "nozzz"`) {
+		t.Errorf("expected the unmatched target quoted back; got:\n%s", stderr)
+	}
+}
+
+// TestPlayHintMasksQuoteBearingSensitivePlayName pins the quoting order. The
+// hint renders each name through `%q`, so a secret carrying a double quote
+// reaches the message escaped; masking each name before quoting it means the
+// hint never depends on the escaped spelling being registered too.
+func TestPlayHintMasksQuoteBearingSensitivePlayName(t *testing.T) {
+	path := writeTasksFile(t, `---
+- name: "play-{{ .secret_value | dq }}"
+  inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_app: { app: api }
+`)
+
+	stdout, stderr, exit := runApply(t, path, `--secret_value=playquotedzzz"x`, "--play", "nozzz")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stderr, "playquotedzzz") {
+		t.Errorf("the --play hint leaked the quote-bearing sensitive input; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, `"play-***"`) {
+		t.Errorf("expected a masked play name in the hint; got:\n%s", stderr)
+	}
+}
+
+// TestApplyPlayHintMasksTaskDeclaredSecretInPlayName is the ordering half of
+// the fix. Nothing here is a sensitive input: dokku_config declares its whole
+// `config:` map sensitive, so the value joins the registry through the task
+// walk - which the filter used to run ahead of. The sibling of
+// TestApplyStartAtTaskUnknownMasksTaskDeclaredSecret, which is the same leak
+// on the --start-at-task hint (#455).
+func TestApplyPlayHintMasksTaskDeclaredSecretInPlayName(t *testing.T) {
+	path := writeTasksFile(t, `---
+- name: play-taskdeclaredzzz
+  tasks:
+    - name: configure api
+      dokku_config:
+        app: api
+        config:
+          TOKEN: taskdeclaredzzz
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--play", "nozzz")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stderr, "taskdeclaredzzz") {
+		t.Errorf("the --play hint leaked a task-declared sensitive value; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, `"play-***"`) {
+		t.Errorf("expected a masked play name in the hint; got:\n%s", stderr)
+	}
+}
+
+func TestPlanPlayHintMasksTaskDeclaredSecretInPlayName(t *testing.T) {
+	path := writeTasksFile(t, `---
+- name: play-taskdeclaredzzz
+  tasks:
+    - name: configure api
+      dokku_config:
+        app: api
+        config:
+          TOKEN: taskdeclaredzzz
+`)
+
+	stdout, stderr, exit := runPlan(t, path, "--play", "nozzz")
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stderr, "taskdeclaredzzz") {
+		t.Errorf("the plan --play hint leaked a task-declared sensitive value; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, `"play-***"`) {
+		t.Errorf("expected a masked play name in the hint; got:\n%s", stderr)
+	}
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -399,9 +399,11 @@ With `--json`, the same information is a `probe` field (`unsupported` or `partia
 Sensitive values are masked in the listing exactly as they are in a run. A task name, play name,
 tag, `when:` predicate, or loop item that interpolated a `sensitive: true` input or a task field
 tagged `sensitive:"true"` renders as `***` on both the human and the `--json` path, so the listing
-is safe to paste into a ticket or a CI log. `--start-at-task` still matches on the real name, which
-means a name masked down to `***` cannot be copied out of the listing and used verbatim - write an
-explicit `name:` on any task you need to resume at.
+is safe to paste into a ticket or a CI log. The hints an unmatched `--play` or `--start-at-task`
+prints - each of which lists the names it could have matched - are masked the same way.
+`--start-at-task` still matches on the real name, which means a name masked down to `***` cannot be
+copied out of the listing and used verbatim - write an explicit `name:` on any task you need to
+resume at.
 
 `--start-at-task <name>` takes an exact task `name:`. Earlier tasks render as `[skipped]` with a
 `(before --start-at-task)` reason and do not run; the matched task and everything after it run:

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -146,6 +146,11 @@ docket plan  --tasks tasks.yml --play api --tags deploy
 to one play, then the tag filter applies to the tasks inside it. An unknown play name produces an
 error listing the available plays.
 
+Those listed names are masked like every other name docket prints, so a play named after a
+`sensitive: true` input is safe to paste into a ticket. `--play` still matches on the real name,
+which means a name that masks down to `***` cannot be copied out of the error and used verbatim -
+give any play you need to select by name a spelling that carries no secret.
+
 ### How a play's `when` is evaluated
 
 A play-level `when:` is checked against the file-level variables only: file-level input defaults,

--- a/tests/bats/plays.bats
+++ b/tests/bats/plays.bats
@@ -109,6 +109,67 @@ EOF
   assert_output --partial '"second"'
 }
 
+@test "plays: --play hint masks a sensitive input in a play name" {
+  # #477: the hint listed every play's name in the clear, so a name that
+  # interpolated a sensitive input leaked. Nothing here contacts the server -
+  # the filter runs and returns before any dokku command.
+  write_tasks_file <<'EOF'
+---
+- name: "play-{{ .secret_value }}"
+  inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_app:
+        app: docket-test-playfilter-first
+- name: keepzzz
+  tasks:
+    - dokku_app:
+        app: docket-test-playfilter-second
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=playleakzzz --play missing
+  assert_failure
+  refute_output --partial "playleakzzz"
+  assert_output --partial '"play-***"'
+  # A play name carrying no secret still prints in full.
+  assert_output --partial '"keepzzz"'
+}
+
+@test "plays: plan --play hint masks a sensitive input in a play name" {
+  write_tasks_file <<'EOF'
+---
+- name: "play-{{ .secret_value }}"
+  inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - dokku_app:
+        app: docket-test-playfilter-first
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --secret_value=playleakzzz --play missing
+  assert_failure
+  refute_output --partial "playleakzzz"
+  assert_output --partial '"play-***"'
+}
+
+@test "plays: --play hint masks a task-declared secret in a play name" {
+  # The task-declared values join the mask registry only after the --play
+  # filter narrows the play list, so the hint registers them from the whole
+  # file before it renders (#477).
+  write_tasks_file <<'EOF'
+---
+- name: play-taskdeclaredzzz
+  tasks:
+    - name: configure the app
+      dokku_config:
+        app: docket-test-playfilter-first
+        config:
+          TOKEN: taskdeclaredzzz
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --play missing
+  assert_failure
+  refute_output --partial "taskdeclaredzzz"
+  assert_output --partial '"play-***"'
+}
+
 @test "plays: --play composes with --tags to filter tasks within the play" {
   require_dokku
   write_tasks_file <<EOF


### PR DESCRIPTION
The hint an unmatched `--play` prints listed every play's name in the clear, so a play name that interpolated a `sensitive: true` input, or that shared text with a task field tagged `sensitive:"true"`, leaked on both the apply and plan paths. It now masks the names it lists, and separates them with commas to match the `--start-at-task` and `validate --strict` hints.

The export path has an unmasked diagnostic of a similar shape, but nothing populates the mask registry there at all, so it is a separate problem and is tracked as #488.

Fixes #477.
