### PR TITLE
fix: make a bare when: follow the input's value

### DIFF
--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -60,6 +60,36 @@ func (c Argument) HasValue() bool {
 	return c.GetValue() != nil
 }
 
+// ContextValue returns the value the recipe sees for this input: the concrete
+// Go value rather than the flag pointer GetValue reports.
+//
+// The pointer is pflag's, not something the recipe asked for, and putting it in
+// the render / predicate context leaked it into two evaluators that each read a
+// pointer as "true" (#497). expr dereferences the operands of an operator but
+// not a program that is nothing but an identifier, so `when: debug` tested the
+// pointer - never nil for a bool / int / float - instead of the value.
+// text/template's own isTrue counts any non-nil pointer as true, so
+// `{{ if .debug }}` in a recipe body did the same.
+//
+// It differs from GetValue in one place, on purpose: an empty string is a
+// value, not nil, so an input left at its zero value renders as the empty
+// string rather than as text/template's `<no value>`. GetValue keeps the nil
+// because HasValue, IsSatisfied, and StringValue read it as "nothing was
+// supplied".
+func (c Argument) ContextValue() interface{} {
+	switch {
+	case c.boolValue != nil:
+		return *c.boolValue
+	case c.intValue != nil:
+		return *c.intValue
+	case c.floatValue != nil:
+		return *c.floatValue
+	case c.stringValue != nil:
+		return *c.stringValue
+	}
+	return nil
+}
+
 // IsSatisfied reports whether this input has a non-empty value that the recipe
 // or the operator actually wrote. It is the test behind `required: true`, and
 // it needs both halves:
