### PR TITLE
docs: document the sensitive input property

### DIFF
--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/dokku/docket/tasks"
 
 	sigil "github.com/gliderlabs/sigil"
@@ -303,10 +304,32 @@ func registerInputFlags(f *flag.FlagSet, data []byte, format string) (map[string
 		default:
 			return arguments, fmt.Errorf("Error parsing input '%s': invalid type", input.Name)
 		}
+		if input.Sensitive {
+			maskFlagDefault(f, input.Name, input.Default)
+		}
 		arguments[input.Name] = arg
 	}
 
 	return arguments, nil
+}
+
+// maskFlagDefault replaces the usage-string default of a `sensitive: true`
+// input's flag with the mask placeholder. pflag renders `(default <DefValue>)`
+// straight from this field, and `--help` is rendered before the recipe is
+// parsed - the mask registry is still empty at that point, so no MaskString at
+// the print site could have caught it (#490).
+//
+// Only the display copy changes. The flag's Value still holds the real default,
+// so the input still resolves to it, and the run that follows still registers
+// and masks it like any other sensitive value. An input that declared no
+// default has nothing to hide, and is the shape `docket export` generates.
+func maskFlagDefault(f *flag.FlagSet, name, def string) {
+	if def == "" {
+		return
+	}
+	if fl := f.Lookup(name); fl != nil {
+		fl.DefValue = subprocess.MaskPlaceholder
+	}
 }
 
 // parseInputDocument decodes data as a Recipe in the given on-disk

