### PR TITLE
fix: mask the secrets docket export reads off the server

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -187,8 +187,24 @@ func (c *ExportCommand) Run(args []string) int {
 		Redact:    c.redact,
 		Inline:    toStdout,
 	})
+	// Export is the one server-reading command with no recipe to collect a
+	// sensitive set from before the run: the values it must mask are the ones
+	// its own exporters just read back. Registered here, ahead of the failure
+	// below as well as the warnings, because the global play is exported
+	// before the app list is read - so a run that dies on apps:list can
+	// already be holding a secret (#488).
+	//
+	// What masks from here on is every diagnostic built from what the server
+	// returned: the warnings, this failure, and the marshal errors further
+	// down. What deliberately does not is the text built from the user's own
+	// arguments - the --app names and --resource addresses reported missing,
+	// and the output paths - because a name masked down to *** would hide the
+	// typo the message exists to report.
+	subprocess.SetGlobalSensitive(res.SensitiveValues())
+	defer subprocess.SetGlobalSensitive(nil)
+
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("export failed: %v", err))
+		c.Ui.Error(fmt.Sprintf("export failed: %v", subprocess.MaskString(err.Error())))
 		return 1
 	}
 	for _, w := range res.Report.Warnings {
@@ -198,7 +214,8 @@ func (c *ExportCommand) Run(args []string) int {
 	// A nonexistent --app must not silently produce an empty recipe (which the
 	// loader then rejects). When nothing was collected, abort without writing;
 	// otherwise the existing apps are exported and the missing names are reported
-	// with a non-zero exit at the end (#346).
+	// with a non-zero exit at the end (#346). The names print unmasked here for
+	// the reason exitForMissingApps gives.
 	if res.PlayCount() == 0 {
 		switch {
 		case len(res.Report.MissingApps) > 0:
@@ -213,7 +230,7 @@ func (c *ExportCommand) Run(args []string) int {
 
 	recipeBytes, err := res.MarshalRecipe(recipeFormat)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("marshal recipe: %v", err))
+		c.Ui.Error(fmt.Sprintf("marshal recipe: %v", subprocess.MaskString(err.Error())))
 		return 1
 	}
 
@@ -274,7 +291,7 @@ func (c *ExportCommand) Run(args []string) int {
 	if writeVars {
 		varsBytes, err := res.MarshalVars(varsFormat)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("marshal vars: %v", err))
+			c.Ui.Error(fmt.Sprintf("marshal vars: %v", subprocess.MaskString(err.Error())))
 			return 1
 		}
 		if err := os.WriteFile(varsOutput, varsBytes, 0o644); err != nil {
@@ -312,6 +329,11 @@ func (c *ExportCommand) Run(args []string) int {
 // exitForMissingApps reports any --app names or --resource addresses that were
 // not found on the server and returns a non-zero exit code, so a typo is
 // surfaced even though what does exist was still exported (#346).
+//
+// The names print unmasked, unlike the warnings Run masks above. They are the
+// user's own arguments echoed back rather than anything the server returned,
+// and the whole message is "you asked for a name that is not there" - which a
+// name masked down to *** would not say (#488).
 func (c *ExportCommand) exitForMissingApps(res *tasks.ExportResult) int {
 	missing := append(append([]string(nil), res.Report.MissingApps...), res.Report.MissingResources...)
 	if len(missing) == 0 {

--- a/commands/export_masking_test.go
+++ b/commands/export_masking_test.go
@@ -1,0 +1,179 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// failingExecRunner answers from responses like fakeExecRunner, except that
+// one command fails with err. fakeExecRunner can only return canned stdout, and
+// the diagnostics this file is about are built from an exporter's error.
+func failingExecRunner(responses map[string]string, failing string, err error) func(context.Context, subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	return func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		key := strings.Join(in.Args, " ")
+		if key == failing {
+			return subprocess.ExecCommandResponse{}, err
+		}
+		return subprocess.ExecCommandResponse{Stdout: responses[key]}, nil
+	}
+}
+
+// TestExportCommandWarningMasksAConfigValue is the point of #488: the mask on
+// the warning loop could never fire, because nothing on the export path ever
+// populated the registry.
+//
+// dokku_app_lock sits directly ahead of dokku_config in appExportOrder, so the
+// warning is appended before the value it quotes has been read at all. That is
+// deliberate: it pins that masking happens when the warning is printed, after
+// the whole read, rather than when it is appended.
+func TestExportCommandWarningMasksAConfigValue(t *testing.T) {
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	defer subprocess.SetExecRunner(failingExecRunner(
+		exportCommandFixture(),
+		"--quiet apps:locked web",
+		errors.New(`apps:locked: unreadable lock state "abc123"`),
+	))()
+	t.Chdir(t.TempDir())
+
+	c, ui := newExportCommand()
+	if code := c.Run(nil); code != 0 {
+		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
+	}
+
+	warnings := ui.ErrorWriter.String()
+	var line string
+	for _, l := range strings.Split(warnings, "\n") {
+		if strings.Contains(l, "web: dokku_app_lock") {
+			line = l
+			break
+		}
+	}
+	if line == "" {
+		t.Fatalf("expected the app_lock export warning, got: %s", warnings)
+	}
+	if strings.Contains(line, "abc123") {
+		t.Errorf("warning leaked the config value: %s", line)
+	}
+	if !strings.Contains(line, `unreadable lock state "***"`) {
+		t.Errorf("warning should carry the masked value, got: %s", line)
+	}
+}
+
+// TestExportCommandRedactWarningMasksAConfigValue is the case that rules out
+// registering from res.Vars once the export is over: --redact writes a
+// placeholder there, so the vars map holds nothing to mask with - while the
+// real value was still read off the server and is still in the warning.
+func TestExportCommandRedactWarningMasksAConfigValue(t *testing.T) {
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	defer subprocess.SetExecRunner(failingExecRunner(
+		exportCommandFixture(),
+		"--quiet apps:locked web",
+		errors.New(`apps:locked: unreadable lock state "abc123"`),
+	))()
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	c, ui := newExportCommand()
+	if code := c.Run([]string{"--redact"}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
+	}
+
+	vars, err := os.ReadFile(filepath.Join(dir, "tasks.vars.yml"))
+	if err != nil {
+		t.Fatalf("read vars: %v", err)
+	}
+	if strings.Contains(string(vars), "abc123") {
+		t.Fatalf("--redact must not write the value anywhere:\n%s", vars)
+	}
+	if warnings := ui.ErrorWriter.String(); strings.Contains(warnings, "abc123") {
+		t.Errorf("warning leaked a value --redact wrote nowhere: %s", warnings)
+	}
+}
+
+// TestExportCommandFailureMasksASecretReadBeforeTheAppList pins why
+// ExportRecipe hands back its partial result on error. The global play is
+// exported before apps:list runs, so by the time the failure is printed the
+// export is already holding the cluster token it read.
+func TestExportCommandFailureMasksASecretReadBeforeTheAppList(t *testing.T) {
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	defer subprocess.SetExecRunner(failingExecRunner(
+		map[string]string{
+			"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken"}`,
+		},
+		"--quiet apps:list",
+		errors.New("apps:list: server rejected cluster token s3cr3ttoken"),
+	))()
+	t.Chdir(t.TempDir())
+
+	c, ui := newExportCommand()
+	if code := c.Run(nil); code != 1 {
+		t.Fatalf("Run exit = %d, want 1: %s", code, ui.ErrorWriter.String())
+	}
+
+	out := ui.ErrorWriter.String()
+	if !strings.Contains(out, "export failed:") {
+		t.Fatalf("expected the export failure, got: %s", out)
+	}
+	if strings.Contains(out, "s3cr3ttoken") {
+		t.Errorf("failure leaked the cluster token read by the global play: %s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("failure should carry the mask placeholder, got: %s", out)
+	}
+}
+
+// TestExportCommandMaskingLeavesTheVarsFileInTheClear pins the invariant that
+// makes registering these values safe at all: masking is display-only. The
+// recipe and the vars-file are written straight to disk, never through the
+// masked Ui, so an export whose every config value is registered still writes
+// a vars-file the operator can apply.
+func TestExportCommandMaskingLeavesTheVarsFileInTheClear(t *testing.T) {
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	c, ui := newExportCommand()
+	if code := c.Run(nil); code != 0 {
+		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
+	}
+
+	vars, err := os.ReadFile(filepath.Join(dir, "tasks.vars.yml"))
+	if err != nil {
+		t.Fatalf("read vars: %v", err)
+	}
+	if !strings.Contains(string(vars), "abc123") {
+		t.Errorf("vars-file must hold the real value, got:\n%s", vars)
+	}
+	if strings.Contains(string(vars), "***") {
+		t.Errorf("vars-file must never be masked, got:\n%s", vars)
+	}
+}
+
+// TestExportCommandMissingAppNameStaysReadable is the deliberate exception. An
+// --app name is the user's own argument echoed back, and the message exists to
+// point at the typo - which "*** not found on server" would not do. It stays
+// unmasked even when it collides with a value the export registered.
+func TestExportCommandMissingAppNameStaysReadable(t *testing.T) {
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	responses := exportCommandFixture()
+	responses["--quiet config:export --format json web"] = `{"API_KEY":"nope-app"}`
+	defer subprocess.SetExecRunner(fakeExecRunner(responses))()
+	t.Chdir(t.TempDir())
+
+	c, ui := newExportCommand()
+	if code := c.Run([]string{"--app", "web", "--app", "nope-app"}); code != 1 {
+		t.Fatalf("Run exit = %d, want 1: %s", code, ui.ErrorWriter.String())
+	}
+
+	out := ui.ErrorWriter.String()
+	if !strings.Contains(out, "nope-app not found on server") {
+		t.Errorf("the missing --app name must stay readable, got: %s", out)
+	}
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -515,6 +515,17 @@ whose name dokku accepted but helm cannot turn into a release name, for example.
 those would fail `docket validate` for the whole recipe rather than for the single task, so the
 warning names the resource and what to do about it instead.
 
+Those warnings, and the failure messages beside them, mask the secrets the export read off the
+server - every `config` value, every field a task marks sensitive, and every property in a family
+declared sensitive - so an export log is safe to paste into a ticket even when an exporter's error
+quotes the value it choked on. The recipe and the vars-file are written straight to their file (or
+to stdout) rather than through that masking, which is the point: the pair has to carry the real
+values to be appliable. Two things are deliberately left readable: an `--app` name or `--resource`
+address reported as not found on the server, and the output paths, both of which are your own
+arguments echoed back at you - a name masked down to `***` would hide the typo the message exists
+to report. The one gap is a value export never managed to read: if an exporter fails while parsing
+it, nothing ever learned it was a secret, and the error text is the only place it appears.
+
 ## docket schema
 
 `docket schema` prints a machine-readable description of every task type docket registers - the

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -63,7 +63,9 @@ server, skip this and use it directly.
 Some state cannot be read back and is left out with a warning - notably write-only credentials
 (`dokku_git_auth`, `dokku_registry_auth`, and datastore backup credentials), datastore service data,
 and service properties (`dokku_service_property`), which you add by hand. Each task's
-[reference page](tasks/README.md) has an Export support section noting its limits.
+[reference page](tasks/README.md) has an Export support section noting its limits. Those warnings
+mask the secrets the export read, so the log of a migration run is safe to paste into a ticket even
+though the pair of files it wrote is not.
 
 A scheduler-k3s node profile is left out for a different reason: dokku accepts a profile name that
 is too long or carries uppercase, but it cannot turn the derived node-sysctls helm release name into

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -203,6 +203,13 @@ form instead of logging: `ExportAppReport(app string, warn func(msg string))` or
 `ExportReport.Warnings`, so the message is rendered and masked like every other export diagnostic
 and reaches the operator with the run it belongs to.
 
+The set those diagnostics mask against comes from the bodies the exporters return: as each one is
+processed, whatever it declares sensitive - a `sensitive:"true"` field, a `SensitiveValues()`
+override, or a property in a family marked `Sensitive` - is collected for masking, in every mode,
+including `--redact`, where the value is written nowhere but was still read off the server. A task
+that declares its secrets properly therefore needs nothing further to keep them out of its own
+export warnings.
+
 Implement the reporting form *alongside* the plain one, never instead of it. The engine asserts
 `AppExporter` / `GlobalExporter` before it looks for the reporter, so a task carrying only the
 reporting method exports nothing at all; `TestExportReportersAlsoImplementTheBaseExporter` catches

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -237,15 +237,57 @@ type ExportResult struct {
 
 	usedVarNames map[string]bool
 
+	// sensitive collects the literal values this run read off the server that
+	// must be masked in user-facing output, in read order. See noteSensitive.
+	sensitive []string
+
 	// filter narrows emission to the --resource addresses. nil for an
 	// unrestricted export, where every check it performs answers "keep".
 	filter *resourceFilter
+}
+
+// noteSensitive records values this export has identified as credential
+// material, for the caller to hand to the mask registry before it prints
+// anything (commands/export.go does, right after ExportRecipe returns).
+//
+// Export is the one server-reading command with no recipe to collect a
+// sensitive set from ahead of the run: the values it must mask are the ones
+// its own exporters just read back. They are collected here, as each body is
+// processed, rather than read out of res.Vars once the export is over, because
+// res.Vars is not the same set (#488):
+//
+//   - Under --redact the vars map holds a placeholder, not the value. The real
+//     value was still read off the server and can still reach a warning.
+//   - In inline mode nothing is lifted into the vars map at all, yet the
+//     warnings still print to the same stream.
+//
+// Collection is unconditional across modes for that reason. It costs the
+// export nothing: the recipe and the vars-file are written straight to their
+// file or to stdout, never through the masked Ui, so registering a value here
+// masks the diagnostics beside the export and never the export itself.
+//
+// Empties, duplicates, and the trimmed/escaped spellings of each value are
+// subprocess.cleanSensitive's job at registration time, so this only appends.
+func (res *ExportResult) noteSensitive(values ...string) {
+	res.sensitive = append(res.sensitive, values...)
+}
+
+// SensitiveValues returns the literal values this export read off the server
+// that must be masked in user-facing output. The caller registers them; the
+// slice is the result's own and must not be modified.
+func (res *ExportResult) SensitiveValues() []string {
+	return res.sensitive
 }
 
 // ExportRecipe reads the live Dokku server (via the current subprocess host)
 // and assembles a recipe describing it. It enumerates apps, runs every
 // registered AppExporter for each, lifts sensitive values into a vars map
 // (unless opts.Inline), and returns the result for the caller to marshal.
+//
+// The result is never nil, including on error: the global play is exported
+// before the app list is read, so a failure there still hands back what was
+// already collected - and with it the sensitive values the caller has to
+// register before it prints the failure (#488).
 func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 	res := &ExportResult{
 		Vars:         map[string]string{},
@@ -279,7 +321,7 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 
 	apps, err := listApps()
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	// A resource-driven run derives its app list from the addresses, so an app
 	// that does not exist is reported as the address the user actually typed
@@ -425,7 +467,19 @@ func (res *ExportResult) exportAppPlay(app string, opts ExportOptions) map[strin
 // processBody applies vars-extraction (file mode) or redaction (inline mode) to
 // a single task body and returns the possibly-rewritten body plus any input
 // declarations the recipe should carry for lifted values.
+//
+// Whatever the body declares sensitive is noted first, before any of the
+// lifters below decide where the value goes: processSensitiveScalars blanks
+// its copy under inline + --redact, so the original body is the only place the
+// real value survives. sensitiveValuesFromTask is the same collector
+// commands/apply.go runs over a parsed recipe, so export masks the set apply
+// masks for the same content - the sensitive:"true" fields plus the
+// SensitiveValues() overrides that reach the secrets living in a map or a
+// slice of structs (dokku_config, dokku_http_auth_user,
+// dokku_scheduler_k3s_autoscaling_auth). A per-property secret is not
+// expressible as a struct tag, so processPropertyValue notes that one itself.
 func (res *ExportResult) processBody(app string, body interface{}, opts ExportOptions) (interface{}, []map[string]interface{}) {
+	res.noteSensitive(sensitiveValuesFromTask(body)...)
 	switch b := body.(type) {
 	case ConfigTask:
 		return res.processConfig(app, b, opts)
@@ -466,6 +520,13 @@ func (res *ExportResult) processPropertyValue(app string, body interface{}, prop
 	if !sensitive || value == "" {
 		return body, nil
 	}
+	// Only the letsencrypt property task is built from SensitivePropertyFields,
+	// so for scheduler-k3s (the cluster token) and traefik (the dns-provider-*
+	// credentials) no struct tag says this value is a secret - the property
+	// family's PropertyKeys.Sensitive flag does, and processBody's tag walk
+	// cannot see it. Noted here for the same reason tasks/properties.go
+	// registers it at plan time (#488).
+	res.noteSensitive(value)
 	if opts.Inline {
 		if opts.Redact {
 			return rebuild(""), nil

--- a/tasks/export_masking_test.go
+++ b/tasks/export_masking_test.go
@@ -1,0 +1,156 @@
+package tasks
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// registeredSensitive reports whether the export collected want. It asserts on
+// ExportResult.SensitiveValues() rather than on the process-wide mask registry
+// because export does not populate that registry itself: commands/export.go
+// does, once, from this set (#488). Keeping the collection out of the global
+// also keeps every other ExportRecipe test in this package free of leftovers.
+func registeredSensitive(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func assertRegistered(t *testing.T, res *ExportResult, want string) {
+	t.Helper()
+	if !registeredSensitive(res.SensitiveValues(), want) {
+		t.Errorf("expected %q to be collected for masking, got %v", want, res.SensitiveValues())
+	}
+}
+
+func assertNotRegistered(t *testing.T, res *ExportResult, unwanted string) {
+	t.Helper()
+	if registeredSensitive(res.SensitiveValues(), unwanted) {
+		t.Errorf("%q is not a secret and must not be collected for masking, got %v", unwanted, res.SensitiveValues())
+	}
+}
+
+// TestExportRegistersConfigValues is the base case: every config value is an
+// opaque secret, so an export that reads one has something to mask by the time
+// it prints a warning. The base64 spelling comes along because that is how
+// dokku_config declares its own sensitive set, and it is the spelling
+// `config:set --encoded` puts on argv.
+func TestExportRegistersConfigValues(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	assertRegistered(t, res, "s3cr3t")
+	assertRegistered(t, res, base64.StdEncoding.EncodeToString([]byte("s3cr3t")))
+}
+
+// TestExportRedactStillRegistersTheRealValue is the case that makes reading
+// res.Vars after the fact wrong: --redact writes a placeholder there, but the
+// value was still read off the server and can still reach a warning.
+func TestExportRedactStillRegistersTheRealValue(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	res, err := ExportRecipe(ExportOptions{Redact: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if got, ok := res.Vars["app_one_SECRET_KEY"]; !ok || got != "" {
+		t.Fatalf("vars[app_one_SECRET_KEY] = %q (present %v), want a blanked placeholder", got, ok)
+	}
+	assertRegistered(t, res, "s3cr3t")
+}
+
+// TestExportInlineRegistersValuesItDoesNotLift is the other half: inline mode
+// lifts nothing into a vars map at all, yet its warnings print to the same
+// stream as everything else.
+func TestExportInlineRegistersValuesItDoesNotLift(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	res, err := ExportRecipe(ExportOptions{Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if res.HasVars() {
+		t.Fatalf("inline mode must lift nothing, got %v", res.Vars)
+	}
+	assertRegistered(t, res, "s3cr3t")
+}
+
+// TestExportRegistersSensitivePropertyValue covers the secret no struct tag
+// expresses: scheduler-k3s is built from PropertyFields, so only the property
+// family's Sensitive flag says the cluster token is credential material. Its
+// benign sibling in the same report is the boundary.
+func TestExportRegistersSensitivePropertyValue(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "",
+		"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken","global-ingress-class":"nginx-ingress"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	assertRegistered(t, res, "s3cr3ttoken")
+	assertNotRegistered(t, res, "nginx-ingress")
+}
+
+// TestExportRegistersHttpAuthHashes covers the secrets the tag walker cannot
+// reach on its own - they live in a slice of structs, so HttpAuthUserTask
+// declares them through SensitiveValues(). Inline mode is the interesting one:
+// the hash stays in the streamed body and is lifted nowhere.
+func TestExportRegistersHttpAuthHashes(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+
+	res, err := ExportRecipe(ExportOptions{Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	assertRegistered(t, res, exportHttpAuthHash)
+}
+
+// TestExportRegistersEveryLetsencryptPropertyValue pins deliberate
+// over-registration. letsencrypt is the one property task built from
+// SensitivePropertyFields, so its `value` carries `sensitive:"true"` and a
+// benign property registers alongside the credential - even though export
+// leaves that one inline rather than lifting it
+// (TestExportLetsencryptBenignPropertyNotLifted). That is exactly what apply
+// masks for the same task, and over-masking is the safe direction.
+func TestExportRegistersEveryLetsencryptPropertyValue(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                            "web",
+		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"tok3n"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	assertRegistered(t, res, "tok3n")
+	assertRegistered(t, res, "admin@example.com")
+}
+
+// TestExportRegistersNothingForBenignProperties is the boundary the rest of the
+// file leans on: a property plugin built from PropertyFields whose family is
+// not Sensitive contributes nothing, so an export of a server holding no
+// secrets masks nothing and its diagnostics read exactly as they did before.
+func TestExportRegistersNothingForBenignProperties(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                         "",
+		"--quiet git:report --global --format json": `{"global-deploy-branch":"main","global-archive-max-files":"100","global-keep-git-dir":""}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if got := res.SensitiveValues(); len(got) != 0 {
+		t.Errorf("a benign export must collect nothing, got %v", got)
+	}
+}

--- a/tasks/sensitive.go
+++ b/tasks/sensitive.go
@@ -95,7 +95,14 @@ func registerSensitiveMapValues(m map[string]string) {
 }
 
 // sensitiveValuesFromTask returns the masked-value set for a single task.
-func sensitiveValuesFromTask(t Task) []string {
+//
+// It takes interface{} rather than Task because docket export walks task
+// bodies an exporter returns as values, while RegisteredTasks holds pointers
+// (RegisterTask(&ConfigTask{})). Requiring the interface would silently
+// contribute nothing for a task whose Task methods happen to have a pointer
+// receiver - the wrong failure mode for a masking collector. Both steps below
+// work on any value.
+func sensitiveValuesFromTask(t interface{}) []string {
 	var out []string
 	if override, ok := t.(SensitiveOverride); ok {
 		out = append(out, override.SensitiveValues()...)

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -248,3 +248,42 @@ EOF
   assert_success
   refute_output --partial "literal-value-zzz"
 }
+
+# docket export is the one server-reading command with no recipe to collect a
+# sensitive set from ahead of the run, so until #488 its mask registry was
+# empty for the whole run and the mask on its warnings could never fire. The
+# values it masks with are the ones its own exporters read back.
+@test "docket export masks a config value in an export warning (#488)" {
+  require_plugin http-auth
+  dokku apps:create docket-test-mask
+  # The app name doubles as a config value, because the one warning a real
+  # server reliably produces - the http-auth notice below - names the app and
+  # nothing else. Masking that name is masking a value read off the server.
+  dokku config:set --no-restart docket-test-mask APP_NAME=docket-test-mask
+  dokku http-auth:enable docket-test-mask maskuser maskpasszzz
+
+  # --output - has no vars-file to put the hashes in and --redact leaves
+  # nowhere to blank them to, so the export warns; --redact also means the
+  # config value is written nowhere at all, which is exactly the case that
+  # rules out reading the vars map for the values to mask with.
+  run "$(docket_bin)" export --app docket-test-mask --output - --redact
+  assert_success
+  assert_output --partial "warning: ***: http-auth hashes are redacted"
+  refute_output --partial "warning: docket-test-mask:"
+  # Masking is display-only: the streamed recipe still names the app.
+  assert_output --partial "name: docket-test-mask"
+}
+
+@test "docket export leaves a missing --app name readable (#488)" {
+  require_dokku
+  dokku apps:create docket-test-mask
+  dokku config:set --no-restart docket-test-mask MISSING=docket-missing-zzz
+  cd "$BATS_TEST_TMPDIR"
+
+  # The name is the user's own argument echoed back and the message exists to
+  # point at the typo, so it stays in the clear even though the export
+  # registered a config value spelled exactly the same way.
+  run "$(docket_bin)" export --app docket-test-mask --app docket-missing-zzz --output tasks.yml
+  assert_failure
+  assert_output --partial "docket-missing-zzz not found on server"
+}


### PR DESCRIPTION
The mask on `docket export`'s warnings could never fire, because nothing on the export path ever populated the mask registry: export has no recipe to collect one from, and the values it handles are the ones its own exporters read back. A warning built from an exporter error that quoted the value it failed to parse therefore printed that value in the clear. Export now collects what it reads as credential material - every `config` value, every field a task marks sensitive, and every property in a family declared sensitive - and registers it before the first diagnostic is printed, so the warnings, the export failure, and the marshal errors all mask, under `--redact` and on the streamed `--output -` path as well. `docs/writing-tasks.md` already promised a reporter's message was "rendered and masked like every other export diagnostic", so this is the code catching up with the documented contract.

The values are collected as each body is read rather than out of the vars map once the export is over, because the two are not the same set: `--redact` writes a placeholder into the vars map while the real value was still read off the server, and inline mode lifts nothing into it at all. Registering from the vars map would also come too late for the failure message, since the global play is exported before the app list is read.

An `--app` name or `--resource` address reported as not found on the server stays readable, along with the output paths. Those are the user's own arguments echoed back, and the whole point of the message is to name the typo, which `*** not found on server` would not do.

Two things found alongside this are tracked separately: the exported vars-file holds cleartext secrets at mode 0644 (#489), and `docs/inputs.md` never documents the `sensitive` input property (#490).

Fixes #488.
