### PR TITLE
fix: write the exported vars-file at mode 0600

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -165,10 +165,15 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
-	varsFileKeys, err := applyVarsFiles(c.arguments, flags, c.varsFiles)
+	varsFileKeys, varsWarnings, err := applyVarsFiles(c.arguments, flags, c.varsFiles)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
+	}
+	// Warned about on stderr in every mode, --json included: the JSON stream
+	// goes to stdout through the emitter, so this cannot land in it (#489).
+	for _, w := range varsWarnings {
+		c.Ui.Warn(w)
 	}
 
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)

--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -476,31 +477,38 @@ func coerceBool(value interface{}) (bool, error) {
 	return false, fmt.Errorf("expected bool, got %T", value)
 }
 
-// loadVarsFiles parses each path left-to-right and returns the merged flat
-// map plus a `key -> source path` index so unknown-key errors can name the
-// offending file. Later files override earlier files for the same key.
+// loadVarsFiles parses each path left-to-right and returns three views of the
+// result: the merged flat map, a `key -> source path` index so unknown-key
+// errors can name the offending file, and a `path -> declared keys` index.
+// Later files override earlier files for the same key, so the source index is
+// last-writer-wins - right for naming one file in an error, wrong for asking
+// which files a key lives in. varsFileWarnings needs the latter: a base file
+// whose sensitive key a later file overrides still holds that secret on disk
+// (#489).
 //
 // File format is detected by extension: `.json` parses as JSON, anything
 // else parses as YAML. The top-level document must be a string-keyed
 // mapping; lists, scalars, and non-string keys are rejected.