--- a/commands/sensitive_default_masking_test.go
+++ b/commands/sensitive_default_masking_test.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+// sensitive_default_masking_test.go covers #490: the value a `sensitive: true`
+// input resolves to from its own `default:`, rather than from a --vars-file or
+// a --name=value flag.
+//
+// Two halves, because they run at different times. At run time the default is
+// registered like any other resolved value, but every other masking test
+// supplies its secret on the command line, so the default-only path was
+// unasserted. At help time nothing is registered at all - pflag renders
+// `(default <DefValue>)` straight off the flag, before a recipe is parsed - so
+// the default printed in the clear until registerInputFlags started rewriting
+// that field.
+
+// helpCommand is the slice of a command that a --help page needs. Every
+// command that can register recipe-input flags implements it.
+type helpCommand interface {
+	Help() string
+}
+
+// helpCommands builds each command whose --help page can carry input flags.
+// The three share registerInputFlags but reach it from three separate
+// FlagSet() implementations, so each is exercised on its own.
+var helpCommands = map[string]func() helpCommand{
+	"apply":    func() helpCommand { return &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}} },
+	"plan":     func() helpCommand { return &PlanCommand{Meta: command.Meta{Ui: cli.NewMockUi()}} },
+	"validate": func() helpCommand { return &ValidateCommand{Meta: command.Meta{Ui: cli.NewMockUi()}} },
+}
+
+// helpText renders one command's --help page for the recipe at path. FlagSet()
+// resolves the recipe out of os.Args rather than from the parsed flags, so the
+// argv has to be staged the way runApply and runPlan stage it.
+func helpText(t *testing.T, name, path string) string {
+	t.Helper()
+	build, ok := helpCommands[name]
+	if !ok {
+		t.Fatalf("no help command registered for %q", name)
+	}
+	origArgs := os.Args
+	os.Args = []string{"docket-test", name, "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+	return build().Help()
+}
+
+// TestHelpMasksSensitiveInputDefault is the #490 regression. A recipe that
+// writes a secret into `default:` used to have it echoed verbatim by
+// `docket apply --help`, on a path no MaskString could reach: help is rendered
+// before any recipe is parsed, so subprocess's registry is still empty.
+func TestHelpMasksSensitiveInputDefault(t *testing.T) {
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: token, default: helpdefaultzzz, sensitive: true }
+  tasks:
+    - dokku_stub: { key: "{{ .token }}" }
+`)
+
+	for _, name := range []string{"apply", "plan", "validate"} {
+		t.Run(name, func(t *testing.T) {
+			out := helpText(t, name, path)
+			if !strings.Contains(out, "--token") {
+				t.Fatalf("%s --help did not register the input flag at all; got:\n%s", name, out)
+			}
+			if strings.Contains(out, "helpdefaultzzz") {
+				t.Errorf("%s --help leaked the sensitive input's default; got:\n%s", name, out)
+			}
+			if !strings.Contains(out, `(default "***")`) {
+				t.Errorf("%s --help should render the default as the mask placeholder; got:\n%s", name, out)
+			}
+		})
+	}
+}
+
+// TestHelpKeepsNonSensitiveInputDefault pins the other side of the rewrite: it
+// applies to `sensitive: true` inputs only, and only to those that declared a
+// default. An ordinary input still advertises its default - that is what the
+// help page is for - and a sensitive input with nothing to hide gains no
+// spurious placeholder.
+func TestHelpKeepsNonSensitiveInputDefault(t *testing.T) {
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: app, default: web }
+    - { name: token, required: true, sensitive: true }
+  tasks:
+    - dokku_stub: { key: "{{ .app }}" }
+`)
+
+	for _, name := range []string{"apply", "plan", "validate"} {
+		t.Run(name, func(t *testing.T) {
+			out := helpText(t, name, path)
+			if !strings.Contains(out, `(default "web")`) {
+				t.Errorf("%s --help should still advertise an ordinary input's default; got:\n%s", name, out)
+			}
+			if strings.Contains(out, `(default "***")`) {
+				t.Errorf("%s --help masked a default that was never declared; got:\n%s", name, out)
+			}
+		})
+	}
+}
+
+// TestListTasksMasksSensitiveInputResolvedFromDefault is the run-time half.
+// The listing renders resolved values, and with no override the resolved value
+// is the declared default - which reaches the mask registry through
+// Argument.StringValue() exactly as a --vars-file or CLI value would.
+func TestListTasksMasksSensitiveInputResolvedFromDefault(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: secret_value, default: defaultsecretzzz, sensitive: true }
+  tasks:
+    - dokku_stub: { key: "{{ .secret_value }}" }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "defaultsecretzzz") {
+		t.Errorf("listing leaked a sensitive input resolved from its default; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "dokku_stub[key=***]") {
+		t.Errorf("expected the address to render with a masked key; got:\n%s", stdout)
+	}
+
+	stdout, stderr, exit = runApply(t, path, "--list-tasks", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	assertLinesMatchSchema(t, listTasksSchemaPath, stdout)
+	if strings.Contains(stdout, "defaultsecretzzz") {
+		t.Errorf("--json listing leaked a sensitive input resolved from its default; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"name":"dokku_stub[key=***]"`) {
+		t.Errorf("expected a masked name field; got:\n%s", stdout)
+	}
+}

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -32,6 +32,7 @@ Each input supports these properties:
 | `default` | bool / float / int / string | zero value for the type | Used when no value is supplied. |
 | `description` | string | `""` | Shown in `--help` output. |
 | `required` | bool | `false` | Flagged by `validate --strict` when it has no default and no supplied value. |
+| `sensitive` | bool | `false` | Masks the value as `***` wherever docket prints it. See [Sensitive inputs](#sensitive-inputs). |
 | `type` | string | `string` | One of `bool`, `float`, `int`, `string`. Controls how supplied values are coerced. |
 
 Inputs are substituted into task bodies with the [sigil](https://github.com/gliderlabs/sigil)
@@ -144,6 +145,72 @@ Declaring one is reported as `reserved_input_name` by `docket validate` (and rej
 `help`, `v`, and `version` are handled by the CLI framework rather than registered as flags, so
 they are usable as input names.
 
+## Sensitive inputs
+
+An input declared `sensitive: true` holds a secret. Docket registers whatever value the input
+resolves to - whichever layer [precedence](#precedence) picked, a declared `default:` included -
+and replaces every occurrence of that literal with `***` in the text it prints.
+
+```yaml
+---
+- inputs:
+    - name: deploy_token
+      description: "Token the sync reads the private repo with"
+      required: true
+      sensitive: true
+  tasks:
+    - dokku_git_sync:
+        app: api
+        remote: "https://x-access-token:{{ .deploy_token }}@github.com/example/api.git"
+```
+
+Masking is display-only. The task still receives the real value and still sends it to the server;
+this is not encryption, and it is not storage. The recipe on disk, the `--vars-file` beside it, and
+anything `docket fmt` writes all carry the value in the clear. `sensitive:` governs what docket
+prints, nothing else.
+
+What it prints is every stream docket emits: the human output of `apply`, `plan`, and `validate`,
+the `--verbose` command echoes, `--json` on all three, `--list-tasks` on both the human and the JSON
+path, error messages, the hints an unmatched `--play` or `--start-at-task` prints, and the
+`DOKKU_TRACE` debug log. Inside those, a secret is masked wherever it landed: task names, play
+names, tags, `when:` predicates and the errors they raise, and loop items at any depth, object keys
+included. [JSON output](json-output.md) has the field-by-field list.
+
+Docket's own vocabulary is never masked. The `type`, `phase`, `probe`, and `status` fields are fixed
+enums rather than recipe content, and decorations like `(group)` and `[block]` are docket's words
+rather than yours - an input whose value happens to be `group` does not blank them out.
+
+A task type can also mark its own fields secret, with no input involved: `dokku_config` treats every
+value in its `config:` map that way, and a field that exists to carry a credential - a
+`dokku_registry_auth` password, a `dokku_certs` key - is marked in the task's definition. Those
+values are registered and masked on identical terms. The `sensitive:` input property is how you
+protect a value the task would otherwise have no reason to suspect, like the token in the `remote:`
+above. See [Writing tasks](writing-tasks.md) for the task side.
+
+### Masking widens rather than narrows
+
+Masking is literal substring replacement, and docket registers every spelling it can print a value
+in rather than only the one you supplied. A value carrying leading or trailing whitespace masks its
+trimmed spelling too, because a loop item is trimmed on its way into a task name. A value that a
+generated resource address has to quote masks its Go-escaped spelling too, so `sec"ret` masks both
+itself and `sec\"ret`. Padding or punctuating a secret widens what masks; it never narrows it.
+
+The cost of substring replacement is that a short or common value masks unrelated output as well.
+`sensitive: true` is accepted on any `type`, but what gets registered is the value as substituted -
+an `int` registers its digits, a `bool` registers `true` or `false` - so keep it for `string` inputs
+holding real secrets. An input that resolves to an empty string registers nothing at all.
+[JSON output](json-output.md#correlating-runs) lists the caveats in full, including why a task name
+masked down to `***` cannot be pasted back into `--start-at-task`.
+
+### Keep the secret out of `default:`
+
+`--help` renders a sensitive input's default as `(default "***")` rather than the literal, but that
+is the only cover a `default:` gets. A default is recipe text: it sits in the file in the clear,
+survives `docket fmt`, and travels with the recipe wherever the recipe goes. Declare the input
+`required: true` with no default and supply the value through a `--vars-file` or a CLI flag instead.
+That is the shape [`docket export`](command-reference.md#docket-export) writes - a recipe of
+`required: true, sensitive: true` inputs beside a `0600` vars-file holding the values.
+
 ## Layered values with `--vars-file`
 
 For anything beyond a couple of overrides, keep values in a file and pass it with `--vars-file`.
@@ -251,3 +318,4 @@ In a [multi-play recipe](recipes.md#multi-play-recipes), there are two kinds of 
 - [Recipes](recipes.md) - plays and multi-play structure
 - [Task envelope](task-envelope.md) - using inputs in `when:` and `loop:` expressions
 - [Command reference](command-reference.md#docket-validate) - `validate --strict` checks required inputs
+- [Command reference](command-reference.md#docket-export) - the vars-file `docket export` writes is a `--vars-file`

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -9,10 +9,15 @@ import (
 	"sync"
 )
 
-// maskPlaceholder is what every sensitive value is replaced with in user-facing
+// MaskPlaceholder is what every sensitive value is replaced with in user-facing
 // output. Length is intentionally fixed at three asterisks so masked output
 // reveals nothing about the original value (no length, prefix, or suffix).
-const maskPlaceholder = "***"
+//
+// Exported because one caller has to render the placeholder without running
+// text through MaskString: commands/apply_args.go rewrites the usage-string
+// default of a `sensitive: true` input's flag, which `--help` prints before any
+// value has been registered here.
+const MaskPlaceholder = "***"
 
 var (
 	sensitiveMu     sync.RWMutex
@@ -152,7 +157,7 @@ func MaskString(s string) string {
 		if v == "" {
 			continue
 		}
-		s = strings.ReplaceAll(s, v, maskPlaceholder)
+		s = strings.ReplaceAll(s, v, MaskPlaceholder)
 	}
 	return s
 }

--- a/tests/bats/help.bats
+++ b/tests/bats/help.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# help.bats covers the `--help` page a recipe's own inputs contribute to.
+# Nothing here contacts a server: FlagSet() reads the recipe, registers a flag
+# per input, and CommandHelp renders the usage strings, all before Run.
+#
+# The masking cases are #490. `--help` is the one stream docket writes with an
+# empty mask registry - it is rendered before any recipe is parsed - so a
+# `sensitive: true` input's `default:` is masked by rewriting the flag's
+# advertised default rather than by MaskString at the print site. The Go tests
+# in commands/sensitive_default_masking_test.go call Help() directly; these
+# drive the real binary through the CLI dispatcher, which prints help on stderr
+# and exits 0.
+
+setup() {
+  docket_build
+}
+
+@test "apply --help masks a sensitive input's default value" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: token, default: helpdefaultzzz, sensitive: true }
+  tasks:
+    - dokku_app: { app: web }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --help
+  assert_success
+  assert_output --partial "--token"
+  refute_output --partial "helpdefaultzzz"
+  assert_output --partial '(default "***")'
+}
+
+@test "apply --help still shows an ordinary input's default" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: app, default: web }
+    - { name: token, required: true, sensitive: true }
+  tasks:
+    - dokku_app: { app: "{{ .app }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --help
+  assert_success
+  assert_output --partial '(default "web")'
+  refute_output --partial '(default "***")'
+}

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -415,6 +415,24 @@ EOF
   assert_output --partial '"name":"deploy (item=***)"'
 }
 
+@test "--list-tasks masks a sensitive input resolved from its default" {
+  # #490: the listing renders resolved values, and with no override the
+  # resolved value is the input's own `default:`. It reaches the mask registry
+  # through the same Argument.StringValue() a --vars-file or CLI value does, so
+  # a secret written into `default:` masks like any other.
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: app_name, default: listdefaultzzz, sensitive: true }
+  tasks:
+    - dokku_app: { app: "{{ .app_name }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  refute_output --partial "listdefaultzzz"
+  assert_output --partial "dokku_app[app=***]"
+}
+
 @test "--list-tasks masks a whitespace-padded sensitive loop item in the name" {
   # #473: the `(item=<value>)` suffix renders the item through TrimSpace, so a
   # secret carrying leading or trailing whitespace stopped matching the literal


### PR DESCRIPTION
`docs/inputs.md` is the canonical reference for the input block, but its property table never listed `sensitive`, so the one page named after the feature omitted the property that decides whether a secret is printed. Every other page already treats it as established. The row is short, and the semantics it cannot carry get a section of their own: masking is display-only, it covers every stream docket writes rather than only the human one, and it widens rather than narrows when a value carries padding or a character Go quoting escapes. The See also gains the `docket export` link, since the vars-file export writes is a `--vars-file` and the two halves of that story lived in different files with no path between them.

Writing the section turned up a leak on the same surface. An input declared `sensitive: true` has its resolved value registered for masking before the recipe is parsed, but `--help` is rendered earlier still, so the registry is empty and pflag printed a `default:` written into the recipe verbatim. The advertised default is now rewritten to the mask placeholder, which changes only the usage string: the flag still holds the real value, so the input resolves to it and masks like any other secret once a run starts. An input that declared no default is untouched, which is the shape `docket export` generates and the one the new section recommends.

Fixes #490.
