### PR TITLE
fix: accept every bool spelling the command line accepts

### DIFF
--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -124,20 +124,6 @@ func (c *Argument) SetStringValue(ptr *string) {
 	c.stringValue = ptr
 }
 
-// isTrueString and isFalseString delegate to tasks.ParseInputBool so the flag
-// path, the --vars-file coercion in coerceBool, and the invalid_input_default
-// diagnostic all agree on which spellings are a bool. Splitting them back apart
-// would let a `default:` the validator accepts fail to register, or the reverse.
-func isTrueString(s string) bool {
-	v, ok := tasks.ParseInputBool(s)
-	return ok && v
-}
-
-func isFalseString(s string) bool {
-	v, ok := tasks.ParseInputBool(s)
-	return ok && !v
-}
-
 func getTaskYamlFilename(s []string) string {
 	path, _ := resolveTaskFileFromArgs(s)
 	return path
@@ -510,20 +496,45 @@ func coerceFloat(value interface{}) (float64, error) {
 	return 0, fmt.Errorf("expected float, got %T", value)
 }
 
+// coerceBool reads a --vars-file value for a `type: bool` input. Strings go
+// through tasks.ParseInputBool so the vars file, a recipe `default:`, and the
+// invalid_input_default diagnostic all agree on which spellings are a bool.
+//
+// A native number is a bool only when it is exactly 1 or 0 - the spelling pflag
+// takes for `--debug=1`, which a hand-written or generated vars file has no
+// reason to spell differently (#495). Any other number is an error rather than
+// C-style truthiness. The reverse does not hold: coerceInt and coerceFloat
+// reject a native bool, the same way pflag refuses `--replicas=true`.
 func coerceBool(value interface{}) (bool, error) {
 	switch v := value.(type) {
 	case bool:
 		return v, nil
 	case string:
-		if isTrueString(v) {
-			return true, nil
-		}
-		if isFalseString(v) {
-			return false, nil
+		if b, ok := tasks.ParseInputBool(v); ok {
+			return b, nil
 		}
 		return false, fmt.Errorf("expected bool, got %q", v)
+	case int:
+		return coerceBoolNumber(float64(v), v)
+	case int64:
+		return coerceBoolNumber(float64(v), v)
+	case float64:
+		return coerceBoolNumber(v, v)
 	}
 	return false, fmt.Errorf("expected bool, got %T", value)
+}
+
+// coerceBoolNumber maps the numbers pflag spells a bool with onto one, naming
+// the value rather than its Go type in the error a number outside that pair
+// raises: "expected bool, got 2" is actionable where "got int" is not.
+func coerceBoolNumber(n float64, original interface{}) (bool, error) {
+	switch n {
+	case 1:
+		return true, nil
+	case 0:
+		return false, nil
+	}
+	return false, fmt.Errorf("expected bool, got %v", original)
 }
 
 // loadVarsFiles parses each path left-to-right and returns three views of the
@@ -749,7 +760,11 @@ func holdsSensitiveInput(keys []string, arguments map[string]*Argument) bool {
 //
 // A sensitive value is registered only when the recipe declared it or the user
 // supplied it. Registering an implicit zero would hand the masker "0" or
-// "false" and blank out every unrelated occurrence of that substring.
+// "false" and blank out every unrelated occurrence of that substring. A
+// declared one still registers whatever the input resolved to, so a
+// `sensitive: true, type: bool, default: 1` hands it the literal "true" - the
+// documented reason to keep `sensitive:` for string inputs holding real
+// secrets.
 func buildInputContext(arguments map[string]*Argument, userSet map[string]bool) (map[string]interface{}, []string, error) {
 	names := make([]string, 0, len(arguments))
 	for name := range arguments {

--- a/commands/apply_args_test.go
+++ b/commands/apply_args_test.go
@@ -10,46 +10,80 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-func TestIsTrueString(t *testing.T) {
-	trueValues := []string{"true", "yes", "on", "y", "Y"}
-	for _, v := range trueValues {
-		if !isTrueString(v) {
-			t.Errorf("isTrueString(%q) = false, want true", v)
-		}
+// TestCoerceBool covers the --vars-file half of #495: a string goes through
+// tasks.ParseInputBool, so the vars file reads the same vocabulary a `default:`
+// does, and a native 1 / 0 is the bool pflag reads `--debug=1` as.
+func TestCoerceBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   interface{}
+		want    bool
+		wantErr bool
+	}{
+		{"native true", true, true, false},
+		{"native false", false, false, false},
+		{"string true", "true", true, false},
+		{"string cased", "TRUE", true, false},
+		{"string yes", "yes", true, false},
+		{"string on", "On", true, false},
+		{"string t", "t", true, false},
+		{"string one", "1", true, false},
+		{"string false", "false", false, false},
+		{"string no", "No", false, false},
+		{"string off", "off", false, false},
+		{"string f", "F", false, false},
+		{"string zero", "0", false, false},
+		{"int one", 1, true, false},
+		{"int zero", 0, false, false},
+		{"int64 one", int64(1), true, false},
+		{"float one", float64(1), true, false},
+		{"float zero", float64(0), false, false},
+		{"other int rejected", 2, false, true},
+		{"negative int rejected", -1, false, true},
+		{"fractional float rejected", 1.5, false, true},
+		{"unrelated string rejected", "maybe", false, true},
+		{"empty string rejected", "", false, true},
+		{"list rejected", []interface{}{true}, false, true},
 	}
-
-	falseValues := []string{"false", "no", "off", "n", "N", "", "maybe", "1", "0"}
-	for _, v := range falseValues {
-		if isTrueString(v) {
-			t.Errorf("isTrueString(%q) = true, want false", v)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := coerceBool(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("coerceBool(%#v) = %v, want an error", tt.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("coerceBool(%#v) failed: %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Errorf("coerceBool(%#v) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
 	}
 }
 
-func TestIsFalseString(t *testing.T) {
-	falseValues := []string{"false", "no", "off", "n", "N"}
-	for _, v := range falseValues {
-		if !isFalseString(v) {
-			t.Errorf("isFalseString(%q) = false, want true", v)
-		}
+// TestCoerceBoolNumberErrorNamesTheValue: "expected bool, got 2" is actionable
+// where "expected bool, got int" is not.
+func TestCoerceBoolNumberErrorNamesTheValue(t *testing.T) {
+	_, err := coerceBool(2)
+	if err == nil {
+		t.Fatal("expected an error for 2")
 	}
-
-	trueValues := []string{"true", "yes", "on", "y", "Y", "", "maybe", "1", "0"}
-	for _, v := range trueValues {
-		if isFalseString(v) {
-			t.Errorf("isFalseString(%q) = true, want false", v)
-		}
+	if !strings.Contains(err.Error(), "got 2") {
+		t.Errorf("error = %q, want it to name the value", err)
 	}
 }
 
-func TestIsTrueAndFalseAreMutuallyExclusive(t *testing.T) {
-	allValues := []string{"true", "false", "yes", "no", "on", "off", "y", "n", "Y", "N", "", "maybe"}
-	for _, v := range allValues {
-		isTrue := isTrueString(v)
-		isFalse := isFalseString(v)
-		if isTrue && isFalse {
-			t.Errorf("value %q is both true and false", v)
-		}
+// TestCoerceIntAndFloatStillRejectBool: the widening runs one way. pflag takes
+// `--debug=1` and refuses `--replicas=true`, and the vars file matches it.
+func TestCoerceIntAndFloatStillRejectBool(t *testing.T) {
+	if _, err := coerceInt(true); err == nil {
+		t.Error("coerceInt(true) succeeded, want an error")
+	}
+	if _, err := coerceFloat(true); err == nil {
+		t.Error("coerceFloat(true) succeeded, want an error")
 	}
 }
 
@@ -664,9 +698,13 @@ func TestSetFromVarsFileBool(t *testing.T) {
 		{"string true", "true", true, false},
 		{"string yes", "yes", true, false},
 		{"string on", "on", true, false},
+		{"string cased", "True", true, false},
 		{"string false", "false", false, false},
 		{"string no", "no", false, false},
-		{"int rejected", 1, false, true},
+		{"int one", 1, true, false},
+		{"int zero", 0, false, false},
+		{"float one", float64(1), true, false},
+		{"other int rejected", 2, false, true},
 		{"unrelated string rejected", "banana", false, true},
 	}
 	for _, tt := range tests {

--- a/commands/input_bool_spellings_test.go
+++ b/commands/input_bool_spellings_test.go
@@ -1,0 +1,235 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+
+	flag "github.com/spf13/pflag"
+)
+
+// input_bool_spellings_test.go covers #495. A bool input had three faces and
+// each parsed a different vocabulary: `default:` and `--vars-file` read
+// true/yes/on/y, pflag read true/false/1/0/t/f on the command line, and neither
+// set contained the other - so `default: 1` was an error while `--debug=1` was
+// not, and `default: True` was an error while YAML considered it the same value
+// as `default: true`. docket's table is now the case-insensitive union, which
+// makes it a superset of pflag's.
+//
+// The second half is that a resolved default has to reach the render as its
+// type. An input declared on a play that also has tasks is play-local, which is
+// the shape of the issue's own reproduction, and those defaults used to layer
+// into the context as the raw text the recipe wrote.
+
+// boolSpellingRecipe declares one bool input with the given default and renders
+// it into a task body, so --list-tasks shows what the input resolved to.
+func boolSpellingRecipe(def string) string {
+	return `---
+- inputs:
+    - { name: debug, type: bool, default: ` + def + ` }
+  tasks:
+    - dokku_app: { app: "web-{{ .debug }}" }
+`
+}
+
+func TestBoolDefaultTakesEverySpellingTheCommandLineTakes(t *testing.T) {
+	tests := map[string]string{
+		"1":     "web-true",
+		"t":     "web-true",
+		"T":     "web-true",
+		"True":  "web-true",
+		"TRUE":  "web-true",
+		"On":    "web-true",
+		"YES":   "web-true",
+		"0":     "web-false",
+		"f":     "web-false",
+		"False": "web-false",
+		"FALSE": "web-false",
+		"Off":   "web-false",
+		"N":     "web-false",
+	}
+	for def, want := range tests {
+		t.Run(def, func(t *testing.T) {
+			path := writeTasksFile(t, boolSpellingRecipe(def))
+
+			stdout, stderr, exit := runValidate(t, path)
+			if exit != 0 {
+				t.Fatalf("validate exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+			}
+
+			stdout, stderr, exit = runApply(t, path, "--list-tasks")
+			if exit != 0 {
+				t.Fatalf("apply exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+			}
+			if !strings.Contains(stdout, "dokku_app[app="+want+"]") {
+				t.Errorf("default %q did not resolve to %q; got:\n%s", def, want, stdout)
+			}
+		})
+	}
+}
+
+// TestBoolDefaultStillRejectsANearMiss: the table widened, it did not stop
+// judging. A spelling in neither vocabulary is still invalid_input_default.
+func TestBoolDefaultStillRejectsANearMiss(t *testing.T) {
+	for _, def := range []string{"maybe", "2", "yeah"} {
+		t.Run(def, func(t *testing.T) {
+			path := writeTasksFile(t, boolSpellingRecipe(def))
+			stdout, stderr, exit := runValidate(t, path)
+			if exit != 1 {
+				t.Fatalf("exit = %d, want 1; stdout=%s stderr=%s", exit, stdout, stderr)
+			}
+			human := stdout + stderr
+			if !strings.Contains(human, `its default "`+def+`" is not a valid bool`) {
+				t.Errorf("output does not name the default; got:\n%s", human)
+			}
+			if !strings.Contains(human, "use one of true, yes, on, y, t, 1") {
+				t.Errorf("output does not carry the widened hint; got:\n%s", human)
+			}
+		})
+	}
+}
+
+// TestRegisterInputFlagsWidenedBoolDefault: the flag the recipe registers holds
+// the resolved value, so `--help` and an untouched run agree with validate.
+func TestRegisterInputFlagsWidenedBoolDefault(t *testing.T) {
+	f := flag.NewFlagSet("apply", flag.ContinueOnError)
+	arguments, err := registerInputFlags(f, []byte(boolSpellingRecipe("On")), tasks.FormatYAML)
+	if err != nil {
+		t.Fatalf("registerInputFlags returned error: %v", err)
+	}
+	debug, ok := arguments["debug"]
+	if !ok {
+		t.Fatal("no argument registered for the bool input")
+	}
+	if got := debug.StringValue(); got != "true" {
+		t.Errorf("debug resolved to %q, want %q", got, "true")
+	}
+	if !debug.HasDefault {
+		t.Error("debug.HasDefault = false, but the recipe declared one")
+	}
+}
+
+// TestVarsFileSpellsABoolTheWayTheCommandLineDoes is the issue's third face: a
+// vars file used to refuse `debug: 1` while `--debug=1` was accepted.
+func TestVarsFileSpellsABoolTheWayTheCommandLineDoes(t *testing.T) {
+	tests := map[string]struct {
+		vars string
+		want string
+	}{
+		"native number one":  {"debug: 1\n", "web-true"},
+		"native number zero": {"debug: 0\n", "web-false"},
+		"string cased":       {"debug: \"On\"\n", "web-true"},
+		"string off":         {"debug: \"off\"\n", "web-false"},
+		"native bool":        {"debug: true\n", "web-true"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := writeTasksFile(t, boolSpellingRecipe("false"))
+			vars := filepath.Join(filepath.Dir(path), "vars.yml")
+			if err := os.WriteFile(vars, []byte(tt.vars), 0o644); err != nil {
+				t.Fatalf("write vars.yml: %v", err)
+			}
+
+			stdout, stderr, exit := runApply(t, path, "--list-tasks", "--vars-file", vars)
+			if exit != 0 {
+				t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+			}
+			if !strings.Contains(stdout, "dokku_app[app="+tt.want+"]") {
+				t.Errorf("vars file %q did not resolve to %q; got:\n%s", tt.vars, tt.want, stdout)
+			}
+		})
+	}
+}
+
+// TestVarsFileRejectsANumberThatIsNotABool: 1 and 0 are the spellings pflag
+// takes, not an invitation to C-style truthiness.
+func TestVarsFileRejectsANumberThatIsNotABool(t *testing.T) {
+	path := writeTasksFile(t, boolSpellingRecipe("false"))
+	vars := filepath.Join(filepath.Dir(path), "vars.yml")
+	if err := os.WriteFile(vars, []byte("debug: 2\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yml: %v", err)
+	}
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks", "--vars-file", vars)
+	if exit == 0 {
+		t.Fatalf("exit = 0, want failure; stdout=%s stderr=%s", stdout, stderr)
+	}
+	human := stdout + stderr
+	if !strings.Contains(human, `input "debug"`) || !strings.Contains(human, "got 2") {
+		t.Errorf("error does not name the input and the value; got:\n%s", human)
+	}
+}
+
+// TestPlayLocalBoolDefaultResolvesToItsType is the issue's own reproduction
+// shape: one play carrying both the input and the tasks, which makes the input
+// play-local. Its default used to layer into the render context as raw text, so
+// a widened spelling would have rendered `web-On` where the flag path renders
+// `web-true`.
+func TestPlayLocalBoolDefaultResolvesToItsType(t *testing.T) {
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: file_level, type: bool, default: "on" }
+- name: api
+  inputs:
+    - { name: play_local, type: bool, default: "on" }
+    - { name: replicas, type: int, default: "007" }
+  tasks:
+    - dokku_app: { app: "web-{{ .file_level }}-{{ .play_local }}-{{ .replicas }}" }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "dokku_app[app=web-true-true-7]") {
+		t.Errorf("a play-local default did not resolve to its type; got:\n%s", stdout)
+	}
+}
+
+// TestBoolInputReadsTheSameInWhenFromEitherLayer pins the parity the play-local
+// coercion buys: a predicate comparing a bool input reads the same value
+// whether the input was declared file-level or play-local. Before, a play-local
+// input compared the string "true" to a bool and was never equal.
+func TestBoolInputReadsTheSameInWhenFromEitherLayer(t *testing.T) {
+	recipe := func(def string) string {
+		return `---
+- inputs:
+    - { name: file_debug, type: bool, default: "` + def + `" }
+- name: api
+  inputs:
+    - { name: play_debug, type: bool, default: "` + def + `" }
+  tasks:
+    - name: from-file-level
+      when: 'file_debug == true'
+      dokku_app: { app: a }
+    - name: from-play-local
+      when: 'play_debug == true'
+      dokku_app: { app: b }
+`
+	}
+
+	t.Run("true", func(t *testing.T) {
+		path := writeTasksFile(t, recipe("yes"))
+		stdout, stderr, exit := runApply(t, path, "--list-tasks")
+		if exit != 0 {
+			t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+		}
+		if strings.Contains(stdout, "[skipped]") {
+			t.Errorf("a task was skipped although both inputs are true; got:\n%s", stdout)
+		}
+	})
+
+	t.Run("false", func(t *testing.T) {
+		path := writeTasksFile(t, recipe("no"))
+		stdout, stderr, exit := runApply(t, path, "--list-tasks")
+		if exit != 0 {
+			t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+		}
+		if strings.Count(stdout, "[skipped]") != 2 {
+			t.Errorf("want both tasks skipped; got:\n%s", stdout)
+		}
+	})
+}

--- a/commands/validate_input_declaration_test.go
+++ b/commands/validate_input_declaration_test.go
@@ -87,7 +87,7 @@ func TestValidateReportsInvalidInputDeclarations(t *testing.T) {
 `,
 			code:    "invalid_input_default",
 			message: `input "debug" declares type bool but its default "maybe" is not a valid bool`,
-			hint:    "use one of true, yes, on, y",
+			hint:    "use one of true, yes, on, y, t, 1 (or false, no, off, n, f, 0); case does not matter",
 		},
 	}
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -60,10 +60,12 @@ reports one that is not as `invalid_input_default`, and a `type:` outside the fo
 `invalid_input_type`, both naming the input and the line it sits on; `plan` and `apply` refuse the
 recipe offline with the same message rather than running it.
 
-A `bool` default is spelled `true`, `yes`, `on`, or `y` (or `false`, `no`, `off`, `n`) - the same
-vocabulary a `--vars-file` uses, and deliberately not pflag's, which is what parses a `--debug=1`
-typed on the command line. A `default:` is read as the text of the scalar you wrote, so an unquoted
-`default: true` is fine but `default: True` is not.
+A `bool` default is spelled `true`, `yes`, `on`, `y`, `t`, or `1` (or `false`, `no`, `off`, `n`,
+`f`, `0`), in any case - `True` and `TRUE` read the same as `true`. That is the same vocabulary a
+`--vars-file` uses, and it is a superset of pflag's, which is what parses a `--debug=1` typed on the
+command line, so every spelling the command line accepts is also a spelling a `default:` accepts.
+The reverse does not hold: pflag takes only `true`/`false`/`1`/`0`/`t`/`f`, so `--debug=yes` is not
+a command line docket accepts.
 
 ## Input names
 
@@ -291,9 +293,11 @@ Values are coerced to each input's declared `type`:
 - `string`: any scalar (a YAML boolean `true` becomes the string `"true"`).
 - `int`: whole numbers, including numeric strings and whole-valued JSON numbers.
 - `float`: floats, ints, and parseable numeric strings.
-- `bool`: native booleans, or a string spelled `true`/`yes`/`on`/`y` (or `false`/`no`/`off`/`n`).
-  A `--name=value` flag on the command line is parsed separately by pflag, which accepts
-  `true`/`false`/`1`/`0` but not `yes`/`on`.
+- `bool`: native booleans, a native `1` or `0`, or a string spelled `true`/`yes`/`on`/`y`/`t`/`1`
+  (or `false`/`no`/`off`/`n`/`f`/`0`) in any case. Any other number is an error rather than a
+  truthiness test, so `debug: 2` is refused. A `--name=value` flag on the command line is parsed
+  separately by pflag, which accepts the `true`/`false`/`1`/`0`/`t`/`f` subset of these but not
+  `yes`/`on`.
 
 A key in a vars file that does not match any declared input is a hard error, with a suggestion for
 the closest real name:

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -136,7 +136,9 @@ specific step, for example enabling Let's Encrypt only in production:
         state: present
 ```
 
-The expression sees the file-level inputs. Inside a `loop:` it also sees `.item` and `.index`.
+The expression sees the inputs visible to the play it sits in - the file-level ones plus that play's
+own [play-local inputs](inputs.md#per-play-inputs-precedence), each resolved to its declared `type:`.
+Inside a `loop:` it also sees `.item` and `.index`.
 Once any task has used `register:`, every later predicate also sees `.registered.<name>` (below).
 
 ## `loop`: repeat a task over a list

--- a/tasks/input.go
+++ b/tasks/input.go
@@ -1,11 +1,24 @@
 package tasks
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+)
 
 // InputTypeNames lists the `type:` values an input may declare, in the
 // canonical order diagnostics spell them. An input that declares no `type:` is
 // a string.
 var InputTypeNames = []string{"bool", "float", "int", "string"}
+
+// InputBoolTrueSpellings and InputBoolFalseSpellings are the spellings a bool
+// input value may be written in, in the order diagnostics list them. They are
+// the union of docket's own vocabulary and pflag's, so the set is a superset of
+// what `strconv.ParseBool` takes: every spelling that works on the command line
+// also works as a `default:` or a --vars-file value (#495).
+var (
+	InputBoolTrueSpellings  = []string{"true", "yes", "on", "y", "t", "1"}
+	InputBoolFalseSpellings = []string{"false", "no", "off", "n", "f", "0"}
+)
 
 // CanonicalInputType maps a declared `type:` onto its canonical spelling,
 // resolving the empty type to "string". ok is false for a type docket does not
@@ -21,19 +34,26 @@ func CanonicalInputType(t string) (string, bool) {
 }
 
 // ParseInputBool parses the string spelling of a bool input value - a recipe
-// `default:` or a --vars-file scalar - into a bool. ok is false for any other
-// spelling, the empty string included: a caller that treats an omitted default
-// as the type's zero value checks for that before asking.
+// `default:` or a --vars-file scalar - into a bool. Matching is
+// case-insensitive, so `True` and `TRUE` read the same as `true`. ok is false
+// for any other spelling, the empty string included: a caller that treats an
+// omitted default as the type's zero value checks for that before asking.
 //
-// These are docket's own spellings, not pflag's. A `--name=value` flag typed on
-// the command line is parsed by pflag, which takes true/false/1/0 but not
-// yes/on; see docs/inputs.md.
+// The table is a superset of the one pflag parses a `--name=value` flag with,
+// which is what keeps the two from disagreeing about the same recipe. It is not
+// a subset: `yes` and `on` are docket's alone, so they remain unusable on the
+// command line. See docs/inputs.md.
 func ParseInputBool(s string) (bool, bool) {
-	switch s {
-	case "true", "yes", "on", "y", "Y":
-		return true, true
-	case "false", "no", "off", "n", "N":
-		return false, true
+	lowered := strings.ToLower(s)
+	for _, spelling := range InputBoolTrueSpellings {
+		if lowered == spelling {
+			return true, true
+		}
+	}
+	for _, spelling := range InputBoolFalseSpellings {
+		if lowered == spelling {
+			return false, true
+		}
 	}
 	return false, false
 }
@@ -50,4 +70,40 @@ func ParseInputInt(s string) (int, bool) {
 func ParseInputFloat(s string) (float64, bool) {
 	v, err := strconv.ParseFloat(s, 64)
 	return v, err == nil
+}
+
+// inputDefaultValue resolves a declared `default:` to the value the input
+// renders as, in the same Go shape commands.registerInputFlags hands the flag
+// set: a typed pointer for bool / int / float, so a `default: on` renders as
+// `true` rather than as the text `on`, and both halves of a recipe's input
+// context hold the same thing (#495).
+//
+// The fallback is the raw text, not the type's zero value: a default that does
+// not parse, or a `type:` docket does not implement, is reported as
+// invalid_input_default / invalid_input_type, and `validate` collects its
+// problems and keeps rendering. Substituting a zero there would hide the text
+// an unsafe_input_value diagnostic needs to see.
+//
+// Each call allocates its own pointer, so two plays declaring the same input
+// name never share one.
+func inputDefaultValue(typ, def string) interface{} {
+	canonical, ok := CanonicalInputType(typ)
+	if !ok {
+		return def
+	}
+	switch canonical {
+	case "bool":
+		if v, parsed := ParseInputBool(def); parsed {
+			return &v
+		}
+	case "int":
+		if v, parsed := ParseInputInt(def); parsed {
+			return &v
+		}
+	case "float":
+		if v, parsed := ParseInputFloat(def); parsed {
+			return &v
+		}
+	}
+	return def
 }

--- a/tasks/input_declaration_test.go
+++ b/tasks/input_declaration_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -60,9 +61,8 @@ func TestCheckInputDeclarationsFlagsUnparseableDefault(t *testing.T) {
 		"int":   {`- { name: port, type: int, default: abc }`, `input "port" declares type int but its default "abc" is not a valid int`},
 		"float": {`- { name: ratio, type: float, default: half }`, `input "ratio" declares type float but its default "half" is not a valid float`},
 		"bool":  {`- { name: debug, type: bool, default: maybe }`, `input "debug" declares type bool but its default "maybe" is not a valid bool`},
-		// YAML hands the field the text that was written, so an unquoted
-		// `True` arrives as "True" and is not one of docket's spellings.
-		"bool cased": {`- { name: debug, type: bool, default: True }`, `input "debug" declares type bool but its default "True" is not a valid bool`},
+		// A near miss of a real spelling is still a miss, widened table or not.
+		"bool number": {`- { name: debug, type: bool, default: 2 }`, `input "debug" declares type bool but its default "2" is not a valid bool`},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -94,6 +94,21 @@ func TestCheckInputDeclarationsAcceptsOmittedDefault(t *testing.T) {
 `)
 	if problems := checkInputDeclarations(declaredInputs(data, FormatYAML)); len(problems) > 0 {
 		t.Errorf("omitted defaults were flagged: %+v", problems)
+	}
+}
+
+// TestCheckInputDeclarationsAcceptsWidenedBoolDefaults: #495. YAML hands the
+// field the text that was written, so an unquoted `True` arrives as "True" and
+// a `1` as "1"; both are the same value the command line spells that way, and
+// the validator now reads them as such.
+func TestCheckInputDeclarationsAcceptsWidenedBoolDefaults(t *testing.T) {
+	for _, def := range []string{"True", "TRUE", "1", "0", "On", "off", "t", "F", "Y", "n"} {
+		t.Run(def, func(t *testing.T) {
+			data := []byte("---\n- inputs:\n    - { name: debug, type: bool, default: " + def + " }\n  tasks: []\n")
+			if problems := checkInputDeclarations(declaredInputs(data, FormatYAML)); len(problems) > 0 {
+				t.Errorf("default %q was flagged: %+v", def, problems)
+			}
+		})
 	}
 }
 
@@ -159,22 +174,48 @@ func TestValidateReportsInvalidInputType(t *testing.T) {
 	}
 }
 
+// TestParseInputBoolSpellings pins the widened table from #495: docket's
+// vocabulary is the union of its own and pflag's, matched case-insensitively,
+// so every spelling `--debug=...` takes on the command line is also a spelling
+// a `default:` or a --vars-file value may use.
 func TestParseInputBoolSpellings(t *testing.T) {
-	for _, s := range []string{"true", "yes", "on", "y", "Y"} {
+	for _, s := range []string{"true", "yes", "on", "y", "t", "1", "True", "TRUE", "Yes", "ON", "Y", "T"} {
 		if v, ok := ParseInputBool(s); !ok || !v {
 			t.Errorf("ParseInputBool(%q) = (%v, %v), want (true, true)", s, v, ok)
 		}
 	}
-	for _, s := range []string{"false", "no", "off", "n", "N"} {
+	for _, s := range []string{"false", "no", "off", "n", "f", "0", "False", "FALSE", "No", "Off", "N", "F"} {
 		if v, ok := ParseInputBool(s); !ok || v {
 			t.Errorf("ParseInputBool(%q) = (%v, %v), want (false, true)", s, v, ok)
 		}
 	}
 	// The empty string is not a spelling: a caller that treats an omitted
-	// default as the zero value checks for it before asking.
-	for _, s := range []string{"", "maybe", "1", "0", "True"} {
+	// default as the zero value checks for it before asking. Widening the table
+	// did not make it a free-for-all - a near miss is still a near miss.
+	for _, s := range []string{"", "maybe", "2", "-1", "1.0", "yeah", "onn", " true", "true "} {
 		if _, ok := ParseInputBool(s); ok {
 			t.Errorf("ParseInputBool(%q) reported ok", s)
+		}
+	}
+}
+
+// TestParseInputBoolCoversPflag is the point of #495 stated directly: pflag
+// parses the command line with strconv.ParseBool, so anything it accepts there
+// has to be readable as a `default:` too, or the same spelling means two things
+// in one recipe.
+func TestParseInputBoolCoversPflag(t *testing.T) {
+	for _, s := range []string{"1", "t", "T", "TRUE", "true", "True", "0", "f", "F", "FALSE", "false", "False"} {
+		want, err := strconv.ParseBool(s)
+		if err != nil {
+			t.Fatalf("strconv.ParseBool(%q) failed, fix the test table: %v", s, err)
+		}
+		got, ok := ParseInputBool(s)
+		if !ok {
+			t.Errorf("ParseInputBool(%q) reported not-ok, but pflag accepts it", s)
+			continue
+		}
+		if got != want {
+			t.Errorf("ParseInputBool(%q) = %v, pflag reads it as %v", s, got, want)
 		}
 	}
 }

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -783,6 +783,12 @@ func renderRecipeBytes(data []byte, context map[string]interface{}) ([]byte, err
 // Default string are skipped so they cannot accidentally shadow a real
 // file-level value with "".
 //
+// A default is layered in resolved to its declared type, matching the typed
+// pointer the base context already holds for the same input from flag
+// registration. Injecting the raw text instead made a play-local
+// `type: bool, default: on` render as `on` where the file-level half rendered
+// `true`, and made `when: 'debug == true'` compare a string to a bool (#495).
+//
 // Exported because the apply / plan executors need to build the same
 // per-play context the loader used so per-task `when:` predicates see
 // the same values as the rendered task bodies.
@@ -801,7 +807,7 @@ func BuildPerPlayContext(base map[string]interface{}, playInputs []Input, userSe
 		if in.Default == "" {
 			continue
 		}
-		out[in.Name] = in.Default
+		out[in.Name] = inputDefaultValue(in.Type, in.Default)
 	}
 	return out
 }

--- a/tasks/play_test.go
+++ b/tasks/play_test.go
@@ -297,6 +297,74 @@ func TestBuildPerPlayContextRespectsUserSet(t *testing.T) {
 	}
 }
 
+// TestBuildPerPlayContextResolvesTypedDefaults covers #495. A play-local
+// default used to layer in as the raw text the recipe wrote, while the same
+// input reached the base context as the typed pointer flag registration
+// allocated - so `type: bool, default: on` rendered as `on` in a play-local
+// input and as `true` in a file-level one. Both halves now hold the same shape.
+func TestBuildPerPlayContextResolvesTypedDefaults(t *testing.T) {
+	playInputs := []Input{
+		{Name: "debug", Type: "bool", Default: "on"},
+		{Name: "quiet", Type: "bool", Default: "0"},
+		{Name: "replicas", Type: "int", Default: "3"},
+		{Name: "ratio", Type: "float", Default: "1.5"},
+		{Name: "app", Default: "web"},
+		{Name: "broken", Type: "bool", Default: "mabye"},
+		{Name: "untyped", Type: "duration", Default: "5s"},
+	}
+
+	out := BuildPerPlayContext(map[string]interface{}{}, playInputs, nil)
+
+	if v, ok := out["debug"].(*bool); !ok || v == nil || !*v {
+		t.Errorf("debug = %#v, want a *bool holding true", out["debug"])
+	}
+	if v, ok := out["quiet"].(*bool); !ok || v == nil || *v {
+		t.Errorf("quiet = %#v, want a *bool holding false", out["quiet"])
+	}
+	if v, ok := out["replicas"].(*int); !ok || v == nil || *v != 3 {
+		t.Errorf("replicas = %#v, want a *int holding 3", out["replicas"])
+	}
+	if v, ok := out["ratio"].(*float64); !ok || v == nil || *v != 1.5 {
+		t.Errorf("ratio = %#v, want a *float64 holding 1.5", out["ratio"])
+	}
+	// A string default is already the text it renders as.
+	if v, ok := out["app"].(string); !ok || v != "web" {
+		t.Errorf("app = %#v, want the raw string %q", out["app"], "web")
+	}
+	// A default the loader rejects keeps its text rather than becoming a zero:
+	// validate collects its problems and keeps rendering, and the text is what
+	// an unsafe_input_value diagnostic has to see.
+	if v, ok := out["broken"].(string); !ok || v != "mabye" {
+		t.Errorf("broken = %#v, want the raw string %q", out["broken"], "mabye")
+	}
+	if v, ok := out["untyped"].(string); !ok || v != "5s" {
+		t.Errorf("untyped = %#v, want the raw string %q", out["untyped"], "5s")
+	}
+}
+
+// TestBuildPerPlayContextAllocatesPerCall: two plays declaring the same input
+// name with different defaults must not alias one pointer.
+func TestBuildPerPlayContextAllocatesPerCall(t *testing.T) {
+	base := map[string]interface{}{}
+	first := BuildPerPlayContext(base, []Input{{Name: "debug", Type: "bool", Default: "true"}}, nil)
+	second := BuildPerPlayContext(base, []Input{{Name: "debug", Type: "bool", Default: "false"}}, nil)
+
+	firstValue, ok := first["debug"].(*bool)
+	if !ok {
+		t.Fatalf("first debug = %#v, want a *bool", first["debug"])
+	}
+	secondValue, ok := second["debug"].(*bool)
+	if !ok {
+		t.Fatalf("second debug = %#v, want a *bool", second["debug"])
+	}
+	if firstValue == secondValue {
+		t.Fatal("both plays share one pointer; the second default overwrote the first")
+	}
+	if !*firstValue || *secondValue {
+		t.Errorf("values = (%v, %v), want (true, false)", *firstValue, *secondValue)
+	}
+}
+
 func TestMergePlayTagsDedupsAndPreservesOrder(t *testing.T) {
 	got := mergePlayTags([]string{"deploy"}, []string{"api", "deploy"})
 	want := []string{"deploy", "api"}

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -977,10 +977,10 @@ func extractPlayInputs(recipe *yaml.Node) [][]inputWithNode {
 }
 
 // buildSigilContext assembles the variable map sigil renders against. Inputs
-// with a non-empty Default contribute their default value; inputs without a
-// default contribute validatePlaceholder so the render does not error on
-// missing keys. Names collide cleanly across plays since sigil receives a
-// single flat namespace.
+// with a non-empty Default contribute that default resolved to its declared
+// type; inputs without a default contribute validatePlaceholder so the render
+// does not error on missing keys. Names collide cleanly across plays since
+// sigil receives a single flat namespace.
 //
 // `.item` and `.index` references in loop-body templates are hidden from
 // the file-level render via escapeLoopVars / unescapeLoopVars, so they
@@ -1000,7 +1000,10 @@ func buildSigilContext(plays [][]inputWithNode) map[string]interface{} {
 				continue
 			}
 			if in.Default != "" {
-				context[in.Name] = in.Default
+				// Coerced the way the flag path coerces it, so validate
+				// renders the recipe apply would render: a `type: bool,
+				// default: on` is checked as `true`, not as `on` (#495).
+				context[in.Name] = inputDefaultValue(in.Type, in.Default)
 			} else if _, ok := context[in.Name]; !ok {
 				context[in.Name] = validatePlaceholder
 			}
@@ -1137,7 +1140,9 @@ func inputDefaultHint(typ, def string) string {
 	switch typ {
 	case "bool":
 		if _, ok := ParseInputBool(def); !ok {
-			return `use one of true, yes, on, y (or false, no, off, n)`
+			return fmt.Sprintf("use one of %s (or %s); case does not matter",
+				strings.Join(InputBoolTrueSpellings, ", "),
+				strings.Join(InputBoolFalseSpellings, ", "))
 		}
 	case "int":
 		if _, ok := ParseInputInt(def); !ok {

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -1529,3 +1529,50 @@ func TestValidateCLIReferencesSkippedWithoutStrict(t *testing.T) {
 		t.Errorf("non-strict should not surface unknown_start_at_task; got: %+v", *p)
 	}
 }
+
+// TestBuildSigilContextResolvesTypedDefaults covers the validate half of #495.
+// validate renders every input from its declared default, and it used to render
+// the raw text where apply renders the coerced value - so a recipe apply
+// rendered as `web-true` was checked as `web-On`.
+func TestBuildSigilContextResolvesTypedDefaults(t *testing.T) {
+	data := []byte(`---
+- inputs:
+    - { name: debug, type: bool, default: On }
+    - { name: replicas, type: int, default: 3 }
+    - { name: app, default: web }
+    - { name: unset, type: bool }
+  tasks:
+    - dokku_app: { app: "{{ .app }}-{{ .debug }}-{{ .replicas }}" }
+`)
+	context := buildSigilContext(declaredInputs(data, FormatYAML))
+
+	rendered, err := renderRecipeBytes(data, context)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+	if !strings.Contains(string(rendered), "web-true-3") {
+		t.Errorf("validate rendered the raw default text; got:\n%s", rendered)
+	}
+	// An input with no default keeps its placeholder rather than resolving to
+	// the type's zero value, so the render still cannot fail on a missing key.
+	if got, ok := context["unset"].(string); !ok || got != validatePlaceholder {
+		t.Errorf("unset = %#v, want the validate placeholder", context["unset"])
+	}
+}
+
+// TestBuildSigilContextKeepsUnparseableDefaultText: validate collects problems
+// and keeps rendering, so a default the loader rejects has to reach the render
+// as the text that was written. Substituting a zero value there would hide the
+// value an unsafe_input_value diagnostic exists to attribute.
+func TestBuildSigilContextKeepsUnparseableDefaultText(t *testing.T) {
+	data := []byte(`---
+- inputs:
+    - { name: debug, type: bool, default: mabye }
+  tasks:
+    - dokku_app: { app: "web-{{ .debug }}" }
+`)
+	context := buildSigilContext(declaredInputs(data, FormatYAML))
+	if got, ok := context["debug"].(string); !ok || got != "mabye" {
+		t.Errorf("debug = %#v, want the raw text %q", context["debug"], "mabye")
+	}
+}

--- a/tests/bats/inputs.bats
+++ b/tests/bats/inputs.bats
@@ -195,3 +195,60 @@ EOF
   run "$(docket_bin)" validate --tasks "$TASKS_FILE" --strict --debug=false
   assert_success
 }
+
+# #495: a bool `default:` used to read a vocabulary that was neither a superset
+# nor a subset of the one pflag parses `--debug=...` with, so the same spelling
+# meant two different things in one recipe. The table is now the union, matched
+# case-insensitively.
+
+@test "a bool default takes the spellings the command line takes" {
+  for default_value in 1 t True TRUE On YES; do
+    write_tasks_file <<EOF
+---
+- inputs:
+    - { name: debug, type: bool, default: $default_value }
+  tasks:
+    - dokku_app: { app: "web-{{ .debug }}" }
+EOF
+    run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+    assert_success
+
+    run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+    assert_success
+    assert_output --partial "dokku_app[app=web-true]"
+  done
+
+  for default_value in 0 f False FALSE Off N; do
+    write_tasks_file <<EOF
+---
+- inputs:
+    - { name: debug, type: bool, default: $default_value }
+  tasks:
+    - dokku_app: { app: "web-{{ .debug }}" }
+EOF
+    run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+    assert_success
+
+    run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+    assert_success
+    assert_output --partial "dokku_app[app=web-false]"
+  done
+}
+
+@test "docket validate still rejects a bool default in neither vocabulary" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: debug, type: bool, default: maybe }
+  tasks:
+    - dokku_app: { app: "web-{{ .debug }}" }
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial 'its default "maybe" is not a valid bool'
+  assert_output --partial 'use one of true, yes, on, y, t, 1 (or false, no, off, n, f, 0)'
+
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --json
+  assert_failure
+  assert_output --partial '"code":"invalid_input_default"'
+}

--- a/tests/bats/plays.bats
+++ b/tests/bats/plays.bats
@@ -500,3 +500,25 @@ EOF
   assert_output --partial "docket-test-noop-api"
   assert_output --partial "docket-test-noop-worker"
 }
+
+# #495: a play-local input default layered into the render context as the raw
+# text the recipe wrote, while the same input reached the base context as the
+# typed value flag registration produced. A play-local `type: bool, default: on`
+# rendered as `on` where a file-level one rendered as `true`.
+@test "plays: a play-local typed default resolves to its type" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - { name: file_debug, type: bool, default: on }
+- name: api
+  inputs:
+    - { name: play_debug, type: bool, default: on }
+    - { name: replicas, type: int, default: 007 }
+  tasks:
+    - dokku_app:
+        app: "web-{{ .file_debug }}-{{ .play_debug }}-{{ .replicas }}"
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "web-true-true-7"
+}

--- a/tests/bats/vars_file.bats
+++ b/tests/bats/vars_file.bats
@@ -323,3 +323,54 @@ EOF
   assert_output --partial 'he said "hi" loudly'
   dokku_clean_app docket-test-dq
 }
+
+# #495: coerceBool read the same narrow table a `default:` did, so `debug: 1` in
+# a vars file was an error while `--debug=1` on the command line was not.
+
+@test "a vars file spells a bool the way the command line does" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: debug, type: bool, default: false }
+  tasks:
+    - dokku_app: { app: "web-{{ .debug }}" }
+EOF
+
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<'EOF'
+debug: 1
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  assert_output --partial "dokku_app[app=web-true]"
+
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<'EOF'
+debug: "On"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  assert_output --partial "dokku_app[app=web-true]"
+
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<'EOF'
+debug: 0
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  assert_output --partial "dokku_app[app=web-false]"
+}
+
+@test "a vars file rejects a number that is not a bool" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: debug, type: bool, default: false }
+  tasks:
+    - dokku_app: { app: "web-{{ .debug }}" }
+EOF
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<'EOF'
+debug: 2
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_failure
+  assert_output --partial 'input "debug"'
+  assert_output --partial "expected bool, got 2"
+}


### PR DESCRIPTION
A bool input's `default:` and a `--vars-file` value now read the case-insensitive union of docket's own spellings and pflag's, so `default: 1`, `default: True`, and a vars file's `debug: 1` mean what `--debug=1` has always meant; the command line is still parsed by pflag, which takes a subset of that vocabulary rather than a different one. A play-local input's default also resolves to its declared type before the recipe renders, so a `type: bool, default: on` declared on a play that also has tasks renders as `true` rather than as the text `on` and compares equal to `true` in a `when:`, which is the shape the issue reproduces with; the cost is that piping such an input through a sigil string filter now errors the way a file-level one already did. A bare `when: debug` is still true whatever the input holds, which is #497.

Fixes #495.