-func loadVarsFiles(paths []string) (map[string]interface{}, map[string]string, error) {
+func loadVarsFiles(paths []string) (map[string]interface{}, map[string]string, map[string][]string, error) {
 	merged := map[string]interface{}{}
 	sources := map[string]string{}
+	perFile := map[string][]string{}
 	for _, path := range paths {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, nil, fmt.Errorf("--vars-file %s: %v", path, err)
+			return nil, nil, nil, fmt.Errorf("--vars-file %s: %v", path, err)
 		}
 		one, err := parseVarsFile(path, data)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		for k, v := range one {
 			merged[k] = v
 			sources[k] = path
+			perFile[path] = append(perFile[path], k)
 		}
 	}
-	return merged, sources, nil
+	return merged, sources, perFile, nil
 }
 
 func parseVarsFile(path string, data []byte) (map[string]interface{}, error) {
@@ -563,18 +571,22 @@ func normaliseYAMLMap(in map[interface{}]interface{}) (map[string]interface{}, e
 // bit is set. Any unknown vars-file key is a hard error with a Levenshtein
 // suggestion against the registered input names.
 //
-// The returned map contains the input names this call wrote into the
+// The first returned map contains the input names this call wrote into the
 // argument set from a vars file. Callers union it with flags.Visit to
 // derive the full "user has overridden this key" set, which #208 needs so
-// per-play input defaults do not shadow user overrides.
-func applyVarsFiles(arguments map[string]*Argument, flags *flag.FlagSet, paths []string) (map[string]bool, error) {
+// per-play input defaults do not shadow user overrides. The second return is
+// the warnings from varsFileWarnings, which the caller prints; they are
+// warnings rather than a second error because the run is fine, the file's
+// mode is not.
+func applyVarsFiles(arguments map[string]*Argument, flags *flag.FlagSet, paths []string) (map[string]bool, []string, error) {
 	if len(paths) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
-	merged, sources, err := loadVarsFiles(paths)
+	merged, sources, perFile, err := loadVarsFiles(paths)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	warnings := varsFileWarnings(paths, perFile, arguments)
 
 	cliSet := map[string]bool{}
 	if flags != nil {
@@ -603,17 +615,77 @@ func applyVarsFiles(arguments map[string]*Argument, flags *flag.FlagSet, paths [
 			if suggestion != "" {
 				hint = fmt.Sprintf("; did you mean %q?", suggestion)
 			}
-			return nil, fmt.Errorf("unknown input %q in --vars-file %s%s", key, sources[key], hint)
+			return nil, nil, fmt.Errorf("unknown input %q in --vars-file %s%s", key, sources[key], hint)
 		}
 		if cliSet[key] {
 			continue
 		}
 		if err := arg.SetFromVarsFile(key, merged[key]); err != nil {
-			return nil, fmt.Errorf("--vars-file %s: %v", sources[key], err)
+			return nil, nil, fmt.Errorf("--vars-file %s: %v", sources[key], err)
 		}
 		applied[key] = true
 	}
-	return applied, nil
+	return applied, warnings, nil
+}
+
+// varsFileWarnings reports each --vars-file that carries a value for an input
+// the recipe declares sensitive and is readable by users other than its owner.
+//
+// The trigger is content, not mode alone. A vars file of ordinary settings -
+// an app name, a replica count - says nothing about secrets, and warning
+// about its mode would be noise on the ordinary per-environment file
+// docs/inputs.md recommends. A `sensitive: true` input is what makes a vars
+// file a secrets file, and an exported one is made of nothing else. This is
+// the reading end of #489: docket export writes its own half of the pair at
+// varsFileMode, but a file that arrived from somewhere docket did not control
+// can be anything.
+//
+// It stays a warning. The file is the user's, docket only reads it, and a
+// recipe that applies cleanly should not fail over the mode of an input file.
+func varsFileWarnings(paths []string, perFile map[string][]string, arguments map[string]*Argument) []string {
+	// Windows has no mode bits to read: os.FileMode.Perm synthesises 0666 or
+	// 0444 from the readonly attribute, so every file there would warn.
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	var out []string
+	seen := map[string]bool{}
+	for _, path := range paths {
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		if !holdsSensitiveInput(perFile[path], arguments) {
+			continue
+		}
+		info, err := os.Stat(path)
+		// A read error is not this function's to report - loadVarsFiles has
+		// already read the file successfully - and a fifo, a device, or a
+		// process substitution has no mode worth complaining about.
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		perm := info.Mode().Perm()
+		if perm&0o077 == 0 {
+			continue
+		}
+		out = append(out, fmt.Sprintf(
+			"warning: --vars-file %s holds sensitive input values and is readable by other users (mode %04o); chmod 600 %s",
+			path, perm, shellQuotePath(path)))
+	}
+	return out
+}
+
+// holdsSensitiveInput reports whether any of keys names an input the recipe
+// declared sensitive. A key with no registered Argument is on its way to the
+// unknown-input error and is not this check's business.
+func holdsSensitiveInput(keys []string, arguments map[string]*Argument) bool {
+	for _, key := range keys {
+		if arg, ok := arguments[key]; ok && arg.Sensitive {
+			return true
+		}
+	}
+	return false
 }
 
 // userSetKeys merges the set of input names the user has overridden via

--- a/commands/apply_args_test.go
+++ b/commands/apply_args_test.go
@@ -443,7 +443,7 @@ func TestLoadVarsFilesYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTempFile(t, dir, "vars.yml", "app: api\nreplicas: 3\ndebug: true\n")
 
-	merged, sources, err := loadVarsFiles([]string{path})
+	merged, sources, _, err := loadVarsFiles([]string{path})
 	if err != nil {
 		t.Fatalf("loadVarsFiles failed: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestLoadVarsFilesJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTempFile(t, dir, "vars.json", `{"app":"api","replicas":3,"debug":false}`)
 
-	merged, _, err := loadVarsFiles([]string{path})
+	merged, _, _, err := loadVarsFiles([]string{path})
 	if err != nil {
 		t.Fatalf("loadVarsFiles failed: %v", err)
 	}
@@ -483,7 +483,7 @@ func TestLoadVarsFilesJSON(t *testing.T) {
 }
 
 func TestLoadVarsFilesMissingFile(t *testing.T) {
-	_, _, err := loadVarsFiles([]string{"/nonexistent/path/vars.yml"})
+	_, _, _, err := loadVarsFiles([]string{"/nonexistent/path/vars.yml"})
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -496,7 +496,7 @@ func TestLoadVarsFilesNonMappingError(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTempFile(t, dir, "list.yml", "- one\n- two\n")
 
-	_, _, err := loadVarsFiles([]string{path})
+	_, _, _, err := loadVarsFiles([]string{path})
 	if err == nil {
 		t.Fatal("expected error for top-level list")
 	}
@@ -510,7 +510,7 @@ func TestLoadVarsFilesMultiFileLastWins(t *testing.T) {
 	a := writeTempFile(t, dir, "a.yml", "app: from-a\nshared: from-a\n")
 	b := writeTempFile(t, dir, "b.yml", "shared: from-b\nextra: only-b\n")
 
-	merged, sources, err := loadVarsFiles([]string{a, b})
+	merged, sources, _, err := loadVarsFiles([]string{a, b})
 	if err != nil {
 		t.Fatalf("loadVarsFiles failed: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestLoadVarsFilesEmptyYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTempFile(t, dir, "empty.yml", "")
 
-	merged, _, err := loadVarsFiles([]string{path})
+	merged, _, _, err := loadVarsFiles([]string{path})
 	if err != nil {
 		t.Fatalf("loadVarsFiles on empty file failed: %v", err)
 	}
@@ -692,7 +692,7 @@ func TestSetFromVarsFileBool(t *testing.T) {
 func TestApplyVarsFilesEmptyPathsNoOp(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "default")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
-	if _, err := applyVarsFiles(args, flags, nil); err != nil {
+	if _, _, err := applyVarsFiles(args, flags, nil); err != nil {
 		t.Fatalf("expected nil error for empty paths, got %v", err)
 	}
 	if *args["app"].stringValue != "default" {
@@ -708,7 +708,7 @@ func TestApplyVarsFilesUpdatesUnsetArgument(t *testing.T) {
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 	flags.String("app", "default", "")
 
-	if _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
+	if _, _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["app"].stringValue; got != "from-vars" {
@@ -729,7 +729,7 @@ func TestApplyVarsFilesCLIOverridesVarsFile(t *testing.T) {
 		t.Fatalf("flags.Parse failed: %v", err)
 	}
 
-	if _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
+	if _, _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["app"].stringValue; got != "from-cli" {
@@ -744,7 +744,7 @@ func TestApplyVarsFilesUnknownKey(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	_, err := applyVarsFiles(args, flags, []string{path})
+	_, _, err := applyVarsFiles(args, flags, []string{path})
 	if err == nil {
 		t.Fatal("expected error for unknown key")
 	}
@@ -762,7 +762,7 @@ func TestApplyVarsFilesUnknownKeyNoSuggestionWhenFar(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	_, err := applyVarsFiles(args, flags, []string{path})
+	_, _, err := applyVarsFiles(args, flags, []string{path})
 	if err == nil {
 		t.Fatal("expected error for unknown key")
 	}
@@ -779,7 +779,7 @@ func TestApplyVarsFilesMultiFileLastWins(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	if _, err := applyVarsFiles(args, flags, []string{a, b}); err != nil {
+	if _, _, err := applyVarsFiles(args, flags, []string{a, b}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["app"].stringValue; got != "from-b" {
@@ -794,7 +794,7 @@ func TestApplyVarsFilesCoercionFailureNamesInput(t *testing.T) {
 	args := map[string]*Argument{"replicas": argFor(t, "int", 0)}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	_, err := applyVarsFiles(args, flags, []string{path})
+	_, _, err := applyVarsFiles(args, flags, []string{path})
 	if err == nil {
 		t.Fatal("expected coercion error")
 	}
@@ -812,7 +812,7 @@ func TestApplyVarsFilesJSONFloatCoercesToInt(t *testing.T) {
 	args := map[string]*Argument{"replicas": argFor(t, "int", 0)}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	if _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
+	if _, _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["replicas"].intValue; got != 5 {

--- a/commands/export.go
+++ b/commands/export.go
@@ -16,6 +16,13 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+// varsFileMode is the mode the companion vars-file is written with. It holds
+// every config value, every field a task marks sensitive, and the credentials
+// behind them in the clear, and its only reader is the same user applying the
+// pair back through --vars-file (#489). The recipe beside it stays 0o644 like
+// every other file docket writes: it carries interpolations, not values.
+const varsFileMode = 0o600
+
 // ExportCommand reads a live Dokku server and writes a recipe describing it -
 // the inverse of apply. Sensitive values are lifted into a companion vars-file
 // that the emitted recipe references through inputs, so the pair applies with
@@ -294,7 +301,7 @@ func (c *ExportCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("marshal vars: %v", subprocess.MaskString(err.Error())))
 			return 1
 		}
-		if err := os.WriteFile(varsOutput, varsBytes, 0o644); err != nil {
+		if err := c.writeVarsFile(varsOutput, varsBytes); err != nil {
 			c.Ui.Error(fmt.Sprintf("write error: %v", err))
 			return 1
 		}
@@ -353,6 +360,40 @@ func (c *ExportCommand) confirmOverwrite(path string) (bool, error) {
 	}
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	return answer == "y" || answer == "yes", nil
+}
+
+// chmodVarsFile is os.File.Chmod, indirected so the warning below can be
+// tested: no filesystem a test can portably create rejects fchmod, and a
+// fallback that tells the operator their secrets are exposed is worth more
+// than an untested one.
+var chmodVarsFile = func(f *os.File, mode os.FileMode) error { return f.Chmod(mode) }
+
+// writeVarsFile writes the companion vars-file at varsFileMode. os.WriteFile
+// is not enough on its own: O_CREATE's mode applies only to a file the call
+// creates, so a vars-file already on disk - one an older docket wrote at
+// 0o644, or one the operator made by hand - would keep whatever mode it had,
+// and the umask can only take bits off 0o600 rather than settle it. The chmod
+// lands on the fd before the first byte is written, so the values never sit in
+// a file anyone else can open; O_TRUNC emptying it first is harmless, since an
+// empty world-readable file leaks nothing.
+//
+// A filesystem that cannot hold the bits - vfat, some network mounts - warns
+// rather than failing the export: the pair is still what was asked for, the
+// operator just has to know this half is exposed. The message names the path
+// unmasked for the reason exitForMissingApps gives.
+func (c *ExportCommand) writeVarsFile(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, varsFileMode)
+	if err != nil {
+		return err
+	}
+	if err := chmodVarsFile(f, varsFileMode); err != nil {
+		c.Ui.Warn(fmt.Sprintf("warning: could not set mode %#o on %s: %v; it holds secrets in the clear", varsFileMode, path, err))
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // deriveVarsOutput returns the default companion vars-file path for a recipe

--- a/commands/export_mode_test.go
+++ b/commands/export_mode_test.go
@@ -1,0 +1,190 @@
+package commands
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// assertPerm fails unless path has exactly the given permission bits.
+func assertPerm(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Errorf("%s mode = %04o, want %04o", path, got, want)
+	}
+}
+
+// umaskPerm returns the mode a 0o644 file actually lands at in dir, which
+// depends on the umask of whoever is running the tests. The recipe is written
+// with a plain os.WriteFile, so this is what it should match - asserting a
+// literal 0644 would fail under a umask of 077.
+func umaskPerm(t *testing.T, dir string) os.FileMode {
+	t.Helper()
+	control := filepath.Join(dir, ".umask-control")
+	if err := os.WriteFile(control, nil, 0o644); err != nil {
+		t.Fatalf("write control file: %v", err)
+	}
+	info, err := os.Stat(control)
+	if err != nil {
+		t.Fatalf("stat control file: %v", err)
+	}
+	return info.Mode().Perm()
+}
+
+// TestExportCommandVarsFileIsPrivate is the point of #489: the vars-file holds
+// every config value in the clear, so it is written 0600 while the recipe -
+// which carries interpolations rather than values - stays public.
+func TestExportCommandVarsFileIsPrivate(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+	vars := filepath.Join(dir, "tasks.vars.yml")
+
+	c, _ := newExportCommand()
+	if code := c.Run([]string{"--output", recipe}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0", code)
+	}
+
+	assertPerm(t, vars, 0o600)
+	assertPerm(t, recipe, umaskPerm(t, dir))
+}
+
+// TestExportCommandVarsOutputIsPrivate pins that the mode follows the file,
+// not the derived default path.
+func TestExportCommandVarsOutputIsPrivate(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+	vars := filepath.Join(dir, "secrets.yml")
+
+	c, _ := newExportCommand()
+	if code := c.Run([]string{"--output", recipe, "--vars-output", vars}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0", code)
+	}
+
+	assertPerm(t, vars, 0o600)
+}
+
+// TestExportCommandRedactedVarsFileIsPrivate: a redacted vars-file holds
+// placeholders, but it is the file the operator then fills in with the real
+// secrets, so splitting the mode by flag would hand them a 0644 file to type
+// credentials into.
+func TestExportCommandRedactedVarsFileIsPrivate(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+	vars := filepath.Join(dir, "tasks.vars.yml")
+
+	c, _ := newExportCommand()
+	if code := c.Run([]string{"--output", recipe, "--redact"}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0", code)
+	}
+
+	assertPerm(t, vars, 0o600)
+}
+
+// TestExportCommandVarsFileModeResetOnOverwrite covers the half of #489 that
+// os.WriteFile cannot do on its own: O_CREATE's mode applies only to a file it
+// creates, so a vars-file an older docket left at 0644 would stay readable
+// forever.
+func TestExportCommandVarsFileModeResetOnOverwrite(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+	vars := filepath.Join(dir, "tasks.vars.yml")
+	if err := os.WriteFile(vars, []byte("OLD\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(vars, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, _ := newExportCommand()
+	if code := c.Run([]string{"--output", recipe, "--overwrite"}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0", code)
+	}
+
+	assertPerm(t, vars, 0o600)
+	got, err := os.ReadFile(vars)
+	if err != nil {
+		t.Fatalf("vars-file not written: %v", err)
+	}
+	if strings.Contains(string(got), "OLD") {
+		t.Errorf("overwrite should replace the vars-file, got %q", got)
+	}
+	if !strings.Contains(string(got), "abc123") {
+		t.Errorf("vars-file should hold the real value:\n%s", got)
+	}
+}
+
+// TestExportCommandRecipeModeLeftAlone: the recipe is not chmod'd, so an
+// operator who locked one down keeps it that way. Only the vars-file's mode is
+// docket's business, because only the vars-file's contents ask for one.
+func TestExportCommandRecipeModeLeftAlone(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(recipe, []byte("OLD\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(recipe, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c, _ := newExportCommand()
+	if code := c.Run([]string{"--output", recipe, "--overwrite"}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0", code)
+	}
+
+	assertPerm(t, recipe, 0o600)
+}
+
+// TestExportCommandWarnsWhenTheModeCannotBeSet covers the fallback for a
+// filesystem that cannot hold permission bits - vfat, some network mounts.
+// The export still finishes, because the pair is what was asked for, but the
+// operator has to be told this half is in the clear.
+func TestExportCommandWarnsWhenTheModeCannotBeSet(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	orig := chmodVarsFile
+	chmodVarsFile = func(*os.File, os.FileMode) error { return errors.New("operation not supported") }
+	defer func() { chmodVarsFile = orig }()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+	vars := filepath.Join(dir, "tasks.vars.yml")
+
+	c, ui := newExportCommand()
+	if code := c.Run([]string{"--output", recipe}); code != 0 {
+		t.Fatalf("a mode that cannot be set must not fail the export, got exit %d", code)
+	}
+
+	stderr := ui.ErrorWriter.String()
+	for _, want := range []string{"could not set mode 0600", vars, "operation not supported"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+
+	// The values are still written, which is the point of not failing.
+	varsBytes, err := os.ReadFile(vars)
+	if err != nil {
+		t.Fatalf("vars-file not written: %v", err)
+	}
+	if !strings.Contains(string(varsBytes), "abc123") {
+		t.Errorf("vars-file should hold the real value:\n%s", varsBytes)
+	}
+}

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -155,10 +155,15 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	varsFileKeys, err := applyVarsFiles(c.arguments, flags, c.varsFiles)
+	varsFileKeys, varsWarnings, err := applyVarsFiles(c.arguments, flags, c.varsFiles)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
+	}
+	// Warned about on stderr in every mode, --json included: the JSON stream
+	// goes to stdout through the emitter, so this cannot land in it (#489).
+	for _, w := range varsWarnings {
+		c.Ui.Warn(w)
 	}
 
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -130,7 +130,8 @@ func (c *ValidateCommand) Run(args []string) int {
 		return 1
 	}
 
-	if _, err := applyVarsFiles(c.arguments, flags, c.varsFiles); err != nil {
+	_, varsWarnings, err := applyVarsFiles(c.arguments, flags, c.varsFiles)
+	if err != nil {
 		if c.json {
 			c.emitJSONProblem(tasks.Problem{
 				Code:    "vars_file_error",
@@ -140,6 +141,12 @@ func (c *ValidateCommand) Run(args []string) int {
 			c.Ui.Error(err.Error())
 		}
 		return 1
+	}
+	// Warned about on stderr in both modes. It is not a validate_problem: the
+	// recipe is fine, and a clean --json run has to keep writing nothing to
+	// stdout so a consumer can treat any output as failure (#489).
+	for _, w := range varsWarnings {
+		c.Ui.Warn(w)
 	}
 
 	formatOverride, err := parseRecipeFormatFlag("--tasks-format", c.tasksFormatFlag)

--- a/commands/vars_file_mode_test.go
+++ b/commands/vars_file_mode_test.go
@@ -1,0 +1,201 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	flag "github.com/spf13/pflag"
+)
+
+// sensitiveArg is argFor plus the declaration that makes a vars-file holding
+// this input a secrets file rather than a settings file.
+func sensitiveArg(t *testing.T, def string) *Argument {
+	t.Helper()
+	arg := argFor(t, "string", def)
+	arg.Sensitive = true
+	return arg
+}
+
+// chmodTempFile writes a vars file and pins its mode. writeTempFile passes
+// 0o644 to os.WriteFile, which the umask can tighten, so these tests set the
+// mode explicitly rather than inheriting whoever is running them.
+func chmodTempFile(t *testing.T, dir, name, content string, mode os.FileMode) string {
+	t.Helper()
+	path := writeTempFile(t, dir, name, content)
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+	return path
+}
+
+// TestApplyVarsFilesWarnsOnPermissiveSensitiveFile is the reading end of #489.
+func TestApplyVarsFilesWarnsOnPermissiveSensitiveFile(t *testing.T) {
+	dir := t.TempDir()
+	path := chmodTempFile(t, dir, "vars.yml", "api_key: s3cret\n", 0o644)
+
+	args := map[string]*Argument{"api_key": sensitiveArg(t, "")}
+	flags := flag.NewFlagSet("t", flag.ContinueOnError)
+
+	_, warnings, err := applyVarsFiles(args, flags, []string{path})
+	if err != nil {
+		t.Fatalf("applyVarsFiles failed: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one", warnings)
+	}
+	for _, want := range []string{path, "sensitive", "0644", "chmod 600"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("warning missing %q\nfull: %s", want, warnings[0])
+		}
+	}
+}
+
+// TestApplyVarsFilesQuietForPrivateSensitiveFile: the file docket export
+// itself writes must not warn about the mode docket export gave it.
+func TestApplyVarsFilesQuietForPrivateSensitiveFile(t *testing.T) {
+	dir := t.TempDir()
+	path := chmodTempFile(t, dir, "vars.yml", "api_key: s3cret\n", varsFileMode)
+
+	args := map[string]*Argument{"api_key": sensitiveArg(t, "")}
+	flags := flag.NewFlagSet("t", flag.ContinueOnError)
+
+	_, warnings, err := applyVarsFiles(args, flags, []string{path})
+	if err != nil {
+		t.Fatalf("applyVarsFiles failed: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("a 0600 vars-file must not warn, got %v", warnings)
+	}
+}
+
+// TestApplyVarsFilesQuietWithoutASensitiveInput keeps the warning off the
+// ordinary per-environment file docs/inputs.md recommends. Its mode is the
+// user's business; nothing in it is a secret.
+func TestApplyVarsFilesQuietWithoutASensitiveInput(t *testing.T) {
+	dir := t.TempDir()
+	path := chmodTempFile(t, dir, "prod.yml", "app: api\nreplicas: 3\n", 0o644)
+
+	args := map[string]*Argument{
+		"app":      argFor(t, "string", ""),
+		"replicas": argFor(t, "int", 1),
+	}
+	flags := flag.NewFlagSet("t", flag.ContinueOnError)
+
+	_, warnings, err := applyVarsFiles(args, flags, []string{path})
+	if err != nil {
+		t.Fatalf("applyVarsFiles failed: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("a vars-file of ordinary settings must not warn, got %v", warnings)
+	}
+}
+
+// TestApplyVarsFilesWarnsOnOverriddenSensitiveKey is why loadVarsFiles tracks
+// keys per file rather than only last-writer-wins: base.yml still holds the
+// secret on disk even though prod.yml's value is the one that gets used.
+func TestApplyVarsFilesWarnsOnOverriddenSensitiveKey(t *testing.T) {
+	dir := t.TempDir()
+	base := chmodTempFile(t, dir, "base.yml", "api_key: from-base\n", 0o644)
+	prod := chmodTempFile(t, dir, "prod.yml", "api_key: from-prod\n", varsFileMode)
+
+	args := map[string]*Argument{"api_key": sensitiveArg(t, "")}
+	flags := flag.NewFlagSet("t", flag.ContinueOnError)
+
+	_, warnings, err := applyVarsFiles(args, flags, []string{base, prod})
+	if err != nil {
+		t.Fatalf("applyVarsFiles failed: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one", warnings)
+	}
+	if !strings.Contains(warnings[0], base) {
+		t.Errorf("warning should name the overridden base file\nfull: %s", warnings[0])
+	}
+	if strings.Contains(warnings[0], prod) {
+		t.Errorf("the 0600 file must not be warned about\nfull: %s", warnings[0])
+	}
+}
+
+// TestApplyVarsFilesRepeatedPathWarnsOnce: passing the same file twice is
+// legal and must not double the warning.
+func TestApplyVarsFilesRepeatedPathWarnsOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := chmodTempFile(t, dir, "vars.yml", "api_key: s3cret\n", 0o644)
+
+	args := map[string]*Argument{"api_key": sensitiveArg(t, "")}
+	flags := flag.NewFlagSet("t", flag.ContinueOnError)
+
+	_, warnings, err := applyVarsFiles(args, flags, []string{path, path})
+	if err != nil {
+		t.Fatalf("applyVarsFiles failed: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Errorf("warnings = %v, want exactly one", warnings)
+	}
+}
+
+// permissiveVarsRecipe is a recipe with one sensitive input and one stub task,
+// paired with a 0644 vars-file supplying that input - the shape that has to
+// produce a warning end to end.
+func permissiveVarsRecipe(t *testing.T) (recipe string, vars string) {
+	t.Helper()
+	recipe = writeTasksFile(t, `---
+- inputs:
+    - name: api_key
+      sensitive: true
+      default: ""
+  tasks:
+    - name: noop
+      dokku_stub: { key: a }
+`)
+	vars = chmodTempFile(t, t.TempDir(), "vars.yml", "api_key: s3cret\n", 0o644)
+	return recipe, vars
+}
+
+// TestApplyWarnsOnPermissiveVarsFile pins where the warning comes out: stderr,
+// through the same Ui.Warn the ambiguous-task-file notice uses.
+func TestApplyWarnsOnPermissiveVarsFile(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: false})
+
+	recipe, vars := permissiveVarsRecipe(t)
+	stdout, stderr, exit := runApply(t, recipe, "--vars-file", vars)
+	if exit != 0 {
+		t.Fatalf("apply exit = %d, want 0\nstdout: %s\nstderr: %s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "readable by other users") {
+		t.Errorf("stderr missing the vars-file warning:\n%s", stderr)
+	}
+	if strings.Contains(stdout, "readable by other users") {
+		t.Errorf("the warning belongs on stderr, not stdout:\n%s", stdout)
+	}
+}
+
+// TestApplyJSONKeepsVarsFileWarningOffTheStream is the reason the warning is
+// not an EventEmitter.TaskWarning: it has no task to name, and the event
+// schema's reason field is a closed enum. Routed to stderr it cannot reach the
+// stream at all, so every stdout line still parses.
+func TestApplyJSONKeepsVarsFileWarningOffTheStream(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: false})
+
+	recipe, vars := permissiveVarsRecipe(t)
+	stdout, stderr, exit := runApply(t, recipe, "--json", "--vars-file", vars)
+	if exit != 0 {
+		t.Fatalf("apply exit = %d, want 0\nstdout: %s\nstderr: %s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "readable by other users") {
+		t.Errorf("stderr missing the vars-file warning:\n%s", stderr)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if line == "" {
+			continue
+		}
+		var event map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("stdout line is not JSON: %q (%v)", line, err)
+		}
+	}
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -132,7 +132,7 @@ Exit code is `0` when no problems are found, `1` otherwise.
 | `--tasks-format <fmt>` | Parse the recipe as `yaml` or `json5` instead of detecting it. |
 | `--json` | Emit one JSON-lines problem per line with a stable schema, for a CI annotator. |
 | `--strict` | Also flag any `required: true` input with no default and no supplied value, and verify that `--play` / `--start-at-task` references resolve to real names. |
-| `--vars-file <path>` | Load input values from a YAML or JSON file (repeatable). Values here count as overrides for `--strict`. See [inputs](inputs.md#layered-values-with---vars-file). |
+| `--vars-file <path>` | Load input values from a YAML or JSON file (repeatable). Values here count as overrides for `--strict`. A file that supplies a `sensitive: true` input and is readable by other users is warned about on stderr. See [inputs](inputs.md#layered-values-with---vars-file). |
 | `--play <name>` | (strict only) Verify the named play exists. |
 | `--start-at-task <name>` | (strict only) Verify a task with this name exists; narrowed by `--play`. |
 
@@ -229,7 +229,7 @@ optimistically predicting `[+] create` for state it never actually read.
 | `--tasks-format <fmt>` | Parse the recipe as `yaml` or `json5` instead of detecting it. |
 | `--json` | Emit JSON-lines events instead of the human formatter. See [JSON output](json-output.md). |
 | `--detailed-exitcode` | Exit `0` for no drift, `2` for drift, `1` on error. Errors win over drift. Mirrors `terraform plan -detailed-exitcode`. |
-| `--vars-file <path>` | Load input values from a file (repeatable). See [inputs](inputs.md#layered-values-with---vars-file). |
+| `--vars-file <path>` | Load input values from a file (repeatable). A file that supplies a `sensitive: true` input and is readable by other users is warned about on stderr. See [inputs](inputs.md#layered-values-with---vars-file). |
 | `--play <name>` | Plan only the named play. Composes with `--tags`. |
 | `--tags <list>` | Plan only tasks whose tags intersect the list. See [task envelope](task-envelope.md#tags). |
 | `--skip-tags <list>` | Skip tasks whose tags intersect the list. See [task envelope](task-envelope.md#tags). |
@@ -288,7 +288,7 @@ recipe cannot be loaded or a `when:` fails to evaluate, and `0` otherwise.
 | `--verbose` | After each task, echo every resolved Dokku command it ran, one per `→` line. Masked against sensitive values. Ignored with `--json` (which already includes commands). |
 | `--json` | Emit JSON-lines events instead of the human formatter. See [JSON output](json-output.md). |
 | `--detailed-exitcode` | Exit `0` when nothing changed, `2` when something did, `1` on error. Errors win over changes. |
-| `--vars-file <path>` | Load input values from a file (repeatable). See [inputs](inputs.md#layered-values-with---vars-file). |
+| `--vars-file <path>` | Load input values from a file (repeatable). A file that supplies a `sensitive: true` input and is readable by other users is warned about on stderr. See [inputs](inputs.md#layered-values-with---vars-file). |
 | `--play <name>` | Run only the named play. Composes with `--tags`. |
 | `--tags <list>` | Run only tasks whose tags intersect the list. See [task envelope](task-envelope.md#tags). |
 | `--skip-tags <list>` | Skip tasks whose tags intersect the list. See [task envelope](task-envelope.md#tags). |
@@ -468,6 +468,16 @@ docket export --resource 'dokku_config[app=api]' --output -
 The correctness contract is idempotency: applying an exported pair back to the same server reports
 no drift (`plan` shows every task `[ok]`).
 
+The two halves are written with different modes, because they hold different things. The recipe
+carries interpolations rather than values, so it lands at `0644` like every other file docket
+writes. The vars-file holds the values themselves in the clear - every `config` value, the
+scheduler-k3s cluster token, the `dns-provider-*` credentials, the http-auth password hashes - so it
+lands at `0600`, readable only by the user who ran the export, which is the same user who reads it
+back through `--vars-file`. That covers `--redact` too: a placeholder file is the one you then type
+the real secrets into, and it covers a vars-file already on disk, whose mode is reset on every
+write so a file an older docket left at `0644` is locked down the next time export writes it. On a
+filesystem that cannot hold the bits at all, export says so and finishes rather than failing.
+
 ### Exporting one resource
 
 `--resource` takes a [resource address](task-envelope.md#names-and-resource-addresses) - the same
@@ -494,9 +504,9 @@ matches nothing on the server is reported by name and exits non-zero, the same w
 |------|--------|
 | `--output <path>` | Where to write the recipe (default `tasks.yml`). Pass `-` to stream a single self-contained recipe (values inlined, no vars-file) to stdout for inspection. Because a stream has no vars-file and touches no file on disk, combining `-` with `--vars-output` or `--overwrite` is an error rather than a silently ignored flag. |
 | `--format <fmt>` | Write `yaml` or `json5` regardless of the `--output` extension, for both the recipe and the vars-file. Without an explicit `--output`, `--format json5` writes `./tasks.json` and `./tasks.vars.json`. Required to stream JSON5 with `--output -`, which has no extension to read. |
-| `--vars-output <path>` | Where to write the companion vars-file (default `<output-base>.vars.<ext>`, e.g. `tasks.vars.yml`). Not valid with `--output -`. When the server holds nothing sensitive there is no vars-file to write, and an explicit path is reported as unwritten rather than passed over. |
+| `--vars-output <path>` | Where to write the companion vars-file (default `<output-base>.vars.<ext>`, e.g. `tasks.vars.yml`). Written `0600` wherever it lands. Not valid with `--output -`. When the server holds nothing sensitive there is no vars-file to write, and an explicit path is reported as unwritten rather than passed over. |
 | `--overwrite` | Overwrite existing output files without prompting. Without it, export prompts before replacing either file, and aborts writing nothing if declined (or if stdin is not interactive). Not valid with `--output -`. |
-| `--redact` | Write placeholder values into the vars-file instead of real secrets, producing a shareable recipe plus a fill-in-the-blanks vars template. The `required` inputs mean `apply` fails loudly until the vars-file is filled in. |
+| `--redact` | Write placeholder values into the vars-file instead of real secrets, producing a shareable recipe plus a fill-in-the-blanks vars template. The `required` inputs mean `apply` fails loudly until the vars-file is filled in, and the template is still written `0600` because filling it in is what puts the secrets there. |
 | `--app <name>` | Restrict the export to the named app. Repeatable. |
 | `--resource <address>` | Restrict the export to a [resource address](task-envelope.md#names-and-resource-addresses), e.g. `dokku_config[app=api]`. A bare task type takes every resource of that type. Repeatable; not valid with `--app`. See [exporting one resource](#exporting-one-resource). |
 | `--host <user@host:port>` | Read a remote server over SSH. Overrides `DOKKU_HOST`. See [remote execution](remote-execution.md). |

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -200,6 +200,22 @@ the closest real name:
 unknown input "appp" in --vars-file prod.yml; did you mean "app"?
 ```
 
+### A vars file that holds secrets
+
+A vars file supplying a value for an input declared `sensitive: true` is a secrets file, not a
+settings file, and docket says so when it is readable by anyone but its owner:
+
+```text
+warning: --vars-file prod.yml holds sensitive input values and is readable by other users (mode 0644); chmod 600 prod.yml
+```
+
+It is a warning rather than an error - the file is yours and docket only reads it - and it goes to
+stderr in every mode, so it stays out of the `--json` streams. A vars file of ordinary settings
+(`app`, `replicas`) never triggers it; the `sensitive: true` declaration is what makes the mode
+worth a word. `chmod 600` settles it. [`docket export`](command-reference.md#docket-export) writes
+its own vars-file at `0600` for the same reason, so an exported pair never trips this; a file you
+write yourself, or copy to another host, keeps whatever mode you gave it.
+
 ## Precedence
 
 When the same input is set in more than one place, the highest layer wins. From lowest to highest:

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -97,6 +97,12 @@ cannot be read. Both keys are absent for a task that probes everything it manage
 prose and is masked; `probe` is an enum and is not. A recipe containing an `unsupported` task never
 exits `0` under `--detailed-exitcode`.
 
+One notice deliberately appears in no stream at all: the
+[`--vars-file` permissions warning](inputs.md#a-vars-file-that-holds-secrets) is about a file, not a
+task, so there is no play or name to correlate it against. It is written to stderr in every mode -
+`apply --json`, `plan --json`, and `validate --json` alike - which leaves stdout untouched, so a
+clean `validate --json` still writes nothing there.
+
 ## Commands
 
 Both `task` flavors include `commands` as an array of resolved, masked `dokku` command strings. It

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -67,6 +67,10 @@ and service properties (`dokku_service_property`), which you add by hand. Each t
 mask the secrets the export read, so the log of a migration run is safe to paste into a ticket even
 though the pair of files it wrote is not.
 
+`tasks.vars.yml` is written `0600` on the box that produced it, which says nothing about where you
+put it next: move it the way you would move a private key, and delete it once the migration is done.
+If it arrives on the new server readable by anyone else, `plan` and `apply` say so before they run.
+
 A scheduler-k3s node profile is left out for a different reason: dokku accepts a profile name that
 is too long or carries uppercase, but it cannot turn the derived node-sysctls helm release name into
 a legal one, so the profile is already broken on the old server. Carrying it into the recipe would

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -121,6 +121,60 @@ teardown() {
   assert_output --partial "docket-test-export"
 }
 
+@test "docket export writes the vars-file readable only by its owner" {
+  require_dokku
+  dokku apps:create docket-test-export
+  # The config value is what gets lifted into the vars-file, and it is the
+  # reason the file's mode is not the recipe's (#489).
+  dokku config:set --no-restart docket-test-export API_KEY=abc123
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" export --app docket-test-export
+  assert_success
+  assert [ -f tasks.vars.yml ]
+
+  # The recipe keeps whatever the umask gives it, because it carries
+  # interpolations rather than values; the vars-file is the half whose mode
+  # docket picks.
+  run file_mode tasks.vars.yml
+  assert_output "600"
+}
+
+@test "docket export tightens the mode of an existing vars-file" {
+  require_dokku
+  dokku apps:create docket-test-export
+  dokku config:set --no-restart docket-test-export API_KEY=abc123
+  cd "$BATS_TEST_TMPDIR"
+  # A vars-file an older docket left world-readable: os.WriteFile would have
+  # kept that mode, so the secrets would stay exposed forever (#489).
+  echo "old: value" >tasks.vars.yml
+  chmod 644 tasks.vars.yml
+
+  run "$(docket_bin)" export --app docket-test-export --overwrite
+  assert_success
+
+  run file_mode tasks.vars.yml
+  assert_output "600"
+  run grep -c "abc123" tasks.vars.yml
+  assert_output "1"
+}
+
+@test "docket export --redact still writes the vars-file private" {
+  require_dokku
+  dokku apps:create docket-test-export
+  dokku config:set --no-restart docket-test-export API_KEY=abc123
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" export --app docket-test-export --redact
+  assert_success
+  assert [ -f tasks.vars.yml ]
+  run grep -q "abc123" tasks.vars.yml
+  assert_failure
+
+  # A redacted vars-file holds placeholders, but it is the file the operator
+  # then types the real secrets into.
+  run file_mode tasks.vars.yml
+  assert_output "600"
+}
+
 @test "docket export --output - rejects --vars-output" {
   # #419: a streamed recipe inlines its values, so the vars-file the flag
   # asks for can never be written. Rejected before the server is read,

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -114,6 +114,13 @@ dokku_clean_scheduler_k3s_profile() {
   dokku --quiet scheduler-k3s:profiles:remove "$profile" >/dev/null 2>&1 || true
 }
 
+# file_mode prints a file's permission bits as octal digits (e.g. 600).
+# GNU stat and BSD stat spell the same question differently, so try both the
+# way the mtime checks in fmt.bats do.
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
 # require_dokku skips the current test when no dokku binary is installed.
 require_dokku() {
   if ! command -v dokku >/dev/null 2>&1; then

--- a/tests/bats/vars_file.bats
+++ b/tests/bats/vars_file.bats
@@ -92,6 +92,91 @@ EOF
   assert_output --partial "mapping"
 }
 
+# offline: the permissions warning (#489) needs no server either. A vars-file
+# supplying a `sensitive: true` input is a secrets file; its mode is worth a
+# word, and a file of ordinary settings is not.
+@test "docket validate warns on a world-readable --vars-file holding a secret" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: api_key
+      sensitive: true
+      default: ""
+  tasks:
+    - dokku_app:
+        app: docket-test-vars
+EOF
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<EOF
+api_key: s3cret
+EOF
+  chmod 644 "$BATS_TEST_TMPDIR/vars.yml"
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  assert_output --partial "readable by other users"
+  assert_output --partial "chmod 600"
+}
+
+@test "docket validate stays quiet for a --vars-file at 0600" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: api_key
+      sensitive: true
+      default: ""
+  tasks:
+    - dokku_app:
+        app: docket-test-vars
+EOF
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<EOF
+api_key: s3cret
+EOF
+  chmod 600 "$BATS_TEST_TMPDIR/vars.yml"
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  refute_output --partial "readable by other users"
+}
+
+@test "docket validate stays quiet for a --vars-file of ordinary settings" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: app
+      default: default-app
+  tasks:
+    - dokku_app:
+        app: "{{ .app }}"
+EOF
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<EOF
+app: docket-test-vars
+EOF
+  chmod 644 "$BATS_TEST_TMPDIR/vars.yml"
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  refute_output --partial "readable by other users"
+}
+
+@test "docket validate --json keeps the vars-file warning off stdout" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: api_key
+      sensitive: true
+      default: ""
+  tasks:
+    - dokku_app:
+        app: docket-test-vars
+EOF
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<EOF
+api_key: s3cret
+EOF
+  chmod 644 "$BATS_TEST_TMPDIR/vars.yml"
+  # A clean --json run has to keep writing nothing to stdout, so a consumer
+  # can treat any output as failure without parsing it. bats merges stderr
+  # into $output, so redirect stdout to its own file instead.
+  "$(docket_bin)" validate --json --tasks "$TASKS_FILE" --vars-file "$BATS_TEST_TMPDIR/vars.yml" >"$BATS_TEST_TMPDIR/out.json"
+  assert [ ! -s "$BATS_TEST_TMPDIR/out.json" ]
+}
+
 # end-to-end: substitution verification through plan; needs dokku.
 @test "docket plan with --vars-file overrides file inputs" {
   require_dokku


### PR DESCRIPTION
The vars-file `docket export` writes beside the recipe holds every `config` value, every field a task marks sensitive, the scheduler-k3s cluster token, the letsencrypt and traefik `dns-provider-*` credentials and the http-auth password hashes, all in the clear, and it was written `0644` - under the usual `022` umask, `-rw-r--r--` on the box the export ran on. It is now written `0600`, which is the mode the file's contents ask for and costs nothing, since the pair is consumed by `docket apply --vars-file` as the same user that wrote it. The recipe beside it keeps `0644`: it carries interpolations rather than values, which is the whole point of the split, and forcing a mode on it would widen a recipe someone had deliberately locked down.

`--redact` gets `0600` too. Splitting the mode by flag reads well until you notice that the redacted file is precisely the one the operator then types the real secrets into. The mode is also reset on every write rather than only on create, because `os.WriteFile` leaves an existing file's mode alone and a vars-file an older docket wrote at `0644` would otherwise keep it forever; the chmod lands on the file descriptor before the first byte, so the values never sit in a file anyone else can open. A filesystem that cannot hold permission bits at all - vfat, some network mounts - is reported as a warning rather than failing the export, since the pair is still what was asked for and the operator just has to know this half is exposed.

Writing it privately is only half the question, so reading one is folded in here. Docket never looked at the mode of a `--vars-file` it was handed, and a file locked down where it was produced can be copied to another host at `0644` or hand-written there. `apply`, `plan` and `validate` now warn when a `--vars-file` supplies a value for an input the recipe declares `sensitive: true` and the file is accessible to users other than its owner. The trigger is content rather than mode alone: a vars file of `app` and `replicas` is ordinary configuration and warning about it would be noise on the per-environment file `docs/inputs.md` recommends, while a `sensitive: true` input is what makes a vars file a secrets file - and an exported one is made of nothing else. It stays a warning, since the file is the user's and docket only reads it, and it goes to stderr in every mode, which keeps it out of the `apply`/`plan` event stream and lets a clean `validate --json` go on writing nothing to stdout. The structured `warning` event was the wrong home for it: its `reason` is a closed enum in the published schema, its `play` and `name` are required and there is no task to name, and `validate` has no emitter at all.

`docs/inputs.md` still does not document the `sensitive` input property itself, which is #490 and untouched here; the new section only describes what a vars file holding such an input means for its mode.

Fixes #489.