@@ -68,7 +98,7 @@ func (c Argument) HasValue() bool {
 // float is never nil - every non-string input looked satisfied, so `required:`
 // was enforced for strings only (#493). "The user typed the flag" alone cannot
 // answer it either, because `--app=` types the flag and supplies nothing; the
-// input would resolve to an empty string and render as `<no value>`.
+// input would resolve to an empty string and render an empty app name.
 //
 // userSet is whether the operator supplied a value for this input, on the
 // command line or through a --vars-file; see userSetKeys.
@@ -758,6 +788,10 @@ func holdsSensitiveInput(keys []string, arguments map[string]*Argument) bool {
 // Names are walked in sorted order so a recipe missing more than one required
 // input names the same one on every run.
 //
+// The context holds ContextValue, not GetValue: the flag pointer must not reach
+// the render or the predicates, which both read one as true whatever it points
+// at (#497).
+//
 // A sensitive value is registered only when the recipe declared it or the user
 // supplied it. Registering an implicit zero would hand the masker "0" or
 // "false" and blank out every unrelated occurrence of that substring. A
@@ -779,7 +813,7 @@ func buildInputContext(arguments map[string]*Argument, userSet map[string]bool) 
 		if argument.Required && !argument.IsSatisfied(userSet[name]) {
 			return nil, nil, fmt.Errorf("Missing flag '--%s'", name)
 		}
-		context[name] = argument.GetValue()
+		context[name] = argument.ContextValue()
 		if argument.Sensitive && (argument.HasDefault || userSet[name]) {
 			if v := argument.StringValue(); v != "" {
 				sensitiveValues = append(sensitiveValues, v)

--- a/commands/input_bare_when_test.go
+++ b/commands/input_bare_when_test.go
@@ -1,0 +1,249 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+
+	flag "github.com/spf13/pflag"
+)
+
+// input_bare_when_test.go covers #497. An input value reached the render and
+// the predicates as the pointer pflag allocated for its flag, and both
+// evaluators read a pointer as "true" whatever it points at: expr emits an
+// OpDeref for the operands of an operator but not for a program that is
+// nothing but a top-level identifier, and text/template's isTrue counts any
+// non-nil pointer as true. So `when: debug` ran the task for --debug=false,
+// `when: replicas` ran it at 0, and `{{ if .debug }}` took the then-branch
+// whatever the input held.
+//
+// The context holds concrete values now, so a bare predicate is a truthiness
+// test on the value the operator actually supplied.
+
+// bareWhenRecipe declares one input of the given type and guards one task with
+// a predicate that is only that input's name, so --list-tasks reports [skipped]
+// exactly when the value is falsy.
+func bareWhenRecipe(name, typ string) string {
+	decl := "{ name: " + name
+	if typ != "" {
+		decl += ", type: " + typ
+	}
+	decl += " }"
+	return `---
+- inputs:
+    - ` + decl + `
+  tasks:
+    - name: guarded
+      when: ` + name + `
+      dokku_app: { app: web }
+`
+}
+
+// assertBareWhen runs apply --list-tasks with args and asserts whether the
+// single guarded task was skipped.
+func assertBareWhen(t *testing.T, path string, wantSkipped bool, args ...string) {
+	t.Helper()
+	stdout, stderr, exit := runApply(t, path, append([]string{"--list-tasks"}, args...)...)
+	if exit != 0 {
+		t.Fatalf("apply %v exit = %d, want 0; stdout=%s stderr=%s", args, exit, stdout, stderr)
+	}
+	if got := strings.Contains(stdout, "[skipped]"); got != wantSkipped {
+		t.Errorf("apply %v: skipped = %v, want %v; got:\n%s", args, got, wantSkipped, stdout)
+	}
+}
+
+// TestBareWhenOnABoolInputFollowsTheValue is the issue's own reproduction. Both
+// spellings pflag accepts for false have to skip, and both for true have to
+// run; the zero value an omitted default resolves to is false and skips too.
+func TestBareWhenOnABoolInputFollowsTheValue(t *testing.T) {
+	path := writeTasksFile(t, bareWhenRecipe("debug", "bool"))
+
+	assertBareWhen(t, path, true)
+	assertBareWhen(t, path, true, "--debug=false")
+	assertBareWhen(t, path, true, "--debug=0")
+	assertBareWhen(t, path, false, "--debug=true")
+	assertBareWhen(t, path, false, "--debug=1")
+}
+
+// TestBareWhenOnAnIntInputFollowsTheValue: an int has the same hole - the
+// pointer is never nil, so `when: replicas` was true at 0.
+func TestBareWhenOnAnIntInputFollowsTheValue(t *testing.T) {
+	path := writeTasksFile(t, bareWhenRecipe("replicas", "int"))
+
+	assertBareWhen(t, path, true)
+	assertBareWhen(t, path, true, "--replicas=0")
+	assertBareWhen(t, path, false, "--replicas=2")
+}
+
+// TestBareWhenOnAStringInputFollowsTheValue pins the third type. A string
+// already behaved - an empty one reached the context as nil, which is falsy -
+// so this is the parity check that says all three types now read alike.
+func TestBareWhenOnAStringInputFollowsTheValue(t *testing.T) {
+	path := writeTasksFile(t, bareWhenRecipe("env", ""))
+
+	assertBareWhen(t, path, true)
+	assertBareWhen(t, path, true, "--env=")
+	assertBareWhen(t, path, false, "--env=prod")
+}
+
+// TestTemplateConditionalFollowsABoolInput is the other half of the issue: a
+// `{{ if }}` in a recipe body could not be fixed in truthy, because it is
+// text/template's own isTrue that counts a non-nil pointer as true.
+//
+// The conditional sits in a task field rather than the task name so the
+// assertion reads off the resource address the other input tests use, and it
+// stays inside a quoted scalar so validate and fmt still parse the raw file.
+func TestTemplateConditionalFollowsABoolInput(t *testing.T) {
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: debug, type: bool }
+  tasks:
+    - dokku_app: { app: "cond-{{ if .debug }}on{{ else }}off{{ end }}" }
+`)
+
+	stdout, stderr, exit := runValidate(t, path)
+	if exit != 0 {
+		t.Fatalf("validate exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+
+	stdout, stderr, exit = runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "dokku_app[app=cond-off]") {
+		t.Errorf("a false bool took the then-branch; got:\n%s", stdout)
+	}
+
+	stdout, stderr, exit = runApply(t, path, "--list-tasks", "--debug=true")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "dokku_app[app=cond-on]") {
+		t.Errorf("a true bool took the else-branch; got:\n%s", stdout)
+	}
+}
+
+// TestBareWhenReadsTheSameFromEitherInputLayer is the #495 parity test written
+// with the bare predicate: a file-level input and a play-local one reach a
+// predicate as the same shape, so both halves skip or run together.
+func TestBareWhenReadsTheSameFromEitherInputLayer(t *testing.T) {
+	recipe := func(def string) string {
+		return `---
+- inputs:
+    - { name: file_debug, type: bool, default: "` + def + `" }
+- name: api
+  inputs:
+    - { name: play_debug, type: bool, default: "` + def + `" }
+  tasks:
+    - name: from-file-level
+      when: file_debug
+      dokku_app: { app: a }
+    - name: from-play-local
+      when: play_debug
+      dokku_app: { app: b }
+`
+	}
+
+	t.Run("true", func(t *testing.T) {
+		path := writeTasksFile(t, recipe("yes"))
+		stdout, stderr, exit := runApply(t, path, "--list-tasks")
+		if exit != 0 {
+			t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+		}
+		if strings.Contains(stdout, "[skipped]") {
+			t.Errorf("a task was skipped although both inputs are true; got:\n%s", stdout)
+		}
+	})
+
+	t.Run("false", func(t *testing.T) {
+		path := writeTasksFile(t, recipe("no"))
+		stdout, stderr, exit := runApply(t, path, "--list-tasks")
+		if exit != 0 {
+			t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+		}
+		if strings.Count(stdout, "[skipped]") != 2 {
+			t.Errorf("want both tasks skipped; got:\n%s", stdout)
+		}
+	})
+}
+
+// TestUnsetStringInputRendersEmpty: a string input with no value reached the
+// context as an untyped nil, which text/template renders as `<no value>` - the
+// literal text landed in the task body. It is the empty string now, the zero
+// value the inputs table has always documented.
+//
+// The interpolation is a bare suffix rather than `web-{{ .suffix }}` so the
+// assertion does not depend on how the address renderer quotes a value ending
+// in a hyphen.
+func TestUnsetStringInputRendersEmpty(t *testing.T) {
+	path := writeTasksFile(t, `---
+- inputs:
+    - { name: suffix }
+  tasks:
+    - dokku_app: { app: "web{{ .suffix }}" }
+`)
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "<no value>") {
+		t.Errorf("an unset input rendered the template placeholder; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "dokku_app[app=web]") {
+		t.Errorf("an unset input did not render as empty; got:\n%s", stdout)
+	}
+
+	stdout, stderr, exit = runApply(t, path, "--list-tasks", "--suffix=-api")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "dokku_app[app=web-api]") {
+		t.Errorf("a supplied suffix did not render; got:\n%s", stdout)
+	}
+}
+
+// TestBuildInputContextHoldsConcreteValues is the unit-level statement of the
+// fix: the map handed to the render and to every predicate holds values, not
+// the flag pointers registerInputFlags allocated.
+func TestBuildInputContextHoldsConcreteValues(t *testing.T) {
+	recipe := `---
+- inputs:
+    - { name: debug, type: bool }
+    - { name: replicas, type: int, default: 3 }
+    - { name: ratio, type: float, default: 1.5 }
+    - { name: app, default: web }
+    - { name: suffix }
+  tasks:
+    - dokku_app: { app: "{{ .app }}" }
+`
+	f := flag.NewFlagSet("apply", flag.ContinueOnError)
+	arguments, err := registerInputFlags(f, []byte(recipe), tasks.FormatYAML)
+	if err != nil {
+		t.Fatalf("registerInputFlags returned error: %v", err)
+	}
+
+	context, _, err := buildInputContext(arguments, nil)
+	if err != nil {
+		t.Fatalf("buildInputContext returned error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"debug":    false,
+		"replicas": 3,
+		"ratio":    1.5,
+		"app":      "web",
+		"suffix":   "",
+	}
+	for name, wantValue := range want {
+		got, ok := context[name]
+		if !ok {
+			t.Errorf("context is missing %q", name)
+			continue
+		}
+		if got != wantValue {
+			t.Errorf("context[%q] = %#v, want %#v", name, got, wantValue)
+		}
+	}
+}

--- a/commands/required_input_test.go
+++ b/commands/required_input_test.go
@@ -121,7 +121,7 @@ func TestMissingRequiredInputIsDeterministic(t *testing.T) {
 
 // TestRequiredStringInputIsNotSatisfiedByAnEmptyValue: `--app=` types the flag
 // but supplies nothing. Counting that as an answer would let the input resolve
-// to "" and render as `<no value>`, which is why IsSatisfied checks the
+// to "" and render an app named `web-`, which is why IsSatisfied checks the
 // resolved value as well as where it came from.
 func TestRequiredStringInputIsNotSatisfiedByAnEmptyValue(t *testing.T) {
 	path := writeTasksFile(t, `---

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -67,6 +67,22 @@ command line, so every spelling the command line accepts is also a spelling a `d
 The reverse does not hold: pflag takes only `true`/`false`/`1`/`0`/`t`/`f`, so `--debug=yes` is not
 a command line docket accepts.
 
+Whatever the spelling, the input reaches the recipe as its declared type - a `bool` is a boolean and
+an `int` is a number, not the text you wrote. So naming an input on its own is a truthiness test,
+both in a [`when:`](task-envelope.md#when-run-a-task-conditionally) and in a `{{ if }}`:
+
+```yaml
+---
+- inputs:
+    - { name: debug, type: bool }
+  tasks:
+    - name: only when debugging
+      when: debug
+      dokku_app: { app: "web{{ if .debug }}-verbose{{ end }}" }
+```
+
+An input left at its zero value is false there, and renders as `false`, `0`, or the empty string.
+
 ## Input names
 
 Because an input is referenced as `{{ .name }}`, its `name` must be a valid template variable: a

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -141,6 +141,24 @@ own [play-local inputs](inputs.md#per-play-inputs-precedence), each resolved to 
 Inside a `loop:` it also sees `.item` and `.index`.
 Once any task has used `register:`, every later predicate also sees `.registered.<name>` (below).
 
+A predicate that is only an input's name is a truthiness test on that input's value, so a `bool`
+input needs no comparison spelled out:
+
+```yaml
+- inputs:
+    - { name: debug, type: bool }
+  tasks:
+    - name: only when debugging
+      when: debug
+      dokku_app: { app: web }
+```
+
+`when: debug` skips the task until the input is true; on an `int` input a bare `when:` is false
+while the value is `0`, and on a `string` one while it is empty. `not debug` and `debug == true` say
+the same thing more explicitly. The rule is expr's: `false`, `0`, `""`, `nil`, and an empty list or
+map are false, everything else is true. A `{{ if .debug }}` in a task body reads the same value the
+same way.
+
 ## `loop`: repeat a task over a list
 
 `loop:` expands a single task into one copy per item, so you do not repeat yourself. The value is

--- a/tasks/input.go
+++ b/tasks/input.go
@@ -73,19 +73,21 @@ func ParseInputFloat(s string) (float64, bool) {
 }
 
 // inputDefaultValue resolves a declared `default:` to the value the input
-// renders as, in the same Go shape commands.registerInputFlags hands the flag
-// set: a typed pointer for bool / int / float, so a `default: on` renders as
+// renders as, in the same Go shape commands.buildInputContext hands the render
+// and predicate contexts: a bool / int / float, so a `default: on` renders as
 // `true` rather than as the text `on`, and both halves of a recipe's input
 // context hold the same thing (#495).
+//
+// The value is concrete rather than a typed pointer. A pointer reads as true
+// whatever it points at, in a bare `when: debug` and in a `{{ if .debug }}`
+// alike, which is #497; nothing downstream wants the pointer, so nothing is
+// handed one.
 //
 // The fallback is the raw text, not the type's zero value: a default that does
 // not parse, or a `type:` docket does not implement, is reported as
 // invalid_input_default / invalid_input_type, and `validate` collects its
 // problems and keeps rendering. Substituting a zero there would hide the text
 // an unsafe_input_value diagnostic needs to see.
-//
-// Each call allocates its own pointer, so two plays declaring the same input
-// name never share one.
 func inputDefaultValue(typ, def string) interface{} {
 	canonical, ok := CanonicalInputType(typ)
 	if !ok {
@@ -94,15 +96,15 @@ func inputDefaultValue(typ, def string) interface{} {
 	switch canonical {
 	case "bool":
 		if v, parsed := ParseInputBool(def); parsed {
-			return &v
+			return v
 		}
 	case "int":
 		if v, parsed := ParseInputInt(def); parsed {
-			return &v
+			return v
 		}
 	case "float":
 		if v, parsed := ParseInputFloat(def); parsed {
-			return &v
+			return v
 		}
 	}
 	return def

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -783,11 +783,11 @@ func renderRecipeBytes(data []byte, context map[string]interface{}) ([]byte, err
 // Default string are skipped so they cannot accidentally shadow a real
 // file-level value with "".
 //
-// A default is layered in resolved to its declared type, matching the typed
-// pointer the base context already holds for the same input from flag
-// registration. Injecting the raw text instead made a play-local
-// `type: bool, default: on` render as `on` where the file-level half rendered
-// `true`, and made `when: 'debug == true'` compare a string to a bool (#495).
+// A default is layered in resolved to its declared type, matching the value the
+// base context already holds for the same input from flag registration.
+// Injecting the raw text instead made a play-local `type: bool, default: on`
+// render as `on` where the file-level half rendered `true`, and made
+// `when: 'debug == true'` compare a string to a bool (#495).
 //
 // Exported because the apply / plan executors need to build the same
 // per-play context the loader used so per-task `when:` predicates see

--- a/tasks/play_test.go
+++ b/tasks/play_test.go
@@ -299,9 +299,13 @@ func TestBuildPerPlayContextRespectsUserSet(t *testing.T) {
 
 // TestBuildPerPlayContextResolvesTypedDefaults covers #495. A play-local
 // default used to layer in as the raw text the recipe wrote, while the same
-// input reached the base context as the typed pointer flag registration
-// allocated - so `type: bool, default: on` rendered as `on` in a play-local
-// input and as `true` in a file-level one. Both halves now hold the same shape.
+// input reached the base context from flag registration already resolved - so
+// `type: bool, default: on` rendered as `on` in a play-local input and as
+// `true` in a file-level one. Both halves now hold the same shape.
+//
+// That shape is the concrete value, not a typed pointer: a pointer reads as
+// true in a bare `when: debug` and in a `{{ if .debug }}` whatever it points at
+// (#497).
 func TestBuildPerPlayContextResolvesTypedDefaults(t *testing.T) {
 	playInputs := []Input{
 		{Name: "debug", Type: "bool", Default: "on"},
@@ -315,17 +319,17 @@ func TestBuildPerPlayContextResolvesTypedDefaults(t *testing.T) {
 
 	out := BuildPerPlayContext(map[string]interface{}{}, playInputs, nil)
 
-	if v, ok := out["debug"].(*bool); !ok || v == nil || !*v {
-		t.Errorf("debug = %#v, want a *bool holding true", out["debug"])
+	if v, ok := out["debug"].(bool); !ok || !v {
+		t.Errorf("debug = %#v, want the bool true", out["debug"])
 	}
-	if v, ok := out["quiet"].(*bool); !ok || v == nil || *v {
-		t.Errorf("quiet = %#v, want a *bool holding false", out["quiet"])
+	if v, ok := out["quiet"].(bool); !ok || v {
+		t.Errorf("quiet = %#v, want the bool false", out["quiet"])
 	}
-	if v, ok := out["replicas"].(*int); !ok || v == nil || *v != 3 {
-		t.Errorf("replicas = %#v, want a *int holding 3", out["replicas"])
+	if v, ok := out["replicas"].(int); !ok || v != 3 {
+		t.Errorf("replicas = %#v, want the int 3", out["replicas"])
 	}
-	if v, ok := out["ratio"].(*float64); !ok || v == nil || *v != 1.5 {
-		t.Errorf("ratio = %#v, want a *float64 holding 1.5", out["ratio"])
+	if v, ok := out["ratio"].(float64); !ok || v != 1.5 {
+		t.Errorf("ratio = %#v, want the float64 1.5", out["ratio"])
 	}
 	// A string default is already the text it renders as.
 	if v, ok := out["app"].(string); !ok || v != "web" {
@@ -342,26 +346,29 @@ func TestBuildPerPlayContextResolvesTypedDefaults(t *testing.T) {
 	}
 }
 
-// TestBuildPerPlayContextAllocatesPerCall: two plays declaring the same input
-// name with different defaults must not alias one pointer.
-func TestBuildPerPlayContextAllocatesPerCall(t *testing.T) {
+// TestBuildPerPlayContextKeepsPlayDefaultsIndependent: two plays declaring the
+// same input name with different defaults each keep their own value. The
+// contexts used to hold pointers, where the risk was aliasing one allocation;
+// they hold values now, where the risk is one call writing into the map another
+// call handed back.
+func TestBuildPerPlayContextKeepsPlayDefaultsIndependent(t *testing.T) {
 	base := map[string]interface{}{}
 	first := BuildPerPlayContext(base, []Input{{Name: "debug", Type: "bool", Default: "true"}}, nil)
 	second := BuildPerPlayContext(base, []Input{{Name: "debug", Type: "bool", Default: "false"}}, nil)
 
-	firstValue, ok := first["debug"].(*bool)
+	firstValue, ok := first["debug"].(bool)
 	if !ok {
-		t.Fatalf("first debug = %#v, want a *bool", first["debug"])
+		t.Fatalf("first debug = %#v, want a bool", first["debug"])
 	}
-	secondValue, ok := second["debug"].(*bool)
+	secondValue, ok := second["debug"].(bool)
 	if !ok {
-		t.Fatalf("second debug = %#v, want a *bool", second["debug"])
+		t.Fatalf("second debug = %#v, want a bool", second["debug"])
 	}
-	if firstValue == secondValue {
-		t.Fatal("both plays share one pointer; the second default overwrote the first")
+	if !firstValue || secondValue {
+		t.Errorf("values = (%v, %v), want (true, false)", firstValue, secondValue)
 	}
-	if !*firstValue || *secondValue {
-		t.Errorf("values = (%v, %v), want (true, false)", *firstValue, *secondValue)
+	if _, ok := base["debug"]; ok {
+		t.Errorf("base gained the play-local key; got %v", base["debug"])
 	}
 }
 

--- a/tasks/predicate.go
+++ b/tasks/predicate.go
@@ -82,9 +82,10 @@ func (c *identifierCollector) Visit(node *ast.Node) {
 }
 
 // EvalBool runs prog against env and reports the truthiness of the
-// result. Non-bool results are coerced via the standard expr truth rules
-// (nil, 0, "", and empty collections are false; everything else is
-// true). Returns an error when the program errors at run time.
+// result. Non-bool results are coerced by truthy, which follows the
+// standard expr truth rules (nil, 0, "", and empty collections are
+// false; everything else is true). Returns an error when the program
+// errors at run time.
 func EvalBool(prog *vm.Program, env map[string]interface{}) (bool, error) {
 	if prog == nil {
 		return true, nil
@@ -118,8 +119,8 @@ func EvalList(prog *vm.Program, env map[string]interface{}) ([]interface{}, erro
 
 // truthy mirrors expr's Boolean coercion: nil, false, zero numerics,
 // empty strings, and empty collections are false; everything else is
-// true. Reaching the default case for an unsupported type returns true
-// since a non-nil structural value is meaningful.
+// true. Only a value with no zero worth speaking of - a struct, a
+// channel, a func - reaches the closing `return true`.
 func truthy(v interface{}) bool {
 	switch x := v.(type) {
 	case nil:
@@ -139,15 +140,43 @@ func truthy(v interface{}) bool {
 	case map[string]interface{}:
 		return len(x) > 0
 	}
-	// Reflect fallback for typed collections (`[]string` from
-	// registered.foo.Commands, `[]TaskOutputState` from .Results, typed
-	// maps) that do not match the generic case arms above. A typed nil
-	// slice/map has Kind Slice/Map and length 0, so an empty one is
-	// correctly false rather than falling through to the default true.
+	// Reflect fallback for everything the case arms above cannot name: typed
+	// collections (`[]string` from registered.foo.Commands,
+	// `[]TaskOutputState` from .Results, typed maps), pointers, and the
+	// scalar kinds a plain type switch would miss. A typed nil slice/map has
+	// Kind Slice/Map and length 0, so an empty one is correctly false rather
+	// than falling through to the default true.
+	//
+	// The pointer arm is what makes `when: debug` follow a bool input rather
+	// than the pointer holding it (#497). expr emits an OpDeref for the
+	// operands of a binary or unary node, so `debug == true` was always
+	// correct, but a program that is nothing but a top-level identifier gets
+	// none and hands the raw value straight here. Nothing puts a flag pointer
+	// in the context any more - see commands.Argument.ContextValue - so this
+	// is the guard for a pointer arriving from anywhere else.
+	//
+	// The scalar arms cover the same hole one type down: an int32, a uint, a
+	// float32, or a named `type count int` matches no case above, and a zero
+	// one has no business being true.
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
+	case reflect.Ptr:
+		if rv.IsNil() {
+			return false
+		}
+		return truthy(rv.Elem().Interface())
 	case reflect.Slice, reflect.Array, reflect.Map:
 		return rv.Len() > 0
+	case reflect.Bool:
+		return rv.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv.Int() != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return rv.Uint() != 0
+	case reflect.Float32, reflect.Float64:
+		return rv.Float() != 0
+	case reflect.String:
+		return rv.String() != ""
 	}
 	return true
 }

--- a/tasks/predicate_test.go
+++ b/tasks/predicate_test.go
@@ -257,6 +257,123 @@ func TestTruthyEmptyTypedSlice(t *testing.T) {
 	}
 }
 
+// truthyCount is a named scalar type: it has Kind Int but matches no case
+// arm in truthy's type switch, so it reaches the reflect fallback.
+type truthyCount int
+
+// TestTruthyDereferencesPointers pins #497. An input value used to reach a
+// predicate as the pointer pflag allocated for its flag; expr emits an OpDeref
+// for the operands of a binary or unary node, so `debug == true` was right,
+// but a program that is nothing but a top-level identifier gets none and handed
+// truthy the raw pointer, which matched no case arm and fell through to true.
+// A bare `when: debug` was therefore true for `--debug=false`.
+//
+// Nothing puts a flag pointer in the context any more, so this covers the arm
+// that keeps a pointer from anywhere else honest.
+func TestTruthyDereferencesPointers(t *testing.T) {
+	boolFalse, boolTrue := false, true
+	intZero, intThree := 0, 3
+	floatZero, floatOne := 0.0, 1.5
+	stringEmpty, stringSet := "", "x"
+	ptrToFalse := &boolFalse
+
+	falsy := []interface{}{
+		&boolFalse,
+		(*bool)(nil),
+		&intZero,
+		(*int)(nil),
+		&floatZero,
+		&stringEmpty,
+		(*string)(nil),
+		&ptrToFalse,
+	}
+	for _, v := range falsy {
+		if truthy(v) {
+			t.Errorf("truthy(%#v) = true, want false", v)
+		}
+	}
+
+	ptrToTrue := &boolTrue
+	truthyVals := []interface{}{
+		&boolTrue,
+		&intThree,
+		&floatOne,
+		&stringSet,
+		&ptrToTrue,
+	}
+	for _, v := range truthyVals {
+		if !truthy(v) {
+			t.Errorf("truthy(%#v) = false, want true", v)
+		}
+	}
+}
+
+// TestTruthyCoversNarrowAndNamedScalars is the same hole one type down: a
+// scalar kind truthy has no case arm for reached the reflect fallback, whose
+// switch only knew about collections, so a zero one counted as true.
+func TestTruthyCoversNarrowAndNamedScalars(t *testing.T) {
+	falsy := []interface{}{
+		int8(0), int16(0), int32(0),
+		uint(0), uint8(0), uint16(0), uint32(0), uint64(0),
+		float32(0),
+		truthyCount(0),
+	}
+	for _, v := range falsy {
+		if truthy(v) {
+			t.Errorf("truthy(%#v) = true, want false", v)
+		}
+	}
+	truthyVals := []interface{}{
+		int8(1), int32(-1),
+		uint(2), uint64(9),
+		float32(0.5),
+		truthyCount(3),
+	}
+	for _, v := range truthyVals {
+		if !truthy(v) {
+			t.Errorf("truthy(%#v) = false, want true", v)
+		}
+	}
+}
+
+// TestEvalBoolBareIdentifierFollowsThePointerValue drives #497 through the
+// evaluator rather than through truthy directly: the predicate is the bare
+// identifier the issue reports, and the env holds the pointer shape the apply
+// path used to hand it.
+func TestEvalBoolBareIdentifierFollowsThePointerValue(t *testing.T) {
+	prog, err := CompilePredicate(`debug`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	debug := false
+	got, err := EvalBool(prog, map[string]interface{}{"debug": &debug})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got {
+		t.Error("a bare identifier on a false bool should be falsy; got true")
+	}
+
+	debug = true
+	got, err = EvalBool(prog, map[string]interface{}{"debug": &debug})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Error("a bare identifier on a true bool should be truthy; got false")
+	}
+
+	// The shape the apply path hands it now.
+	got, err = EvalBool(prog, map[string]interface{}{"debug": false})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got {
+		t.Error("a bare identifier on a false bool value should be falsy; got true")
+	}
+}
+
 // TestEvalBoolEmptyTypedSliceFalsy exercises #354 through a predicate:
 // registered.foo.Commands is a []string, empty for a task that ran no
 // subprocess, so `when: registered.foo.Commands` is falsy and the task

--- a/tasks/render_funcs.go
+++ b/tasks/render_funcs.go
@@ -81,11 +81,11 @@ func JSONScalar(v interface{}) (string, error) {
 // must render as an empty string rather than error so a filter survives the
 // empty-context render used for input discovery and the validate syntax check.
 //
-// The apply/plan context stores input values as typed pointers (*string, *int,
-// ...) because pflag hands back pointers. text/template auto-dereferences a
-// pointer for a bare `{{ .x }}`, but passes it verbatim to a filter argument
-// (`{{ .x | dq }}`), so the pointer must be dereferenced here or the address,
-// not the value, would be escaped.
+// The pointer loop is a guard. The apply/plan context holds concrete values
+// since #497, but text/template auto-dereferences a pointer for a bare
+// `{{ .x }}` and passes it verbatim to a filter argument (`{{ .x | dq }}`), so
+// a context assembled anywhere else that still carried a *string would have its
+// address escaped rather than its value.
 func scalarArg(v interface{}) string {
 	if v == nil {
 		return ""

--- a/tasks/render_funcs_test.go
+++ b/tasks/render_funcs_test.go
@@ -78,9 +78,9 @@ func TestDoubleQuoteEscape(t *testing.T) {
 	if got, err := DoubleQuoteEscape(nil); err != nil || got != "" {
 		t.Errorf("DoubleQuoteEscape(nil) = %q, %v; want \"\", nil", got, err)
 	}
-	// The apply/plan context stores input values as *string, and sigil passes
-	// that pointer to the filter verbatim; it must be dereferenced, not
-	// formatted as an address.
+	// A context assembled outside the flag path can still hold a *string, and
+	// sigil passes that pointer to the filter verbatim; it must be
+	// dereferenced, not formatted as an address.
 	s := `say "hi"`
 	if got, err := DoubleQuoteEscape(&s); err != nil || got != `say \"hi\"` {
 		t.Errorf("DoubleQuoteEscape(*string) = %q, %v; want %q", got, err, `say \"hi\"`)
@@ -91,9 +91,11 @@ func TestDoubleQuoteEscape(t *testing.T) {
 	}
 }
 
-// TestGetTasksDoubleQuoteEscapePointerValue guards the #371 apply path: the
-// real apply/plan context holds *string values (pflag hands back pointers), and
-// the dq filter must dereference them rather than render the pointer address.
+// TestGetTasksDoubleQuoteEscapePointerValue guards the #371 apply path end to
+// end. The apply/plan context held *string values (pflag hands back pointers)
+// until #497 moved it to concrete ones; scalarArg's deref stays as the guard
+// for a context built anywhere else, and this pins it - the dq filter must
+// dereference a pointer rather than render its address.
 func TestGetTasksDoubleQuoteEscapePointerValue(t *testing.T) {
 	data := []byte(`---
 - tasks:

--- a/tests/bats/inputs.bats
+++ b/tests/bats/inputs.bats
@@ -252,3 +252,93 @@ EOF
   assert_failure
   assert_output --partial '"code":"invalid_input_default"'
 }
+
+# #497: an input value reached the render and the predicates as the pointer
+# pflag allocated for its flag, and both evaluators read a pointer as true
+# whatever it points at. expr emits a deref for the operands of an operator but
+# not for a predicate that is nothing but an identifier, and text/template's own
+# isTrue counts any non-nil pointer as true.
+
+@test "a bare when: on a bool input follows the value" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: debug, type: bool }
+  tasks:
+    - name: only when debugging
+      when: debug
+      dokku_app: { app: web }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "[skipped] only when debugging"
+
+  for false_value in false 0; do
+    run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --debug=$false_value
+    assert_success
+    assert_output --partial "[skipped] only when debugging"
+  done
+
+  for true_value in true 1; do
+    run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --debug=$true_value
+    assert_success
+    refute_output --partial "[skipped]"
+  done
+}
+
+@test "a bare when: on an int input follows the value" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: replicas, type: int }
+  tasks:
+    - name: scale
+      when: replicas
+      dokku_app: { app: web }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "[skipped] scale"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --replicas=2
+  assert_success
+  refute_output --partial "[skipped]"
+}
+
+@test "a template conditional follows a bool input" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: debug, type: bool }
+  tasks:
+    - dokku_app: { app: "cond-{{ if .debug }}on{{ else }}off{{ end }}" }
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "dokku_app[app=cond-off]"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --debug=true
+  assert_success
+  assert_output --partial "dokku_app[app=cond-on]"
+}
+
+@test "an omitted string default renders as the empty string" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: suffix }
+  tasks:
+    - dokku_app: { app: "web{{ .suffix }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "dokku_app[app=web]"
+  refute_output --partial "<no value>"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --suffix=-api
+  assert_success
+  assert_output --partial "dokku_app[app=web-api]"
+}

--- a/tests/bats/plays.bats
+++ b/tests/bats/plays.bats
@@ -522,3 +522,33 @@ EOF
   assert_success
   assert_output --partial "web-true-true-7"
 }
+
+# #497: an input reached a predicate as the pointer pflag allocated for its
+# flag, and expr only dereferences the operands of an operator - a predicate
+# that is nothing but an identifier got the pointer, which is never nil for a
+# bool, and was true whatever the input held.
+@test "plays: a bare when: reads a play-local bool input" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: file_debug, type: bool, default: false }
+- name: api
+  inputs:
+    - { name: play_debug, type: bool, default: false }
+  tasks:
+    - name: from-file-level
+      when: file_debug
+      dokku_app: { app: docket-test-noop-a }
+    - name: from-play-local
+      when: play_debug
+      dokku_app: { app: docket-test-noop-b }
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "[skipped] from-file-level"
+  assert_output --partial "[skipped] from-play-local"
+
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks --file_debug=true --play_debug=true
+  assert_success
+  refute_output --partial "[skipped]"
+}


### PR DESCRIPTION
An input reached the recipe as the pointer its flag was registered with, and both the predicate evaluator and the template renderer read a pointer as true whatever it points at, so `when: debug` ran the task for `--debug=false`, `when: replicas` ran it at `0`, and a `{{ if .debug }}` in a task body always took its then-branch while the spelled-out `debug == true` and `not debug` were correct all along. A predicate that is nothing but an input's name is now a truthiness test on the value the operator supplied, on every type, and a zero value of a narrower or named numeric type reaching a predicate from anywhere else is no longer true either. One consequence worth naming: an input left at its zero value renders as the empty string rather than `<no value>`, so `when: 'app == ""'` is now true for an unset string input where it used to be false.

Fixes #497.
