### PR TITLE
feat: thread a context through Plan and Execute

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -17,6 +18,12 @@ import (
 
 type ApplyCommand struct {
 	command.Meta
+
+	// Ctx is the run context, populated from main.go with the process signal
+	// context. It carries cancellation down through every task's Plan and
+	// Execute. Nil when the command was constructed directly (tests do this),
+	// in which case Run falls back to context.Background().
+	Ctx context.Context
 
 	tasksFile string
 	// tasksFormatFlag is the raw --tasks-format value; tasksFormat is
@@ -183,6 +190,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		c.Ui.Warn(w)
 	}
 
+	ctx := runContext(c.Ctx)
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
 
 	formatOverride, err := parseRecipeFormatFlag("--tasks-format", c.tasksFormatFlag)
@@ -213,7 +221,7 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	userSet := userSetKeys(flags, varsFileKeys, c.arguments)
 
-	context, sensitiveValues, err := buildInputContext(c.arguments, userSet)
+	inputCtx, sensitiveValues, err := buildInputContext(c.arguments, userSet)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -226,7 +234,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
-	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, context, userSet)
+	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, inputCtx, userSet)
 	if err != nil {
 		c.Ui.Error(subprocess.MaskString(fmt.Sprintf("task error: %v", err)))
 		return 1
@@ -278,7 +286,7 @@ func (c *ApplyCommand) Run(args []string) int {
 			skips:         c.skipTags,
 			fileLevelKeys: fileLevelKeys,
 			userSet:       userSet,
-			context:       context,
+			context:       inputCtx,
 			jsonOut:       c.json,
 		})
 	}
@@ -290,7 +298,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	emitter := c.newEmitter()
 	start := time.Now()
 	counts := ApplyCounts{}
-	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(context, fileLevelKeys, userSet))
+	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(inputCtx, fileLevelKeys, userSet))
 	hasError := false
 	// startedAtTask gates --start-at-task: false until an envelope name
 	// matches c.startAtTask, at which point every subsequent task runs
@@ -308,6 +316,11 @@ func (c *ApplyCommand) Run(args []string) int {
 
 playLoop:
 	for _, play := range plays {
+		// Checked per play as well as per task so a cancelled run does not
+		// print the header of a play whose tasks will never run.
+		if ctx.Err() != nil {
+			break playLoop
+		}
 		if play.IsFileLevel() {
 			// Inputs-only plays carry no tasks; their inputs are
 			// already folded into fileLevelKeys above. They produce
@@ -334,9 +347,10 @@ playLoop:
 
 		emitter.PlayStart(play.Name, resolvedHost)
 
-		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(context, play.Inputs, userSet))
+		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(inputCtx, play.Inputs, userSet))
 
 		ac := &applyContext{
+			ctx:         ctx,
 			play:        play,
 			playExprCtx: playExprCtx,
 			registered:  registered,
@@ -357,11 +371,14 @@ playLoop:
 		// target before the gate could flip `started`, silently no-oping
 		// the run.
 		for _, name := range play.Tasks.Keys() {
+			if ctx.Err() != nil {
+				break playLoop
+			}
 			env := play.Tasks.GetEnvelope(name)
 			outcome := c.executeTask(env, name, ac, nil, "")
 			if outcome.abort {
 				emitter.ApplySummary(counts, time.Since(start))
-				return 1
+				return c.runExit(ctx, true, 0)
 			}
 			if outcome.failed {
 				failed = true
@@ -376,10 +393,27 @@ playLoop:
 
 	emitter.ApplySummary(counts, time.Since(start))
 
+	return c.runExit(ctx, hasError, counts.Changed)
+}
+
+// runExit turns the run's verdict into an exit code, and is the one place that
+// asks whether the run was cancelled. The question has to be asked here rather
+// than tracked by the loop: an interrupt that lands mid-task also makes that
+// task fail, so the loop leaves through the error path and never reaches its
+// own cancellation check. Reporting the interrupt separately from a task
+// failure is what lets an operator tell "I pressed Ctrl-C" from "something
+// broke", and a cancelled run never returns the --detailed-exitcode "changed"
+// code: a wrapper reads 2 as "the run completed and changed something", and an
+// interrupted run completed nothing.
+func (c *ApplyCommand) runExit(ctx context.Context, hasError bool, changed int) int {
+	if ctx.Err() != nil {
+		c.Ui.Error("run cancelled")
+		return 1
+	}
 	if hasError {
 		return 1
 	}
-	if c.detailedExitCode && counts.Changed > 0 {
+	if c.detailedExitCode && changed > 0 {
 		return 2
 	}
 	return 0
@@ -388,6 +422,10 @@ playLoop:
 // applyContext bundles the run-wide state apply's per-task helpers
 // share so the function signatures stay tractable.
 type applyContext struct {
+	// ctx is the run context. Every task this play executes is run under it,
+	// so cancelling it stops the run rather than only the child process of
+	// whichever task happens to be in flight.
+	ctx         context.Context
 	play        *tasks.Play
 	playExprCtx map[string]interface{}
 	registered  map[string]tasks.RegisteredValue
@@ -520,7 +558,7 @@ func (c *ApplyCommand) executeLeafTask(env *tasks.TaskEnvelope, name string, ac 
 		ac.emitter.TaskWarning(ac.play.Name, name, "deprecated", msg)
 	}
 
-	state := env.Task.Execute()
+	state := env.Task.Execute(ac.ctx)
 	ac.counts.Tasks++
 
 	// Probe diagnostics raised during planning (carried out on the state by
@@ -646,7 +684,8 @@ func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *ap
 	}
 
 	// Walk block children. Stop at the first child whose post-override
-	// outcome is failed AND ignore_errors did not swallow it. A
+	// outcome is failed AND ignore_errors did not swallow it, or as soon as
+	// the run context is cancelled. A
 	// swallowed (ignored) child does NOT trigger rescue per #210 rule:
 	// ignore_errors is the "swallow" path; rescue is the "handle" path.
 	var (
@@ -655,6 +694,9 @@ func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *ap
 		lastChildState   tasks.TaskOutputState
 	)
 	for i, child := range env.Block {
+		if ac.ctx.Err() != nil {
+			break
+		}
 		childName := child.Name
 		if childName == "" {
 			childName = fmt.Sprintf("%s.block[%d]", name, i)
@@ -678,6 +720,9 @@ func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *ap
 	rescueErr := error(nil)
 	if blockFailedState != nil {
 		for i, child := range env.Rescue {
+			if ac.ctx.Err() != nil {
+				break
+			}
 			childName := child.Name
 			if childName == "" {
 				childName = fmt.Sprintf("%s.rescue[%d]", name, i)
@@ -700,9 +745,15 @@ func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *ap
 		}
 	}
 
-	// Always children run unconditionally.
+	// Always children run unconditionally - except under a cancelled run,
+	// where every one of them would fail on the dead context the moment it
+	// reached a subprocess. Skipping them reports the interrupt once instead
+	// of once per cleanup task.
 	alwaysErr := error(nil)
 	for i, child := range env.Always {
+		if ac.ctx.Err() != nil {
+			break
+		}
 		childName := child.Name
 		if childName == "" {
 			childName = fmt.Sprintf("%s.always[%d]", name, i)

--- a/commands/cancellation_test.go
+++ b/commands/cancellation_test.go
@@ -1,0 +1,209 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+// runWithCtx drives apply or plan under a caller-supplied context, the way
+// main.go does with the process signal context. The plain runApply / runPlan
+// helpers leave Ctx nil, which is the "constructed directly" path.
+func runWithCtx(t *testing.T, ctx context.Context, sub, path string, args ...string) (string, string, int) {
+	t.Helper()
+	origArgs := os.Args
+	os.Args = []string{"docket-test", sub, "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	ui := cli.NewMockUi()
+	all := append([]string{"--tasks", path}, args...)
+	var exit int
+	switch sub {
+	case "apply":
+		c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+		exit = c.Run(all)
+	case "plan":
+		c := &PlanCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+		exit = c.Run(all)
+	default:
+		t.Fatalf("unknown subcommand %q", sub)
+	}
+	return ui.OutputWriter.String(), ui.ErrorWriter.String(), exit
+}
+
+const twoTaskRecipe = `---
+- tasks:
+    - name: first
+      dokku_stub: { key: first }
+    - name: second
+      dokku_stub: { key: second }
+`
+
+// TestApplyStopsAtCancelledContext pins that cancelling the run context stops
+// the run at the next task rather than letting every remaining task fail one
+// at a time on a dead context. Before the context reached a task at all, an
+// interrupt could only kill the child process of whichever task was in flight
+// and the loop marched on to the next one.
+func TestApplyStopsAtCancelledContext(t *testing.T) {
+	defer stubReset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	secondRan := false
+	stubSet("first", StubFixture{Changed: true, Hook: cancel})
+	stubSet("second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
+
+	path := writeTasksFile(t, twoTaskRecipe)
+	stdout, stderr, exit := runWithCtx(t, ctx, "apply", path)
+
+	if secondRan {
+		t.Error("the task after the cancellation must not run")
+	}
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1 for a cancelled run", exit)
+	}
+	if !strings.Contains(stderr, "run cancelled") {
+		t.Errorf("stderr should say the run was cancelled; got %q", stderr)
+	}
+	if !strings.Contains(stdout, "first") {
+		t.Errorf("the task that did run should still be reported; got %q", stdout)
+	}
+}
+
+// TestPlanStopsAtCancelledContext is the plan-side mirror. plan probes the
+// server for every task, so it needs the same escape hatch as apply.
+func TestPlanStopsAtCancelledContext(t *testing.T) {
+	defer stubReset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	secondRan := false
+	stubSet("first", StubFixture{Changed: true, Hook: cancel})
+	stubSet("second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
+
+	path := writeTasksFile(t, twoTaskRecipe)
+	_, stderr, exit := runWithCtx(t, ctx, "plan", path)
+
+	if secondRan {
+		t.Error("the task after the cancellation must not be planned")
+	}
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1 for a cancelled run", exit)
+	}
+	if !strings.Contains(stderr, "run cancelled") {
+		t.Errorf("stderr should say the run was cancelled; got %q", stderr)
+	}
+}
+
+// TestApplyCancelledRunNeverReportsChanged pins that a cancelled run does not
+// exit 2 under --detailed-exitcode even though a task changed before the
+// interrupt. A wrapper reads 2 as "the run completed and changed something";
+// an interrupted run completed nothing.
+func TestApplyCancelledRunNeverReportsChanged(t *testing.T) {
+	defer stubReset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stubSet("first", StubFixture{Changed: true, Hook: cancel})
+	stubSet("second", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, twoTaskRecipe)
+	if _, _, exit := runWithCtx(t, ctx, "apply", path, "--detailed-exitcode"); exit != 1 {
+		t.Errorf("exit = %d, want 1; a cancelled run must not report 2 (changed)", exit)
+	}
+}
+
+// TestApplyReportsCancellationWhenTheInterruptedTaskAlsoFails is the case the
+// obvious implementation gets wrong. An interrupt that lands while a task is
+// talking to the server also makes that task fail, so the run loop leaves
+// through the error path and never reaches its own cancellation check. Asking
+// about the context once at the exit is what keeps the report honest.
+func TestApplyReportsCancellationWhenTheInterruptedTaskAlsoFails(t *testing.T) {
+	defer stubReset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	secondRan := false
+	stubSet("first", StubFixture{
+		ExecuteError: errors.New("interrupted"),
+		Hook:         cancel,
+	})
+	stubSet("second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
+
+	path := writeTasksFile(t, twoTaskRecipe)
+	_, stderr, exit := runWithCtx(t, ctx, "apply", path)
+
+	if secondRan {
+		t.Error("the task after the cancellation must not run")
+	}
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, "run cancelled") {
+		t.Errorf("an interrupt that also failed the task must still be reported as a cancellation; stderr: %q", stderr)
+	}
+}
+
+// TestApplyCancellationStopsLaterPlays pins the run-level abort. A task error
+// already ends the play it happened in, but the next play still runs - so a
+// recipe whose first play is interrupted would go on to start the second and
+// need interrupting again. This is the behaviour the bats interrupt test
+// exercises end to end against a host that never answers.
+func TestApplyCancellationStopsLaterPlays(t *testing.T) {
+	defer stubReset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	secondPlayRan := false
+	stubSet("first", StubFixture{ExecuteError: errors.New("interrupted"), Hook: cancel})
+	stubSet("second", StubFixture{Changed: true, Hook: func() { secondPlayRan = true }})
+
+	path := writeTasksFile(t, `---
+- name: one
+  tasks:
+    - name: first
+      dokku_stub: { key: first }
+- name: two
+  tasks:
+    - name: second
+      dokku_stub: { key: second }
+`)
+	stdout, stderr, exit := runWithCtx(t, ctx, "apply", path)
+
+	if secondPlayRan {
+		t.Error("the play after the cancellation must not run")
+	}
+	if strings.Contains(stdout, "Play: two") {
+		t.Errorf("a play whose tasks will never run should not print a header; got %q", stdout)
+	}
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stderr, "run cancelled") {
+		t.Errorf("stderr should say the run was cancelled; got %q", stderr)
+	}
+}
+
+// TestApplyWithoutCtxUsesBackground pins the fallback: a command built as a
+// bare struct literal, as most of these tests and any embedding caller that
+// does not set Ctx do, still runs instead of panicking on a nil context.
+func TestApplyWithoutCtxUsesBackground(t *testing.T) {
+	defer stubReset()
+	stubSet("first", StubFixture{Changed: true})
+	stubSet("second", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, twoTaskRecipe)
+	if _, stderr, exit := runApply(t, path); exit != 0 {
+		t.Errorf("exit = %d, want 0; stderr: %s", exit, stderr)
+	}
+}

--- a/commands/context_test.go
+++ b/commands/context_test.go
@@ -1,0 +1,10 @@
+package commands
+
+import "context"
+
+// testCtx is the context the command tests plan and execute under. Same
+// reason as the tasks package's copy: `context` is already bound to an input
+// map in several of these files.
+func testCtx() context.Context {
+	return context.Background()
+}

--- a/commands/export.go
+++ b/commands/export.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -29,6 +30,12 @@ const varsFileMode = 0o600
 // `docket apply --vars-file <vars>`.
 type ExportCommand struct {
 	command.Meta
+
+	// Ctx is the run context, populated from main.go with the process signal
+	// context. It carries cancellation down through every task's Plan and
+	// Execute. Nil when the command was constructed directly (tests do this),
+	// in which case Run falls back to context.Background().
+	Ctx context.Context
 
 	output     string
 	varsOutput string
@@ -181,6 +188,7 @@ func (c *ExportCommand) Run(args []string) int {
 		return 1
 	}
 
+	ctx := runContext(c.Ctx)
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
 	if resolvedHost != "" {
 		defer subprocess.CloseSshControlMaster(resolvedHost)
@@ -188,7 +196,7 @@ func (c *ExportCommand) Run(args []string) int {
 
 	toStdout := c.output == taskFileStdin
 
-	res, err := tasks.ExportRecipe(tasks.ExportOptions{
+	res, err := tasks.ExportRecipe(ctx, tasks.ExportOptions{
 		Apps:      c.apps,
 		Resources: resources,
 		Redact:    c.redact,

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -18,6 +19,12 @@ import (
 // per-task Plan() method; the apply path is never invoked.
 type PlanCommand struct {
 	command.Meta
+
+	// Ctx is the run context, populated from main.go with the process signal
+	// context. It carries cancellation down through every task's Plan and
+	// Execute. Nil when the command was constructed directly (tests do this),
+	// in which case Run falls back to context.Background().
+	Ctx context.Context
 
 	tasksFile string
 	// tasksFormatFlag is the raw --tasks-format value; tasksFormat is
@@ -173,6 +180,7 @@ func (c *PlanCommand) Run(args []string) int {
 		c.Ui.Warn(w)
 	}
 
+	ctx := runContext(c.Ctx)
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
 
 	formatOverride, err := parseRecipeFormatFlag("--tasks-format", c.tasksFormatFlag)
@@ -203,7 +211,7 @@ func (c *PlanCommand) Run(args []string) int {
 
 	userSet := userSetKeys(flags, varsFileKeys, c.arguments)
 
-	context, sensitiveValues, err := buildInputContext(c.arguments, userSet)
+	inputCtx, sensitiveValues, err := buildInputContext(c.arguments, userSet)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -216,7 +224,7 @@ func (c *PlanCommand) Run(args []string) int {
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
-	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, context, userSet)
+	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, inputCtx, userSet)
 	if err != nil {
 		c.Ui.Error(subprocess.MaskString(fmt.Sprintf("task error: %v", err)))
 		return 1
@@ -256,7 +264,7 @@ func (c *PlanCommand) Run(args []string) int {
 			skips:         c.skipTags,
 			fileLevelKeys: fileLevelKeys,
 			userSet:       userSet,
-			context:       context,
+			context:       inputCtx,
 			jsonOut:       c.json,
 		})
 	}
@@ -270,7 +278,7 @@ func (c *PlanCommand) Run(args []string) int {
 	counts := PlanCounts{}
 	hasError := false
 	hasDrift := false
-	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(context, fileLevelKeys, userSet))
+	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(inputCtx, fileLevelKeys, userSet))
 	// registered + loopAccum carry the same role as in apply: predicates
 	// in plan mode see `.registered.<name>` based on the
 	// post-override synthesized TaskOutputState of prior tasks.
@@ -279,7 +287,13 @@ func (c *PlanCommand) Run(args []string) int {
 	registered := map[string]tasks.RegisteredValue{}
 	loopAccum := loopRegisterAccumulator{}
 
+playLoop:
 	for _, play := range plays {
+		// Checked per play as well as per task so a cancelled run does not
+		// print the header of a play whose tasks will never be probed.
+		if ctx.Err() != nil {
+			break playLoop
+		}
 		if play.IsFileLevel() {
 			// Inputs-only plays carry no tasks; their inputs are
 			// already folded into fileLevelKeys above. They produce
@@ -303,9 +317,10 @@ func (c *PlanCommand) Run(args []string) int {
 
 		emitter.PlayStart(play.Name, resolvedHost)
 
-		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(context, play.Inputs, userSet))
+		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(inputCtx, play.Inputs, userSet))
 
 		pc := &planContext{
+			ctx:         ctx,
 			play:        play,
 			playExprCtx: playExprCtx,
 			registered:  registered,
@@ -315,6 +330,9 @@ func (c *PlanCommand) Run(args []string) int {
 		}
 
 		for _, name := range tasks.FilterByTags(play.Tasks, c.tags, c.skipTags) {
+			if ctx.Err() != nil {
+				break playLoop
+			}
 			env := play.Tasks.GetEnvelope(name)
 			outcome := planTask(env, name, pc, nil, "")
 			if outcome.errored {
@@ -328,6 +346,13 @@ func (c *PlanCommand) Run(args []string) int {
 
 	emitter.PlanSummary(counts, time.Since(start))
 
+	// An interrupt that lands mid-probe also fails that task, so the loop
+	// leaves through the error path rather than its own cancellation check;
+	// asking here catches every route out. See ApplyCommand.runExit.
+	if ctx.Err() != nil {
+		c.Ui.Error("run cancelled")
+		return 1
+	}
 	if hasError {
 		return 1
 	}
@@ -349,6 +374,9 @@ func (c *PlanCommand) newEmitter() EventEmitter {
 // planContext bundles the run-wide plan state per-task helpers share so
 // planTask / planLeaf / planGroup signatures stay tractable.
 type planContext struct {
+	// ctx is the run context. Every task this play plans is probed under it,
+	// so cancelling it stops the run rather than only the probe in flight.
+	ctx         context.Context
 	play        *tasks.Play
 	playExprCtx map[string]interface{}
 	registered  map[string]tasks.RegisteredValue
@@ -420,7 +448,7 @@ func planLeaf(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask 
 		pc.emitter.TaskWarning(pc.play.Name, name, "deprecated", msg)
 	}
 
-	result := env.Task.Plan()
+	result := env.Task.Plan(pc.ctx)
 	pc.counts.Tasks++
 
 	// Probe diagnostics raised during planning surface as informational
@@ -556,6 +584,9 @@ func planGroup(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask
 		lastChildState   tasks.TaskOutputState
 	)
 	for i, child := range env.Block {
+		if pc.ctx.Err() != nil {
+			break
+		}
 		childName := child.Name
 		if childName == "" {
 			childName = fmt.Sprintf("%s.block[%d]", name, i)
@@ -581,6 +612,9 @@ func planGroup(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask
 			failedTaskCtx = blockFailedState
 		}
 		for i, child := range env.Rescue {
+			if pc.ctx.Err() != nil {
+				break
+			}
 			childName := child.Name
 			if childName == "" {
 				childName = fmt.Sprintf("%s.rescue[%d]", name, i)
@@ -592,6 +626,9 @@ func planGroup(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask
 			lastChildState = childOutcome.state
 		}
 		for i, child := range env.Always {
+			if pc.ctx.Err() != nil {
+				break
+			}
 			childName := child.Name
 			if childName == "" {
 				childName = fmt.Sprintf("%s.always[%d]", name, i)

--- a/commands/plan_test.go
+++ b/commands/plan_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dokku/docket/tasks"
@@ -46,10 +47,14 @@ func TestPlanCommandHelpDoesNotPanic(t *testing.T) {
 }
 
 // TestPlanCommandUsesPlanInterface guards the contract between the commands
-// package and the tasks package: PlanCommand consumes tasks.Task, which
-// must expose Plan() returning tasks.PlanResult.
+// package and the tasks package: PlanCommand consumes tasks.Task, which must
+// expose Plan and Execute taking the run context and returning the plan /
+// output types the command layer switches on. The context parameter is the
+// part worth pinning - it is how cancellation and the target reach a task,
+// and dropping it would silently put both back on package globals.
 func TestPlanCommandUsesPlanInterface(t *testing.T) {
 	var _ interface {
-		Plan() tasks.PlanResult
+		Plan(ctx context.Context) tasks.PlanResult
+		Execute(ctx context.Context) tasks.TaskOutputState
 	} = (tasks.Task)(nil)
 }

--- a/commands/ssh_flags.go
+++ b/commands/ssh_flags.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"os"
 
 	"github.com/dokku/docket/subprocess"
@@ -32,4 +33,15 @@ func resolveSshFlags(hostFlag string, sudo, acceptNewHostKeys bool) string {
 		_ = os.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "1")
 	}
 	return host
+}
+
+// runContext returns the context every task in this run is planned and
+// executed under. It is the process signal context when docket was started
+// from main.go, so an interrupt cancels the whole run; a command built
+// directly (as the tests do) gets a background context instead.
+func runContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
 }

--- a/commands/stub_task_test.go
+++ b/commands/stub_task_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -57,8 +58,11 @@ func (t StubTask) ProbeSupport() tasks.ProbeSupport {
 	return tasks.ProbeSupport{Status: tasks.ProbeSupported}
 }
 
-func (t StubTask) Plan() tasks.PlanResult {
+func (t StubTask) Plan(ctx context.Context) tasks.PlanResult {
 	fixture := stubGet(t.Key)
+	if fixture.Hook != nil {
+		fixture.Hook()
+	}
 	if fixture.PlanError != nil {
 		return tasks.PlanResult{
 			Status:       tasks.PlanStatusError,
@@ -88,8 +92,11 @@ func (t StubTask) Plan() tasks.PlanResult {
 	}
 }
 
-func (t StubTask) Execute() tasks.TaskOutputState {
+func (t StubTask) Execute(ctx context.Context) tasks.TaskOutputState {
 	fixture := stubGet(t.Key)
+	if fixture.Hook != nil {
+		fixture.Hook()
+	}
 	if fixture.ExecuteError != nil {
 		return tasks.TaskOutputState{
 			Error:        fixture.ExecuteError,
@@ -143,6 +150,11 @@ type StubFixture struct {
 	// success TaskOutputState (apply mode) so tests can drive the run loops'
 	// warning drain. #353.
 	Warnings []tasks.PlanWarning
+	// Hook, when set, runs as the first thing Plan and Execute do. It exists
+	// so a test can make something happen *during* the run - cancelling the
+	// run context, recording that this task was reached - at a deterministic
+	// point rather than racing the executor from another goroutine.
+	Hook func()
 }
 
 var (

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -312,6 +312,19 @@ A multi-command task renders one continuation line per invocation under `--verbo
 Color output respects [`NO_COLOR`](https://no-color.org/): set `NO_COLOR=1` to disable ANSI escapes.
 Output is also plain automatically when piped to a non-TTY.
 
+### Interrupting a run
+
+`Ctrl-C` aborts the whole run, not just the task in flight. The interrupt ends whatever `dokku` or
+`ssh` command is executing, no further task is started - including the plays that would have
+followed - and `apply` prints `run cancelled` and exits `1`. That exit code is deliberate: an
+interrupted run reports `1` rather than the `2` `--detailed-exitcode` uses for "completed, and
+something changed", because it did not complete. A second `Ctrl-C` kills docket outright, in case
+the first one left something wedged.
+
+Cancellation reaches only the local process. Over SSH it ends the local `ssh` client; a `dokku`
+command already running on the remote host keeps going, so re-run `plan` afterwards to see where
+the server actually ended up.
+
 ### Inspecting and resuming
 
 Two flags help when a recipe grows long. `--list-tasks` previews the resolved plan without running,

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -11,15 +11,22 @@ an execution context that maps to a single module; its fields can be templated f
 
 ## The Plan / Execute model
 
-Every task implements two methods. `Plan()` is the canonical one: it probes the live server once,
+Every task implements two methods. `Plan(ctx)` is the canonical one: it probes the live server once,
 computes the difference between the current and desired state, and returns a `PlanResult`. When the
 server is not already in the desired state, `Plan()` embeds an `apply` closure that performs the
-mutation. `Execute()` is always just `ExecutePlan(t.Plan())` - the shared `ExecutePlan` helper
-handles the in-sync, error, and apply cases uniformly, so the mutation logic lives in exactly one
-place per task.
+mutation. `Execute(ctx)` is always just `ExecutePlan(ctx, t.Plan(ctx))` - the shared `ExecutePlan`
+helper handles the in-sync, error, and apply cases uniformly, so the mutation logic lives in exactly
+one place per task.
 
 This split is why `plan` and `apply` agree: both call the same `Plan()`. `apply` reuses the probe
 to decide whether to mutate, which is what makes back-to-back applies no-ops.
+
+Both take a `context.Context`, and so does every helper below them. Pass it to each
+`subprocess.CallExecCommand` / `subprocess.Probe` call rather than reaching for
+`context.Background()`: it is what carries cancellation, so an interrupt or a caller's deadline
+reaches a task that is mid-command instead of waiting for the command to finish. The `apply` closure
+takes one rather than capturing the one `Plan()` ran under, because `ExecutePlan` invokes it
+separately and hands it the caller's current context.
 
 ## Adding a new task
 
@@ -27,7 +34,9 @@ Create `tasks/${TASK_NAME}_task.go`, where the task name is `lower_underscore_ca
 named `lollipop`, `tasks/lollipop_task.go` would contain:
 
 ```go
-package main
+package tasks
+
+import "context"
 
 type LollipopTask struct {
   App     string   `required:"true" identity:"key" yaml:"app" description:"Name of the app"`
@@ -35,7 +44,9 @@ type LollipopTask struct {
   State   State    `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the lollipop"`
 }
 
-func (t LollipopTask) Plan() PlanResult {
+func (t LollipopTask) Plan(ctx context.Context) PlanResult {
+  // DispatchPlan keeps its argument-free branch signature; the closures capture
+  // ctx from the enclosing Plan.
   return DispatchPlan(t.State, map[State]func() PlanResult{
     "present": func() PlanResult {
       // Probe the server once, decide whether to mutate.
@@ -47,7 +58,7 @@ func (t LollipopTask) Plan() PlanResult {
         Status:    PlanStatusCreate, // or PlanStatusModify, PlanStatusDestroy
         Reason:    "...",
         Mutations: []string{"create lollipop"},
-        apply: func() TaskOutputState {
+        apply: func(ctx context.Context) TaskOutputState {
           // Run the underlying dokku command. Return Changed=true on success.
           return TaskOutputState{Changed: true, State: StatePresent}
         },
@@ -57,8 +68,8 @@ func (t LollipopTask) Plan() PlanResult {
   })
 }
 
-func (t LollipopTask) Execute() TaskOutputState {
-  return ExecutePlan(t.Plan())
+func (t LollipopTask) Execute(ctx context.Context) TaskOutputState {
+  return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 func init() {
@@ -170,7 +181,7 @@ func (t LollipopTask) Validate() error {
   return nil
 }
 
-func (t LollipopTask) Plan() PlanResult {
+func (t LollipopTask) Plan(ctx context.Context) PlanResult {
   if err := t.Validate(); err != nil {
     return planErr(err)
   }
@@ -178,8 +189,9 @@ func (t LollipopTask) Plan() PlanResult {
 }
 ```
 
-`Plan()` calls `Validate()` before it probes, so `plan` and `apply` still report the error. Because
-`Validate()` is a pure function of the struct - it must never call a probing or mutating dokku
+`Validate()` takes no context, and that is the point: it never contacts a server, so there is
+nothing to cancel. `Plan()` calls it before it probes, so `plan` and `apply` still report the error.
+Because it is a pure function of the struct - it must never call a probing or mutating dokku
 command - `docket validate` calls the same method offline and surfaces any error as
 `invalid_task_input`, catching the mistake before a server is ever contacted. Keep the error strings
 identical to what `Plan()` used to return so `plan`, `apply`, and `validate` all read the same.
@@ -187,8 +199,8 @@ identical to what `Plan()` used to return so `plan`, `apply`, and `validate` all
 ## Exporting a task
 
 A task that declares itself exportable also implements one of two methods, and is listed in the
-matching order slice in `tasks/export.go`: `ExportApp(app string)` plus an entry in `appExportOrder`
-for app-scoped state, `ExportGlobal()` plus an entry in `globalExportOrder` for the rest. Both return
+matching order slice in `tasks/export.go`: `ExportApp(ctx, app)` plus an entry in `appExportOrder`
+for app-scoped state, `ExportGlobal(ctx)` plus an entry in `globalExportOrder` for the rest. Both return
 task bodies - the task's own struct, populated from the server - and the engine handles
 vars-extraction and redaction afterwards. `TestExportSupportMatchesExportWiring` fails the build for
 an exporter no order list names, and for a task that claims to export without implementing one.
@@ -198,8 +210,8 @@ plannable exactly as the exporter returns it.
 
 When an exporter needs to say something about a particular resource - an asset it could not capture,
 a resource it read back but cannot emit as a task the loader would accept - implement the reporting
-form instead of logging: `ExportAppReport(app string, warn func(msg string))` or
-`ExportGlobalReport(warn func(msg string))`. The engine passes a `warn` callback wired to
+form instead of logging: `ExportAppReport(ctx, app, warn)` or
+`ExportGlobalReport(ctx, warn)`. The engine passes a `warn` callback wired to
 `ExportReport.Warnings`, so the message is rendered and masked like every other export diagnostic
 and reaches the operator with the run it belongs to.
 
@@ -217,12 +229,12 @@ that. The usual shape is a shared private method with two thin entry points, as
 `MaintenanceCustomPageTask` and `SchedulerK3sProfileTask` do:
 
 ```go
-func (t LollipopTask) ExportGlobal() ([]interface{}, error) {
-  return t.exportGlobal(func(string) {})
+func (t LollipopTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+  return t.exportGlobal(ctx, func(string) {})
 }
 
-func (t LollipopTask) ExportGlobalReport(warn func(msg string)) ([]interface{}, error) {
-  return t.exportGlobal(warn)
+func (t LollipopTask) ExportGlobalReport(ctx context.Context, warn func(msg string)) ([]interface{}, error) {
+  return t.exportGlobal(ctx, warn)
 }
 ```
 
@@ -264,13 +276,13 @@ type ChecksToggleTask ToggleFields
 
 // The probe reports the current position. A non-nil error (or a nil probe) is
 // treated as drift, so the enable/disable command runs anyway.
-func checksEnabled(ctx ToggleContext) (bool, error) {
-  // dokku checks:report <app> --format json
+func checksEnabled(ctx context.Context, tc ToggleContext) (bool, error) {
+  // dokku checks:report <tc.App> --format json
   // ... return true when nothing is disabled
 }
 
-func (t ChecksToggleTask) Plan() PlanResult {
-  return planToggle(t.State, t.App, "checks:enable", "checks:disable", checksEnabled)
+func (t ChecksToggleTask) Plan(ctx context.Context) PlanResult {
+  return planToggle(ctx, t.State, t.App, "checks:enable", "checks:disable", checksEnabled)
 }
 ```
 
@@ -316,8 +328,8 @@ func (t NginxPropertyTask) Validate() error {
   return validatePropertyInput(t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
-func (t NginxPropertyTask) Plan() PlanResult {
-  return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t NginxPropertyTask) Plan(ctx context.Context) PlanResult {
+  return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 ```
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/dokku/docket/commands"
 
@@ -21,7 +23,19 @@ func main() {
 }
 
 func Run(args []string) int {
-	ctx := context.Background()
+	// One signal handler for the process, installed here rather than around
+	// every subprocess call. Cancelling this context is what makes an
+	// interrupt abort the run instead of only the task in flight, and
+	// NotifyContext restores the default disposition afterwards so a second
+	// Ctrl-C still kills a wedged process.
+	ctx, stop := signal.NotifyContext(context.Background(),
+		os.Interrupt,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGQUIT,
+		syscall.SIGTERM)
+	defer stop()
+
 	commandMeta := command.SetupRun(ctx, AppName, Version, args)
 	commandMeta.Ui = command.HumanZerologUiWithFields(commandMeta.Ui, make(map[string]interface{}, 0))
 	c := cli.NewCLI(AppName, Version)
@@ -39,10 +53,10 @@ func Run(args []string) int {
 func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFactory {
 	return map[string]cli.CommandFactory{
 		"apply": func() (cli.Command, error) {
-			return &commands.ApplyCommand{Meta: meta}, nil
+			return &commands.ApplyCommand{Meta: meta, Ctx: ctx}, nil
 		},
 		"export": func() (cli.Command, error) {
-			return &commands.ExportCommand{Meta: meta}, nil
+			return &commands.ExportCommand{Meta: meta, Ctx: ctx}, nil
 		},
 		"fmt": func() (cli.Command, error) {
 			return &commands.FmtCommand{Meta: meta}, nil
@@ -51,7 +65,7 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 			return &commands.InitCommand{Meta: meta}, nil
 		},
 		"plan": func() (cli.Command, error) {
-			return &commands.PlanCommand{Meta: meta}, nil
+			return &commands.PlanCommand{Meta: meta, Ctx: ctx}, nil
 		},
 		"schema": func() (cli.Command, error) {
 			return &commands.SchemaCommand{Meta: meta}, nil

--- a/subprocess/cancellation_test.go
+++ b/subprocess/cancellation_test.go
@@ -1,0 +1,105 @@
+package subprocess
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestCallExecCommandHonorsAlreadyCancelledContext pins that a context which
+// is already dead short-circuits rather than running the command. Before the
+// context reached this far, the only thing that could stop a subprocess was a
+// signal handled inside this package, so a caller holding a cancelled context
+// had no way to prevent the next command from running to completion.
+func TestCallExecCommandHonorsAlreadyCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	resp, err := CallExecCommand(ctx, ExecCommandInput{
+		Command: "true",
+	})
+	if err == nil {
+		t.Fatal("expected an error from an already-cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want it to wrap context.Canceled", err)
+	}
+	if !resp.Cancelled {
+		t.Error("response should report Cancelled")
+	}
+}
+
+// TestProbePropagatesCancellation pins that a cancelled probe is reported as a
+// failure rather than as "the probed state is absent". Reading a cancellation
+// as absence would make a plan claim drift and an apply then mutate a server
+// it never successfully read.
+func TestProbePropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ok, err := Probe(ctx, ExecCommandInput{Command: "true"})
+	if err == nil {
+		t.Fatal("expected a cancelled probe to propagate its error")
+	}
+	if ok {
+		t.Error("a cancelled probe must not report a match")
+	}
+}
+
+// TestCallExecCommandDeadlineBoundsTheChild pins that a deadline actually
+// bounds a slow command, which is the property an embedding caller needs and
+// a signal handler cannot provide.
+func TestCallExecCommandDeadlineBoundsTheChild(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := CallExecCommand(ctx, ExecCommandInput{
+		Command: "sleep",
+		Args:    []string{"10"},
+	}); err == nil {
+		t.Fatal("expected the deadline to end the call")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("call took %s; the deadline did not bound the child", elapsed)
+	}
+}
+
+// TestCallExecCommandDoesNotLeakGoroutines is the regression lock on removing
+// the per-call signal handler. Each call used to register a channel with
+// signal.Notify without ever calling signal.Stop, and park a goroutine on that
+// channel that nothing ever woke - so a run leaked one goroutine, one channel
+// registration and one derived context per dokku command it issued.
+func TestCallExecCommandDoesNotLeakGoroutines(t *testing.T) {
+	ctx := context.Background()
+	// Warm up so one-off runtime goroutines are not counted as growth.
+	for i := 0; i < 5; i++ {
+		_, _ = CallExecCommand(ctx, ExecCommandInput{Command: "true"})
+	}
+	settle()
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 100; i++ {
+		if _, err := CallExecCommand(ctx, ExecCommandInput{Command: "true"}); err != nil {
+			t.Fatalf("CallExecCommand: %v", err)
+		}
+	}
+	settle()
+
+	if grew := runtime.NumGoroutine() - before; grew > 5 {
+		t.Errorf("goroutine count grew by %d over 100 calls; the per-call handler is leaking again", grew)
+	}
+}
+
+// settle gives finished commands a moment to release their goroutines before
+// the count is read, so the assertion measures a leak rather than a race with
+// normal teardown.
+func settle() {
+	for i := 0; i < 10; i++ {
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond)
+	}
+	runtime.GC()
+}

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -1,15 +1,12 @@
 package subprocess
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
-
-	"context"
 
 	execute "github.com/alexellis/go-execute/v2"
 	"github.com/fatih/color"
@@ -143,13 +140,16 @@ func (ecr ExecCommandResponse) StdoutBytes() []byte {
 // PlanResult.Commands renders byte-identical to the strings apply emits via
 // state.Commands; sharing the rendering logic keeps the two views from drifting.
 //
-// The function mirrors the dispatch in CallExecCommandWithContext and
-// CallSshCommandWithContext: when the (possibly defaulted) Host is set and the
-// command is `dokku`, the SSH transport's bare `cmd args` form is returned
-// because remote sudo is wrapped server-side via DOKKU_SUDO and never appears
-// in the displayed command. Otherwise the local path's sudo-wrap-when-true
-// form is returned.
-func ResolveCommandString(input ExecCommandInput) string {
+// The function mirrors the dispatch in CallExecCommand and CallSshCommand:
+// when the (possibly defaulted) Host is set and the command is `dokku`, the
+// SSH transport's bare `cmd args` form is returned because remote sudo is
+// wrapped server-side via DOKKU_SUDO and never appears in the displayed
+// command. Otherwise the local path's sudo-wrap-when-true form is returned.
+//
+// ctx is not read yet. It is here because this function has to mirror that
+// dispatch, and the dispatch is what reads the per-invocation target once
+// #423 moves it off the package global.
+func ResolveCommandString(ctx context.Context, input ExecCommandInput) string {
 	if input.Host == "" {
 		input.Host = GetDefaultHost()
 	}
@@ -166,7 +166,7 @@ func ResolveCommandString(input ExecCommandInput) string {
 }
 
 // resolveLocalCommandString joins a local command and args into the masked
-// form CallExecCommandWithContext records on the response.
+// form CallExecCommand records on the response.
 func resolveLocalCommandString(command string, args []string) string {
 	if len(args) == 0 {
 		return MaskString(command)
@@ -183,17 +183,10 @@ func resolveSshCommandString(command string, args []string) string {
 	return MaskString(command + " " + strings.Join(args, " "))
 }
 
-// CallExecCommand executes a command on the local host
-func CallExecCommand(input ExecCommandInput) (ExecCommandResponse, error) {
-	ctx := context.Background()
-	return CallExecCommandWithContext(ctx, input)
-}
-
-// execRunner is the executor CallExecCommand and CallExecCommandWithContext
-// delegate to. It defaults to defaultExecRunner (the real implementation) and
-// can be swapped in tests via SetExecRunner so unit tests return canned
-// responses without spawning a process or contacting a server. Production code
-// must never reassign it.
+// execRunner is the executor CallExecCommand delegates to. It defaults to
+// defaultExecRunner (the real implementation) and can be swapped in tests via
+// SetExecRunner so unit tests return canned responses without spawning a
+// process or contacting a server. Production code must never reassign it.
 //
 // The swap mutates package state and is therefore test-only and not safe under
 // t.Parallel().
@@ -209,7 +202,7 @@ func SetExecRunner(fn func(ctx context.Context, input ExecCommandInput) (ExecCom
 	return func() { execRunner = prev }
 }
 
-// CallExecCommandWithContext executes a command on the local host with the given context.
+// CallExecCommand executes a command on the local host under ctx.
 //
 // When `input.Host` is set (or a default has been configured via
 // SetDefaultHost) and the command is `dokku`, dispatch is routed
@@ -218,9 +211,15 @@ func SetExecRunner(fn func(ctx context.Context, input ExecCommandInput) (ExecCom
 // when a host is configured, since the remote side may not have those
 // binaries (and tests expect local execution).
 //
+// The context is the caller's: cancelling it kills the child process, and a
+// deadline on it bounds the call. Nothing in this package installs a signal
+// handler any more - the command layer wires SIGINT to the run context via
+// signal.NotifyContext, so one interrupt aborts the run rather than the
+// current task.
+//
 // The call is routed through the swappable execRunner so tests can substitute a
 // fake executor; defaultExecRunner is the production path.
-func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+func CallExecCommand(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
 	return execRunner(ctx, input)
 }
 
@@ -231,19 +230,8 @@ func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommand
 		input.Host = GetDefaultHost()
 	}
 	if input.Host != "" && input.Command == "dokku" {
-		return CallSshCommandWithContext(ctx, input.Host, input)
+		return CallSshCommand(ctx, input.Host, input)
 	}
-
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGQUIT,
-		syscall.SIGTERM)
-	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		<-signals
-		cancel()
-	}()
 
 	// isatty reports whether our own stdout is a terminal, which is the
 	// signal used below to decide whether the child may read the terminal.

--- a/subprocess/exec_test.go
+++ b/subprocess/exec_test.go
@@ -56,7 +56,7 @@ func TestResolveCommandString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			SetGlobalSensitive(tc.sensitive)
 			t.Cleanup(func() { SetGlobalSensitive(nil) })
-			if got := ResolveCommandString(tc.input); got != tc.want {
+			if got := ResolveCommandString(context.Background(), tc.input); got != tc.want {
 				t.Errorf("ResolveCommandString = %q, want %q", got, tc.want)
 			}
 		})
@@ -66,7 +66,7 @@ func TestResolveCommandString(t *testing.T) {
 func TestResolveCommandStringHonorsDefaultHost(t *testing.T) {
 	t.Cleanup(func() { SetDefaultHost("") })
 	SetDefaultHost("alice@host")
-	got := ResolveCommandString(ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Sudo: true})
+	got := ResolveCommandString(context.Background(), ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Sudo: true})
 	want := "dokku apps:create api"
 	if got != want {
 		t.Errorf("ResolveCommandString with default host = %q, want %q", got, want)
@@ -146,7 +146,7 @@ func TestExecCommandResponseStderrBytes(t *testing.T) {
 }
 
 func TestCallExecCommandSuccess(t *testing.T) {
-	resp, err := CallExecCommand(ExecCommandInput{
+	resp, err := CallExecCommand(context.Background(), ExecCommandInput{
 		Command: "echo",
 		Args:    []string{"hello"},
 	})
@@ -162,7 +162,7 @@ func TestCallExecCommandSuccess(t *testing.T) {
 }
 
 func TestCallExecCommandFailure(t *testing.T) {
-	resp, err := CallExecCommand(ExecCommandInput{
+	resp, err := CallExecCommand(context.Background(), ExecCommandInput{
 		Command: "false",
 	})
 	if err == nil {
@@ -183,7 +183,7 @@ func TestCallExecCommandFailure(t *testing.T) {
 }
 
 func TestCallExecCommandNotFound(t *testing.T) {
-	_, err := CallExecCommand(ExecCommandInput{
+	_, err := CallExecCommand(context.Background(), ExecCommandInput{
 		Command: "nonexistent-binary-docket-test-12345",
 	})
 	if err == nil {
@@ -209,7 +209,7 @@ func TestCallExecCommandNotFound(t *testing.T) {
 func TestCallExecCommandInheritsProcessEnv(t *testing.T) {
 	t.Setenv("DOCKET_TEST_VAR", "test123")
 
-	resp, err := CallExecCommand(ExecCommandInput{Command: "env"})
+	resp, err := CallExecCommand(context.Background(), ExecCommandInput{Command: "env"})
 	if err != nil {
 		t.Fatalf("CallExecCommand failed: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestCallExecCommandWithContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	_, err := CallExecCommandWithContext(ctx, ExecCommandInput{
+	_, err := CallExecCommand(ctx, ExecCommandInput{
 		Command: "sleep",
 		Args:    []string{"10"},
 	})
@@ -242,7 +242,7 @@ func TestSetExecRunnerSwapsAndRestores(t *testing.T) {
 
 	// Both entry points route through the swapped runner without spawning a
 	// process (the command below does not exist on PATH).
-	resp, err := CallExecCommand(ExecCommandInput{Command: "dokku", Args: []string{"apps:list"}})
+	resp, err := CallExecCommand(context.Background(), ExecCommandInput{Command: "dokku", Args: []string{"apps:list"}})
 	if err != nil {
 		t.Fatalf("CallExecCommand with fake runner failed: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestSetExecRunnerSwapsAndRestores(t *testing.T) {
 	restore()
 
 	// After restore the real executor runs again: echo succeeds locally.
-	resp, err = CallExecCommand(ExecCommandInput{Command: "echo", Args: []string{"hi"}})
+	resp, err = CallExecCommand(context.Background(), ExecCommandInput{Command: "echo", Args: []string{"hi"}})
 	if err != nil {
 		t.Fatalf("CallExecCommand after restore failed: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestCallExecCommandResponseCommandIsMasked(t *testing.T) {
 	SetGlobalSensitive([]string{"topsecret123"})
 	defer SetGlobalSensitive(nil)
 
-	resp, err := CallExecCommand(ExecCommandInput{
+	resp, err := CallExecCommand(context.Background(), ExecCommandInput{
 		Command: "echo",
 		Args:    []string{"login", "topsecret123"},
 	})
@@ -299,7 +299,7 @@ func TestCallExecCommandTraceLogIsMasked(t *testing.T) {
 	log.SetOutput(&buf)
 	defer log.SetOutput(prev)
 
-	if _, err := CallExecCommand(ExecCommandInput{
+	if _, err := CallExecCommand(context.Background(), ExecCommandInput{
 		Command: "echo",
 		Args:    []string{"login", "topsecret123"},
 	}); err != nil {
@@ -317,7 +317,7 @@ func TestCallExecCommandTraceLogIsMasked(t *testing.T) {
 func TestCallExecCommandResponseCommandUnmaskedWhenNoSecrets(t *testing.T) {
 	SetGlobalSensitive(nil)
 
-	resp, err := CallExecCommand(ExecCommandInput{
+	resp, err := CallExecCommand(context.Background(), ExecCommandInput{
 		Command: "echo",
 		Args:    []string{"hello", "world"},
 	})

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -44,13 +44,11 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/signal"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
 	execute "github.com/alexellis/go-execute/v2"
 	"github.com/fatih/color"
@@ -234,8 +232,8 @@ var (
 // (`apps:exists`, `network:exists`, `<service>:linked`, etc.). Probes
 // that need stdout should call CallExecCommand directly and use
 // `errors.As(err, &*SSHError)` to discriminate.
-func Probe(input ExecCommandInput) (bool, error) {
-	result, err := CallExecCommand(input)
+func Probe(ctx context.Context, input ExecCommandInput) (bool, error) {
+	result, err := CallExecCommand(ctx, input)
 	if err != nil {
 		// Transport-level failure (ssh connect/auth/host-key): propagate
 		// so the caller can render `! ssh: ...`.
@@ -257,7 +255,7 @@ func Probe(input ExecCommandInput) (bool, error) {
 	return result.ExitCode == 0, nil
 }
 
-// SetDefaultHost registers the host that CallExecCommandWithContext
+// SetDefaultHost registers the host that CallExecCommand
 // should use when ExecCommandInput.Host is empty. Pass an empty string
 // to clear the default. Mirrors the SetGlobalSensitive pattern.
 func SetDefaultHost(host string) {
@@ -284,22 +282,16 @@ func ensureSshAvailable() error {
 	return sshLookPathErr
 }
 
-// CallSshCommand executes a remote command over ssh against host using
-// the background context.
-func CallSshCommand(host string, input ExecCommandInput) (ExecCommandResponse, error) {
-	return CallSshCommandWithContext(context.Background(), host, input)
-}
-
-// CallSshCommandWithContext executes a remote command over ssh against
-// host. The execution pipeline mirrors CallExecCommandWithContext (same
-// signal handling, DOKKU_TRACE logging, masking, stdio wiring) so callers
-// see identical behavior aside from the transport.
+// CallSshCommand executes a remote command over ssh against host under
+// ctx. The execution pipeline mirrors CallExecCommand (same DOKKU_TRACE
+// logging, masking, stdio wiring) so callers see identical behavior aside
+// from the transport.
 //
 // On exit code 255 (OpenSSH's transport-failure code), the returned
 // error is `*SSHError`. On any other non-zero exit, the returned error
 // is the plain underlying error so the formatter renders the failure
 // as a remote dokku error.
-func CallSshCommandWithContext(ctx context.Context, host string, input ExecCommandInput) (ExecCommandResponse, error) {
+func CallSshCommand(ctx context.Context, host string, input ExecCommandInput) (ExecCommandResponse, error) {
 	target, err := parseDokkuHost(host)
 	if err != nil {
 		return ExecCommandResponse{}, &SSHError{Host: host, Err: err}
@@ -307,17 +299,6 @@ func CallSshCommandWithContext(ctx context.Context, host string, input ExecComma
 	if err := ensureSshAvailable(); err != nil {
 		return ExecCommandResponse{}, &SSHError{Host: target.UserHost(), Err: err}
 	}
-
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGQUIT,
-		syscall.SIGTERM)
-	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		<-signals
-		cancel()
-	}()
 
 	// isatty reports whether our own stdout is a terminal, which is the
 	// signal used below to decide whether the child may read the terminal.

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -322,7 +322,7 @@ func TestBuildSshArgvRejectsUnquotable(t *testing.T) {
 
 	// The same failure surfaces through the dispatcher as a transport-level
 	// *SSHError so plan/apply render it with the `ssh:` prefix.
-	_, err := CallSshCommand("alice@host", ExecCommandInput{
+	_, err := CallSshCommand(context.Background(), "alice@host", ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"config:set", "app", "a\nb"},
 	})
@@ -418,7 +418,7 @@ func TestClassifySshResultSuccess(t *testing.T) {
 }
 
 func TestCallSshCommandReturnsSshErrorOnEmptyHost(t *testing.T) {
-	_, err := CallSshCommand("", ExecCommandInput{Command: "dokku", Args: []string{"version"}})
+	_, err := CallSshCommand(context.Background(), "", ExecCommandInput{Command: "dokku", Args: []string{"version"}})
 	if err == nil {
 		t.Fatal("expected error for empty host")
 	}
@@ -429,22 +429,22 @@ func TestCallSshCommandReturnsSshErrorOnEmptyHost(t *testing.T) {
 }
 
 func TestProbeSuccess(t *testing.T) {
-	matched, err := Probe(ExecCommandInput{Command: "true"})
+	matched, err := Probe(context.Background(), ExecCommandInput{Command: "true"})
 	if err != nil {
-		t.Fatalf("Probe(true) returned error: %v", err)
+		t.Fatalf("Probe(context.Background(), true) returned error: %v", err)
 	}
 	if !matched {
-		t.Error("Probe(true) should report matched=true")
+		t.Error("Probe(context.Background(), true) should report matched=true")
 	}
 }
 
 func TestProbeDokkuLevelFailure(t *testing.T) {
-	matched, err := Probe(ExecCommandInput{Command: "false"})
+	matched, err := Probe(context.Background(), ExecCommandInput{Command: "false"})
 	if err != nil {
-		t.Errorf("Probe(false) returned non-nil error %v - dokku-level exit should be normalised", err)
+		t.Errorf("Probe(context.Background(), false) returned non-nil error %v - dokku-level exit should be normalised", err)
 	}
 	if matched {
-		t.Error("Probe(false) should report matched=false")
+		t.Error("Probe(context.Background(), false) should report matched=false")
 	}
 }
 
@@ -455,7 +455,7 @@ func TestProbeSshTransportErrorPropagates(t *testing.T) {
 	t.Cleanup(func() { SetDefaultHost("") })
 	SetDefaultHost("docket-test@127.0.0.1:1")
 
-	matched, err := Probe(ExecCommandInput{
+	matched, err := Probe(context.Background(), ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "apps:exists", "anything"},
 	})
@@ -476,7 +476,7 @@ func TestProbeLocalExecErrorPropagates(t *testing.T) {
 	// rather than reporting the probed state as absent. This is the
 	// no-dokku-installed scenario: without propagation, plan would print a
 	// confident [+] create for every resource instead of [!].
-	matched, err := Probe(ExecCommandInput{
+	matched, err := Probe(context.Background(), ExecCommandInput{
 		Command: "nonexistent-binary-docket-test-12345",
 		Args:    []string{"--quiet", "apps:exists", "anything"},
 	})
@@ -499,7 +499,7 @@ func TestProbeExecRanFlagControlsAbsence(t *testing.T) {
 			return resp, &ExecError{Response: resp, Err: errors.New("absent"), Ran: true}
 		})()
 
-		matched, err := Probe(ExecCommandInput{Command: "dokku"})
+		matched, err := Probe(context.Background(), ExecCommandInput{Command: "dokku"})
 		if err != nil {
 			t.Fatalf("Probe should treat a ran non-zero exit as absent, got err %v", err)
 		}
@@ -514,7 +514,7 @@ func TestProbeExecRanFlagControlsAbsence(t *testing.T) {
 			return resp, &ExecError{Response: resp, Err: context.Canceled}
 		})()
 
-		matched, err := Probe(ExecCommandInput{Command: "dokku"})
+		matched, err := Probe(context.Background(), ExecCommandInput{Command: "dokku"})
 		if matched {
 			t.Error("Probe should report matched=false on a cancelled probe")
 		}

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -82,8 +83,8 @@ func (t AclAppTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the app ACL
-func (t AclAppTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t AclAppTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the AclAppTask's inputs without contacting the server, so
@@ -99,13 +100,13 @@ func (t AclAppTask) Validate() error {
 }
 
 // Plan reports the drift the AclAppTask would produce.
-func (t AclAppTask) Plan() PlanResult {
+func (t AclAppTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			current, err := getAclAppUsers(t.App)
+			current, err := getAclAppUsers(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -132,14 +133,14 @@ func (t AclAppTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			current, err := getAclAppUsers(t.App)
+			current, err := getAclAppUsers(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -173,9 +174,9 @@ func (t AclAppTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -184,8 +185,8 @@ func (t AclAppTask) Plan() PlanResult {
 
 // getAclAppUsers reads the current ACL for an app via `acl:list APP`. The
 // plugin emits one username per line; an empty ACL produces no output.
-func getAclAppUsers(app string) (map[string]bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getAclAppUsers(ctx context.Context, app string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "acl:list", app},
 	})
@@ -205,8 +206,8 @@ func getAclAppUsers(app string) (map[string]bool, error) {
 }
 
 // ExportApp reconstructs the app's ACL user list, or nil when it is empty.
-func (t AclAppTask) ExportApp(app string) ([]interface{}, error) {
-	users, err := getAclAppUsers(app)
+func (t AclAppTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	users, err := getAclAppUsers(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/acl_app_task_integration_test.go
+++ b/tasks/acl_app_task_integration_test.go
@@ -11,13 +11,13 @@ func TestIntegrationAclApp(t *testing.T) {
 	skipIfPluginMissingT(t, "acl")
 
 	appName := "docket-test-acl-app"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	assertACL := func(t *testing.T, label string, want []string) {
 		t.Helper()
-		got, err := getAclAppUsers(appName)
+		got, err := getAclAppUsers(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getAclAppUsers failed: %v", label, err)
 		}
@@ -43,7 +43,7 @@ func TestIntegrationAclApp(t *testing.T) {
 
 	// add two users
 	addTask := AclAppTask{App: appName, Users: []string{"alice", "bob"}, State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add users: %v", result.Error)
 	}
@@ -56,7 +56,7 @@ func TestIntegrationAclApp(t *testing.T) {
 	assertACL(t, "after add", []string{"alice", "bob"})
 
 	// add same users again - idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -67,7 +67,7 @@ func TestIntegrationAclApp(t *testing.T) {
 
 	// remove one user
 	removeTask := AclAppTask{App: appName, Users: []string{"bob"}, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove user: %v", result.Error)
 	}
@@ -80,7 +80,7 @@ func TestIntegrationAclApp(t *testing.T) {
 	assertACL(t, "after remove bob", []string{"alice"})
 
 	// remove same user again - idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -90,13 +90,13 @@ func TestIntegrationAclApp(t *testing.T) {
 	assertACL(t, "after idempotent remove", []string{"alice"})
 
 	// re-add bob and carol, then clear with empty users
-	if err := (AclAppTask{App: appName, Users: []string{"bob", "carol"}, State: StatePresent}).Execute().Error; err != nil {
+	if err := (AclAppTask{App: appName, Users: []string{"bob", "carol"}, State: StatePresent}).Execute(testCtx()).Error; err != nil {
 		t.Fatalf("failed to re-add users: %v", err)
 	}
 	assertACL(t, "after re-add", []string{"alice", "bob", "carol"})
 
 	clearTask := AclAppTask{App: appName, State: StateAbsent}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear ACL: %v", result.Error)
 	}
@@ -106,7 +106,7 @@ func TestIntegrationAclApp(t *testing.T) {
 	assertACL(t, "after clear", nil)
 
 	// clear again - idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second clear: %v", result.Error)
 	}

--- a/tasks/acl_app_task_test.go
+++ b/tasks/acl_app_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAclAppTaskInvalidState(t *testing.T) {
 	task := AclAppTask{App: "test-app", Users: []string{"alice"}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestAclAppTaskInvalidState(t *testing.T) {
 
 func TestAclAppTaskPresentMissingApp(t *testing.T) {
 	task := AclAppTask{Users: []string{"alice"}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -26,7 +26,7 @@ func TestAclAppTaskPresentMissingApp(t *testing.T) {
 
 func TestAclAppTaskAbsentMissingApp(t *testing.T) {
 	task := AclAppTask{State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -37,7 +37,7 @@ func TestAclAppTaskAbsentMissingApp(t *testing.T) {
 
 func TestAclAppTaskPresentEmptyUsers(t *testing.T) {
 	task := AclAppTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty users and state=present should return an error")
 	}

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -58,14 +59,14 @@ func (t AclServiceTask) ProbeSupport() ProbeSupport {
 // field inversion versus the other service tasks: Service holds the instance
 // name and Type the datastore type. Services with no ACL entries - and every
 // service when the dokku-acl plugin is absent - are skipped.
-func (t AclServiceTask) ExportGlobal() ([]interface{}, error) {
-	services, err := listServices()
+func (t AclServiceTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	services, err := listServices(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var out []interface{}
 	for _, s := range services {
-		users, err := getAclServiceUsers(s.Type, s.Name)
+		users, err := getAclServiceUsers(ctx, s.Type, s.Name)
 		if err != nil {
 			var sshErr *subprocess.SSHError
 			if errors.As(err, &sshErr) {
@@ -126,8 +127,8 @@ func (t AclServiceTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the service ACL
-func (t AclServiceTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t AclServiceTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the AclServiceTask's inputs without contacting the server.
@@ -142,13 +143,13 @@ func (t AclServiceTask) Validate() error {
 }
 
 // Plan reports the drift the AclServiceTask would produce.
-func (t AclServiceTask) Plan() PlanResult {
+func (t AclServiceTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			current, err := getAclServiceUsers(t.Type, t.Service)
+			current, err := getAclServiceUsers(ctx, t.Type, t.Service)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -175,14 +176,14 @@ func (t AclServiceTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			current, err := getAclServiceUsers(t.Type, t.Service)
+			current, err := getAclServiceUsers(ctx, t.Type, t.Service)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -216,9 +217,9 @@ func (t AclServiceTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -229,8 +230,8 @@ func (t AclServiceTask) Plan() PlanResult {
 // `acl:list-service TYPE SERVICE`. The plugin's `cmd-acl-list-service`
 // emits one username per line on STDERR (via `ls -1 ... >&2`), unlike
 // `acl:list` which uses stdout, so we read stderr here.
-func getAclServiceUsers(serviceType, service string) (map[string]bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getAclServiceUsers(ctx context.Context, serviceType, service string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "acl:list-service", serviceType, service},
 	})

--- a/tasks/acl_service_task_integration_test.go
+++ b/tasks/acl_service_task_integration_test.go
@@ -15,17 +15,17 @@ func TestIntegrationAclService(t *testing.T) {
 	serviceName := "docket-test-acl-service"
 
 	// ensure clean state and create the redis service
-	destroyService(serviceType, serviceName)
-	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	destroyService(testCtx(), serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to create redis service: %v", r.Error)
 	}
 	t.Cleanup(func() {
-		destroyService(serviceType, serviceName)
+		destroyService(testCtx(), serviceType, serviceName)
 	})
 
 	assertACL := func(t *testing.T, label string, want []string) {
 		t.Helper()
-		got, err := getAclServiceUsers(serviceType, serviceName)
+		got, err := getAclServiceUsers(testCtx(), serviceType, serviceName)
 		if err != nil {
 			t.Fatalf("%s: getAclServiceUsers failed: %v", label, err)
 		}
@@ -51,7 +51,7 @@ func TestIntegrationAclService(t *testing.T) {
 
 	// add two users
 	addTask := AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{"alice", "bob"}, State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add users: %v", result.Error)
 	}
@@ -64,7 +64,7 @@ func TestIntegrationAclService(t *testing.T) {
 	assertACL(t, "after add", []string{"alice", "bob"})
 
 	// add same users again - idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -75,7 +75,7 @@ func TestIntegrationAclService(t *testing.T) {
 
 	// remove one user
 	removeTask := AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{"bob"}, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove user: %v", result.Error)
 	}
@@ -88,7 +88,7 @@ func TestIntegrationAclService(t *testing.T) {
 	assertACL(t, "after remove bob", []string{"alice"})
 
 	// remove same user again - idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -98,13 +98,13 @@ func TestIntegrationAclService(t *testing.T) {
 	assertACL(t, "after idempotent remove", []string{"alice"})
 
 	// re-add bob and carol, then clear with empty users
-	if err := (AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{"bob", "carol"}, State: StatePresent}).Execute().Error; err != nil {
+	if err := (AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{"bob", "carol"}, State: StatePresent}).Execute(testCtx()).Error; err != nil {
 		t.Fatalf("failed to re-add users: %v", err)
 	}
 	assertACL(t, "after re-add", []string{"alice", "bob", "carol"})
 
 	clearTask := AclServiceTask{Service: serviceName, Type: serviceType, State: StateAbsent}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear ACL: %v", result.Error)
 	}
@@ -114,7 +114,7 @@ func TestIntegrationAclService(t *testing.T) {
 	assertACL(t, "after clear", nil)
 
 	// clear again - idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second clear: %v", result.Error)
 	}

--- a/tasks/acl_service_task_test.go
+++ b/tasks/acl_service_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAclServiceTaskInvalidState(t *testing.T) {
 	task := AclServiceTask{Service: "my-redis", Type: "redis", Users: []string{"alice"}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -16,7 +16,7 @@ func TestAclServiceTaskInvalidState(t *testing.T) {
 func TestAclServiceTaskMissingService(t *testing.T) {
 	for _, st := range []State{StatePresent, StateAbsent} {
 		task := AclServiceTask{Type: "redis", Users: []string{"alice"}, State: st}
-		result := task.Execute()
+		result := task.Execute(testCtx())
 		if result.Error == nil {
 			t.Fatalf("Execute without service (state=%s) should return an error", st)
 		}
@@ -29,7 +29,7 @@ func TestAclServiceTaskMissingService(t *testing.T) {
 func TestAclServiceTaskMissingType(t *testing.T) {
 	for _, st := range []State{StatePresent, StateAbsent} {
 		task := AclServiceTask{Service: "my-redis", Users: []string{"alice"}, State: st}
-		result := task.Execute()
+		result := task.Execute(testCtx())
 		if result.Error == nil {
 			t.Fatalf("Execute without type (state=%s) should return an error", st)
 		}
@@ -41,7 +41,7 @@ func TestAclServiceTaskMissingType(t *testing.T) {
 
 func TestAclServiceTaskPresentEmptyUsers(t *testing.T) {
 	task := AclServiceTask{Service: "my-redis", Type: "redis", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty users and state=present should return an error")
 	}

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -72,8 +73,8 @@ func (t AppCloneTask) Examples() ([]Doc, error) {
 }
 
 // Execute clones an existing dokku app to a new app
-func (t AppCloneTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t AppCloneTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the AppCloneTask's inputs without contacting the server.
@@ -90,13 +91,13 @@ func (t AppCloneTask) Validate() error {
 }
 
 // Plan reports the drift the AppCloneTask would produce.
-func (t AppCloneTask) Plan() PlanResult {
+func (t AppCloneTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := appExists(t.App)
+			exists, err := appExists(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -114,9 +115,9 @@ func (t AppCloneTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("target app %s missing", t.App),
 				Mutations: []string{fmt.Sprintf("clone %s -> %s", t.SourceApp, t.App)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},

--- a/tasks/app_clone_task_integration_test.go
+++ b/tasks/app_clone_task_integration_test.go
@@ -10,11 +10,11 @@ func TestIntegrationAppClone(t *testing.T) {
 	sourceApp := "docket-test-clone-source"
 	targetApp := "docket-test-clone-target"
 
-	destroyApp(sourceApp)
-	destroyApp(targetApp)
-	createApp(sourceApp)
-	defer destroyApp(sourceApp)
-	defer destroyApp(targetApp)
+	destroyApp(testCtx(), sourceApp)
+	destroyApp(testCtx(), targetApp)
+	createApp(testCtx(), sourceApp)
+	defer destroyApp(testCtx(), sourceApp)
+	defer destroyApp(testCtx(), targetApp)
 
 	// clone the source app to the target
 	cloneTask := AppCloneTask{
@@ -23,7 +23,7 @@ func TestIntegrationAppClone(t *testing.T) {
 		SkipDeploy: true,
 		State:      StatePresent,
 	}
-	result := cloneTask.Execute()
+	result := cloneTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clone app: %v", result.Error)
 	}
@@ -33,13 +33,13 @@ func TestIntegrationAppClone(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	exists, _ := appExists(targetApp)
+	exists, _ := appExists(testCtx(), targetApp)
 	if !exists {
 		t.Errorf("expected target app %q to exist after clone", targetApp)
 	}
 
 	// cloning again should be idempotent (target already exists)
-	result = cloneTask.Execute()
+	result = cloneTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second clone: %v", result.Error)
 	}

--- a/tasks/app_clone_task_test.go
+++ b/tasks/app_clone_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAppCloneTaskInvalidState(t *testing.T) {
 	task := AppCloneTask{App: "new-app", SourceApp: "old-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestAppCloneTaskInvalidState(t *testing.T) {
 
 func TestAppCloneTaskMissingApp(t *testing.T) {
 	task := AppCloneTask{SourceApp: "old-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -26,7 +26,7 @@ func TestAppCloneTaskMissingApp(t *testing.T) {
 
 func TestAppCloneTaskMissingSourceApp(t *testing.T) {
 	task := AppCloneTask{App: "new-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without source_app should return an error")
 	}

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // AppJsonPropertyTask manages the app.json configuration for a given dokku application
 type AppJsonPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t AppJsonPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the app.json property
-func (t AppJsonPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t AppJsonPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // appJsonPropertyTable maps app-json property names to the JSON keys emitted
@@ -87,20 +89,20 @@ func (t AppJsonPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the AppJsonPropertyTask would produce.
-func (t AppJsonPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t AppJsonPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t AppJsonPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t AppJsonPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return AppJsonPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t AppJsonPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t AppJsonPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return AppJsonPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/app_json_property_task_integration_test.go
+++ b/tasks/app_json_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationAppJsonPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-app-json-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationAppJsonPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := AppJsonPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "app-json global " + tc.property,
 					setTask:   AppJsonPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/app_json_property_task_test.go
+++ b/tasks/app_json_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAppJsonPropertyTaskInvalidState(t *testing.T) {
 	task := AppJsonPropertyTask{App: "test-app", Property: "appjson-path", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestAppJsonPropertyTaskInvalidState(t *testing.T) {
 
 func TestAppJsonPropertyTaskMissingApp(t *testing.T) {
 	task := AppJsonPropertyTask{Property: "appjson-path", Value: "app.json", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestAppJsonPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "app.json",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestAppJsonPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestAppJsonPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "app.json",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -64,18 +65,18 @@ func (t AppLockTask) Examples() ([]Doc, error) {
 }
 
 // Execute locks or unlocks the app
-func (t AppLockTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t AppLockTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the AppLockTask would produce.
-func (t AppLockTask) Plan() PlanResult {
+func (t AppLockTask) Plan(ctx context.Context) PlanResult {
 	if t.App == "" {
 		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			locked, err := appLocked(t.App)
+			locked, err := appLocked(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -91,14 +92,14 @@ func (t AppLockTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "app unlocked",
 				Mutations: []string{"lock " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			locked, err := appLocked(t.App)
+			locked, err := appLocked(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -114,9 +115,9 @@ func (t AppLockTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "app locked",
 				Mutations: []string{"unlock " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -125,8 +126,8 @@ func (t AppLockTask) Plan() PlanResult {
 
 // ExportApp emits a dokku_app_lock task only when the app is locked (apps are
 // unlocked by default).
-func (t AppLockTask) ExportApp(app string) ([]interface{}, error) {
-	locked, err := appLocked(app)
+func (t AppLockTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	locked, err := appLocked(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +141,8 @@ func (t AppLockTask) ExportApp(app string) ([]interface{}, error) {
 // the probe could not run - a transport failure, a missing dokku binary,
 // or a cancellation; (false, nil) when dokku reports unlocked; (true,
 // nil) when locked.
-func appLocked(app string) (bool, error) {
-	return subprocess.Probe(subprocess.ExecCommandInput{
+func appLocked(ctx context.Context, app string) (bool, error) {
+	return subprocess.Probe(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "apps:locked", app},
 	})

--- a/tasks/app_lock_task_integration_test.go
+++ b/tasks/app_lock_task_integration_test.go
@@ -9,18 +9,18 @@ func TestIntegrationAppLock(t *testing.T) {
 
 	appName := "docket-test-app-lock"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// initial state - not locked
-	if locked, _ := appLocked(appName); locked {
+	if locked, _ := appLocked(testCtx(), appName); locked {
 		t.Fatalf("expected newly-created app %q to be unlocked", appName)
 	}
 
 	// lock the app
 	lockTask := AppLockTask{App: appName, State: StatePresent}
-	result := lockTask.Execute()
+	result := lockTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to lock app: %v", result.Error)
 	}
@@ -30,25 +30,25 @@ func TestIntegrationAppLock(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	if locked, _ := appLocked(appName); !locked {
+	if locked, _ := appLocked(testCtx(), appName); !locked {
 		t.Errorf("expected app %q to be locked after lock task", appName)
 	}
 
 	// lock again - should be idempotent
-	result = lockTask.Execute()
+	result = lockTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second lock: %v", result.Error)
 	}
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent lock")
 	}
-	if locked, _ := appLocked(appName); !locked {
+	if locked, _ := appLocked(testCtx(), appName); !locked {
 		t.Errorf("expected app %q to remain locked", appName)
 	}
 
 	// unlock the app
 	unlockTask := AppLockTask{App: appName, State: StateAbsent}
-	result = unlockTask.Execute()
+	result = unlockTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unlock app: %v", result.Error)
 	}
@@ -58,19 +58,19 @@ func TestIntegrationAppLock(t *testing.T) {
 	if result.State != StateAbsent {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
-	if locked, _ := appLocked(appName); locked {
+	if locked, _ := appLocked(testCtx(), appName); locked {
 		t.Errorf("expected app %q to be unlocked after unlock task", appName)
 	}
 
 	// unlock again - should be idempotent
-	result = unlockTask.Execute()
+	result = unlockTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second unlock: %v", result.Error)
 	}
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent unlock")
 	}
-	if locked, _ := appLocked(appName); locked {
+	if locked, _ := appLocked(testCtx(), appName); locked {
 		t.Errorf("expected app %q to remain unlocked", appName)
 	}
 }

--- a/tasks/app_lock_task_test.go
+++ b/tasks/app_lock_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAppLockTaskInvalidState(t *testing.T) {
 	task := AppLockTask{App: "test-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestAppLockTaskInvalidState(t *testing.T) {
 
 func TestAppLockTaskPresentMissingApp(t *testing.T) {
 	task := AppLockTask{State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -26,7 +26,7 @@ func TestAppLockTaskPresentMissingApp(t *testing.T) {
 
 func TestAppLockTaskAbsentMissingApp(t *testing.T) {
 	task := AppLockTask{State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}

--- a/tasks/app_report.go
+++ b/tasks/app_report.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/dokku/docket/subprocess"
 )
@@ -12,8 +13,8 @@ type AppDeploySource struct {
 }
 
 // getAppDeploySource retrieves the deploy source for an app via apps:report
-func getAppDeploySource(app string) (AppDeploySource, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getAppDeploySource(ctx context.Context, app string) (AppDeploySource, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"apps:report", app, "--format", "json"},
 	})

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"context"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -62,15 +64,15 @@ func (t AppTask) Examples() ([]Doc, error) {
 }
 
 // Execute creates or destroys an app
-func (t AppTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t AppTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the AppTask would produce.
-func (t AppTask) Plan() PlanResult {
+func (t AppTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := appExists(t.App)
+			exists, err := appExists(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -83,14 +85,14 @@ func (t AppTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "app missing",
 				Mutations: []string{"create app " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := appExists(t.App)
+			exists, err := appExists(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -103,9 +105,9 @@ func (t AppTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "app present",
 				Mutations: []string{"destroy app " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -114,7 +116,7 @@ func (t AppTask) Plan() PlanResult {
 
 // ExportApp reconstructs the app itself. Enumeration already confirmed the app
 // exists, so this simply declares it present (its default state).
-func (t AppTask) ExportApp(app string) ([]interface{}, error) {
+func (t AppTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
 	return []interface{}{AppTask{App: app}}, nil
 }
 
@@ -123,8 +125,8 @@ func (t AppTask) ExportApp(app string) ([]interface{}, error) {
 // (false, err) when the probe could not run - a transport failure, a
 // missing dokku binary, or a cancellation. Plan() callers must
 // short-circuit on the error.
-func appExists(appName string) (bool, error) {
-	return subprocess.Probe(subprocess.ExecCommandInput{
+func appExists(ctx context.Context, appName string) (bool, error) {
+	return subprocess.Probe(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "apps:exists", appName},
 	})
@@ -146,22 +148,22 @@ func destroyAppInputs(app string) []subprocess.ExecCommandInput {
 
 // destroyApp is retained as an integration-test helper. It runs the
 // destroy-app apply path synchronously.
-func destroyApp(app string) TaskOutputState {
-	exists, _ := appExists(app)
+func destroyApp(ctx context.Context, app string) TaskOutputState {
+	exists, _ := appExists(ctx, app)
 	if !exists {
 		return TaskOutputState{Changed: false, State: StateAbsent}
 	}
-	return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, destroyAppInputs(app))
+	return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, destroyAppInputs(app))
 }
 
 // createApp is retained as an integration-test helper. It runs the
 // create-app apply path synchronously.
-func createApp(app string) TaskOutputState {
-	exists, _ := appExists(app)
+func createApp(ctx context.Context, app string) TaskOutputState {
+	exists, _ := appExists(ctx, app)
 	if exists {
 		return TaskOutputState{Changed: false, State: StatePresent}
 	}
-	return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, createAppInputs(app))
+	return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, createAppInputs(app))
 }
 
 // init registers the AppTask with the task registry

--- a/tasks/app_task_integration_test.go
+++ b/tasks/app_task_integration_test.go
@@ -10,11 +10,11 @@ func TestIntegrationAppCreateAndDestroy(t *testing.T) {
 	appName := "docket-test-app"
 
 	// ensure clean state
-	destroyApp(appName)
+	destroyApp(testCtx(), appName)
 
 	// create the app
 	task := AppTask{App: appName, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create app: %v", result.Error)
 	}
@@ -26,7 +26,7 @@ func TestIntegrationAppCreateAndDestroy(t *testing.T) {
 	}
 
 	// creating again should be idempotent
-	result = task.Execute()
+	result = task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent create failed: %v", result.Error)
 	}
@@ -39,7 +39,7 @@ func TestIntegrationAppCreateAndDestroy(t *testing.T) {
 
 	// destroy the app
 	destroyTask := AppTask{App: appName, State: StateAbsent}
-	result = destroyTask.Execute()
+	result = destroyTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to destroy app: %v", result.Error)
 	}
@@ -51,7 +51,7 @@ func TestIntegrationAppCreateAndDestroy(t *testing.T) {
 	}
 
 	// destroying again should be idempotent
-	result = destroyTask.Execute()
+	result = destroyTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent destroy failed: %v", result.Error)
 	}

--- a/tasks/app_task_test.go
+++ b/tasks/app_task_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestAppTaskInvalidState(t *testing.T) {
 	task := AppTask{App: "test-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // AppsPropertyTask manages the apps plugin configuration for a given dokku application or globally
 type AppsPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t AppsPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the apps property
-func (t AppsPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t AppsPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // appsPropertyTable maps apps property names to the JSON keys emitted by
@@ -103,20 +105,20 @@ func (t AppsPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the AppsPropertyTask would produce.
-func (t AppsPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t AppsPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t AppsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t AppsPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return AppsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t AppsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t AppsPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return AppsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/apps_property_task_integration_test.go
+++ b/tasks/apps_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationAppsPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-apps-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -35,7 +35,7 @@ func TestIntegrationAppsPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := AppsPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "apps global " + tc.property,
 					setTask:   AppsPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/apps_property_task_test.go
+++ b/tasks/apps_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAppsPropertyTaskInvalidState(t *testing.T) {
 	task := AppsPropertyTask{App: "test-app", Property: "deploy-source", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestAppsPropertyTaskInvalidState(t *testing.T) {
 
 func TestAppsPropertyTaskMissingApp(t *testing.T) {
 	task := AppsPropertyTask{Property: "deploy-source", Value: "git", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestAppsPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "true",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestAppsPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestAppsPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "git",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuilderDockerfilePropertyTask manages the builder-dockerfile configuration for a given dokku application
 type BuilderDockerfilePropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuilderDockerfilePropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the builder-dockerfile property
-func (t BuilderDockerfilePropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuilderDockerfilePropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // builderDockerfilePropertyTable maps builder-dockerfile property names to
@@ -88,20 +90,20 @@ func (t BuilderDockerfilePropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuilderDockerfilePropertyTask would produce.
-func (t BuilderDockerfilePropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuilderDockerfilePropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuilderDockerfilePropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuilderDockerfilePropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuilderDockerfilePropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuilderDockerfilePropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuilderDockerfilePropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuilderDockerfilePropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_dockerfile_property_task_integration_test.go
+++ b/tasks/builder_dockerfile_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuilderDockerfilePropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builder-dockerfile"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuilderDockerfilePropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuilderDockerfilePropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builder-dockerfile global " + tc.property,
 					setTask:   BuilderDockerfilePropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builder_dockerfile_property_task_test.go
+++ b/tasks/builder_dockerfile_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuilderDockerfilePropertyTaskInvalidState(t *testing.T) {
 	task := BuilderDockerfilePropertyTask{App: "test-app", Property: "dockerfile-path", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuilderDockerfilePropertyTaskInvalidState(t *testing.T) {
 
 func TestBuilderDockerfilePropertyTaskMissingApp(t *testing.T) {
 	task := BuilderDockerfilePropertyTask{Property: "dockerfile-path", Value: "Dockerfile", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuilderDockerfilePropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "Dockerfile",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuilderDockerfilePropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuilderDockerfilePropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "Dockerfile",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuilderHerokuishPropertyTask manages the builder-herokuish configuration for a given dokku application
 type BuilderHerokuishPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuilderHerokuishPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the builder-herokuish property
-func (t BuilderHerokuishPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuilderHerokuishPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // builderHerokuishPropertyTable maps builder-herokuish property names to the
@@ -88,20 +90,20 @@ func (t BuilderHerokuishPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuilderHerokuishPropertyTask would produce.
-func (t BuilderHerokuishPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuilderHerokuishPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuilderHerokuishPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuilderHerokuishPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuilderHerokuishPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuilderHerokuishPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuilderHerokuishPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuilderHerokuishPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_herokuish_property_task_integration_test.go
+++ b/tasks/builder_herokuish_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuilderHerokuishPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builder-herokuish"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuilderHerokuishPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuilderHerokuishPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builder-herokuish global " + tc.property,
 					setTask:   BuilderHerokuishPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builder_herokuish_property_task_test.go
+++ b/tasks/builder_herokuish_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuilderHerokuishPropertyTaskInvalidState(t *testing.T) {
 	task := BuilderHerokuishPropertyTask{App: "test-app", Property: "allowed", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuilderHerokuishPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuilderHerokuishPropertyTaskMissingApp(t *testing.T) {
 	task := BuilderHerokuishPropertyTask{Property: "allowed", Value: "true", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuilderHerokuishPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "true",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuilderHerokuishPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuilderHerokuishPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "true",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuilderLambdaPropertyTask manages the builder-lambda configuration for a given dokku application
 type BuilderLambdaPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuilderLambdaPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the builder-lambda property
-func (t BuilderLambdaPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuilderLambdaPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // builderLambdaPropertyTable maps builder-lambda property names to the JSON
@@ -88,20 +90,20 @@ func (t BuilderLambdaPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuilderLambdaPropertyTask would produce.
-func (t BuilderLambdaPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuilderLambdaPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuilderLambdaPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuilderLambdaPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuilderLambdaPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuilderLambdaPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuilderLambdaPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuilderLambdaPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_lambda_property_task_integration_test.go
+++ b/tasks/builder_lambda_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuilderLambdaPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builder-lambda"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuilderLambdaPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuilderLambdaPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builder-lambda global " + tc.property,
 					setTask:   BuilderLambdaPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builder_lambda_property_task_test.go
+++ b/tasks/builder_lambda_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuilderLambdaPropertyTaskInvalidState(t *testing.T) {
 	task := BuilderLambdaPropertyTask{App: "test-app", Property: "lambdayml-path", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuilderLambdaPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuilderLambdaPropertyTaskMissingApp(t *testing.T) {
 	task := BuilderLambdaPropertyTask{Property: "lambdayml-path", Value: "lambda.yml", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuilderLambdaPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "lambda.yml",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuilderLambdaPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuilderLambdaPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "lambda.yml",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuilderNixpacksPropertyTask manages the builder-nixpacks configuration for a given dokku application
 type BuilderNixpacksPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuilderNixpacksPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the builder-nixpacks property
-func (t BuilderNixpacksPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuilderNixpacksPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // builderNixpacksPropertyTable maps builder-nixpacks property names to the
@@ -88,20 +90,20 @@ func (t BuilderNixpacksPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuilderNixpacksPropertyTask would produce.
-func (t BuilderNixpacksPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuilderNixpacksPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuilderNixpacksPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuilderNixpacksPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuilderNixpacksPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuilderNixpacksPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuilderNixpacksPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuilderNixpacksPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_nixpacks_property_task_integration_test.go
+++ b/tasks/builder_nixpacks_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuilderNixpacksPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builder-nixpacks"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuilderNixpacksPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuilderNixpacksPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builder-nixpacks global " + tc.property,
 					setTask:   BuilderNixpacksPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builder_nixpacks_property_task_test.go
+++ b/tasks/builder_nixpacks_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuilderNixpacksPropertyTaskInvalidState(t *testing.T) {
 	task := BuilderNixpacksPropertyTask{App: "test-app", Property: "nixpackstoml-path", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuilderNixpacksPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuilderNixpacksPropertyTaskMissingApp(t *testing.T) {
 	task := BuilderNixpacksPropertyTask{Property: "nixpackstoml-path", Value: "nixpacks.toml", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuilderNixpacksPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "nixpacks.toml",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuilderNixpacksPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuilderNixpacksPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "nixpacks.toml",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuilderPackPropertyTask manages the builder-pack configuration for a given dokku application
 type BuilderPackPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuilderPackPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the builder-pack property
-func (t BuilderPackPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuilderPackPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // builderPackPropertyTable maps builder-pack property names to the JSON keys
@@ -87,20 +89,20 @@ func (t BuilderPackPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuilderPackPropertyTask would produce.
-func (t BuilderPackPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuilderPackPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuilderPackPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuilderPackPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuilderPackPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuilderPackPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuilderPackPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuilderPackPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_pack_property_task_integration_test.go
+++ b/tasks/builder_pack_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuilderPackPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builder-pack"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuilderPackPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuilderPackPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builder-pack global " + tc.property,
 					setTask:   BuilderPackPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builder_pack_property_task_test.go
+++ b/tasks/builder_pack_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuilderPackPropertyTaskInvalidState(t *testing.T) {
 	task := BuilderPackPropertyTask{App: "test-app", Property: "projecttoml-path", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuilderPackPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuilderPackPropertyTaskMissingApp(t *testing.T) {
 	task := BuilderPackPropertyTask{Property: "projecttoml-path", Value: "project.toml", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuilderPackPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "project.toml",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuilderPackPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuilderPackPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "project.toml",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuilderTask manages the builder configuration for a given dokku application
 type BuilderPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t BuilderPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute executes the builder configuration task
-func (t BuilderPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuilderPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // builderPropertyTable maps builder property names to the JSON keys emitted
@@ -97,20 +99,20 @@ func (t BuilderPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuilderPropertyTask would produce.
-func (t BuilderPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuilderPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuilderPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuilderPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuilderPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuilderPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuilderPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuilderPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_property_task_integration_test.go
+++ b/tasks/builder_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuilderPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builder"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -35,7 +35,7 @@ func TestIntegrationBuilderPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuilderPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builder global " + tc.property,
 					setTask:   BuilderPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builder_property_task_test.go
+++ b/tasks/builder_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuilderPropertyTaskInvalidState(t *testing.T) {
 	task := BuilderPropertyTask{App: "test-app", Property: "selected", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuilderPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuilderPropertyTaskMissingApp(t *testing.T) {
 	task := BuilderPropertyTask{Property: "selected", Value: "dockerfile", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuilderPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "dockerfile",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuilderPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuilderPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "dockerfile",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuilderRailpackPropertyTask manages the builder-railpack configuration for a given dokku application
 type BuilderRailpackPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuilderRailpackPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the builder-railpack property
-func (t BuilderRailpackPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuilderRailpackPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // builderRailpackPropertyTable maps builder-railpack property names to the
@@ -88,20 +90,20 @@ func (t BuilderRailpackPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuilderRailpackPropertyTask would produce.
-func (t BuilderRailpackPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuilderRailpackPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuilderRailpackPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuilderRailpackPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuilderRailpackPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuilderRailpackPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuilderRailpackPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuilderRailpackPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builder_railpack_property_task_integration_test.go
+++ b/tasks/builder_railpack_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuilderRailpackPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builder-railpack"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuilderRailpackPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuilderRailpackPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builder-railpack global " + tc.property,
 					setTask:   BuilderRailpackPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builder_railpack_property_task_test.go
+++ b/tasks/builder_railpack_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuilderRailpackPropertyTaskInvalidState(t *testing.T) {
 	task := BuilderRailpackPropertyTask{App: "test-app", Property: "railpackjson-path", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuilderRailpackPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuilderRailpackPropertyTaskMissingApp(t *testing.T) {
 	task := BuilderRailpackPropertyTask{Property: "railpackjson-path", Value: "railpack.json", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuilderRailpackPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "railpack.json",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuilderRailpackPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuilderRailpackPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "railpack.json",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuildpacksPropertyTask manages the buildpacks configuration for a given dokku application
 type BuildpacksPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuildpacksPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the buildpacks property
-func (t BuildpacksPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuildpacksPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // buildpacksPropertyTable maps buildpacks property names to the JSON keys
@@ -89,20 +91,20 @@ func (t BuildpacksPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuildpacksPropertyTask would produce.
-func (t BuildpacksPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuildpacksPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuildpacksPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuildpacksPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuildpacksPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuildpacksPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuildpacksPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuildpacksPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/buildpacks_property_task_integration_test.go
+++ b/tasks/buildpacks_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuildpacksPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-buildpacks-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuildpacksPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuildpacksPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "buildpacks global " + tc.property,
 					setTask:   BuildpacksPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/buildpacks_property_task_test.go
+++ b/tasks/buildpacks_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuildpacksPropertyTaskInvalidState(t *testing.T) {
 	task := BuildpacksPropertyTask{App: "test-app", Property: "stack", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuildpacksPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuildpacksPropertyTaskMissingApp(t *testing.T) {
 	task := BuildpacksPropertyTask{Property: "stack", Value: "gliderlabs/herokuish:latest", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuildpacksPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "gliderlabs/herokuish:latest",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuildpacksPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuildpacksPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "gliderlabs/herokuish:latest",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,8 +86,8 @@ func (t BuildpacksTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the buildpacks for a given app
-func (t BuildpacksTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuildpacksTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the BuildpacksTask's inputs without contacting the server.
@@ -101,18 +102,18 @@ func (t BuildpacksTask) Validate() error {
 }
 
 // Plan reports the drift the BuildpacksTask would produce.
-func (t BuildpacksTask) Plan() PlanResult {
+func (t BuildpacksTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planBuildpacksAdd(t) },
-		StateAbsent:  func() PlanResult { return planBuildpacksRemove(t) },
+		StatePresent: func() PlanResult { return planBuildpacksAdd(ctx, t) },
+		StateAbsent:  func() PlanResult { return planBuildpacksRemove(ctx, t) },
 	})
 }
 
-func planBuildpacksAdd(t BuildpacksTask) PlanResult {
-	current, err := getOrderedBuildpacks(t.App)
+func planBuildpacksAdd(ctx context.Context, t BuildpacksTask) PlanResult {
+	current, err := getOrderedBuildpacks(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -140,15 +141,15 @@ func planBuildpacksAdd(t BuildpacksTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("set %d buildpack(s) in order", len(t.Buildpacks)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
 
-func planBuildpacksRemove(t BuildpacksTask) PlanResult {
-	current, err := getBuildpacks(t.App)
+func planBuildpacksRemove(ctx context.Context, t BuildpacksTask) PlanResult {
+	current, err := getBuildpacks(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -169,9 +170,9 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 			Status:    PlanStatusDestroy,
 			Reason:    fmt.Sprintf("clear %d buildpack(s)", len(current)),
 			Mutations: mutations,
-			Commands:  resolveCommands(inputs),
-			apply: func() TaskOutputState {
-				return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+			Commands:  resolveCommands(ctx, inputs),
+			apply: func(ctx context.Context) TaskOutputState {
+				return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 			},
 		}
 	}
@@ -198,17 +199,17 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d buildpack(s) to remove", len(toRemove)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }
 
 // ExportApp reads the app's buildpacks and returns a dokku_buildpacks task, or
 // nil when none are set.
-func (t BuildpacksTask) ExportApp(app string) ([]interface{}, error) {
-	list, err := getOrderedBuildpacks(app)
+func (t BuildpacksTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	list, err := getOrderedBuildpacks(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -225,8 +226,8 @@ func (t BuildpacksTask) ExportApp(app string) ([]interface{}, error) {
 // getOrderedBuildpacks fetches the app's buildpacks in build-precedence order
 // from the `list` key of buildpacks:report. Unlike getBuildpacks (an unordered
 // set) this preserves order, which the plan probe and export both require.
-func getOrderedBuildpacks(app string) ([]string, error) {
-	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getOrderedBuildpacks(ctx context.Context, app string) ([]string, error) {
+	response, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "buildpacks:report", app, "--format", "json"},
 	})
@@ -251,8 +252,8 @@ func getOrderedBuildpacks(app string) ([]string, error) {
 }
 
 // getBuildpacks fetches the current buildpacks list for an app
-func getBuildpacks(app string) (map[string]bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getBuildpacks(ctx context.Context, app string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "buildpacks:list", app},
 	})

--- a/tasks/buildpacks_task_integration_test.go
+++ b/tasks/buildpacks_task_integration_test.go
@@ -10,15 +10,15 @@ func TestIntegrationBuildpacks(t *testing.T) {
 
 	appName := "docket-test-buildpacks"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	bp := "https://github.com/heroku/heroku-buildpack-nodejs.git"
 
 	assertListed := func(t *testing.T, label string, want map[string]bool) {
 		t.Helper()
-		got, err := getBuildpacks(appName)
+		got, err := getBuildpacks(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getBuildpacks failed: %v", label, err)
 		}
@@ -46,7 +46,7 @@ func TestIntegrationBuildpacks(t *testing.T) {
 		Buildpacks: []string{bp},
 		State:      StatePresent,
 	}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add buildpack: %v", result.Error)
 	}
@@ -59,7 +59,7 @@ func TestIntegrationBuildpacks(t *testing.T) {
 	assertListed(t, "after add", map[string]bool{bp: true})
 
 	// add same buildpack again - should be idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -74,7 +74,7 @@ func TestIntegrationBuildpacks(t *testing.T) {
 		Buildpacks: []string{bp},
 		State:      StateAbsent,
 	}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove buildpack: %v", result.Error)
 	}
@@ -87,7 +87,7 @@ func TestIntegrationBuildpacks(t *testing.T) {
 	assertListed(t, "after remove", map[string]bool{})
 
 	// remove same buildpack again - should be idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -97,7 +97,7 @@ func TestIntegrationBuildpacks(t *testing.T) {
 	assertListed(t, "after idempotent remove", map[string]bool{})
 
 	// add buildpack again, then clear
-	if err := addTask.Execute().Error; err != nil {
+	if err := addTask.Execute(testCtx()).Error; err != nil {
 		t.Fatalf("failed to re-add buildpack: %v", err)
 	}
 	assertListed(t, "after re-add", map[string]bool{bp: true})
@@ -106,7 +106,7 @@ func TestIntegrationBuildpacks(t *testing.T) {
 		App:   appName,
 		State: StateAbsent,
 	}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear buildpacks: %v", result.Error)
 	}
@@ -116,7 +116,7 @@ func TestIntegrationBuildpacks(t *testing.T) {
 	assertListed(t, "after clear", map[string]bool{})
 
 	// clear again - should be idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second clear: %v", result.Error)
 	}
@@ -134,16 +134,16 @@ func TestIntegrationBuildpacksOrder(t *testing.T) {
 
 	appName := "docket-test-buildpacks-order"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	nodejs := "https://github.com/heroku/heroku-buildpack-nodejs.git"
 	nginx := "https://github.com/heroku/heroku-buildpack-nginx.git"
 
 	assertOrder := func(label string, want []string) {
 		t.Helper()
-		got, err := getOrderedBuildpacks(appName)
+		got, err := getOrderedBuildpacks(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getOrderedBuildpacks failed: %v", label, err)
 		}
@@ -153,7 +153,7 @@ func TestIntegrationBuildpacksOrder(t *testing.T) {
 	}
 
 	setTask := BuildpacksTask{App: appName, Buildpacks: []string{nodejs, nginx}, State: StatePresent}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set ordered buildpacks: %v", result.Error)
 	}
@@ -162,7 +162,7 @@ func TestIntegrationBuildpacksOrder(t *testing.T) {
 	}
 	assertOrder("after set", []string{nodejs, nginx})
 
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent set failed: %v", result.Error)
 	}
@@ -172,7 +172,7 @@ func TestIntegrationBuildpacksOrder(t *testing.T) {
 	assertOrder("after idempotent set", []string{nodejs, nginx})
 
 	reorderTask := BuildpacksTask{App: appName, Buildpacks: []string{nginx, nodejs}, State: StatePresent}
-	result = reorderTask.Execute()
+	result = reorderTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to reorder buildpacks: %v", result.Error)
 	}
@@ -181,7 +181,7 @@ func TestIntegrationBuildpacksOrder(t *testing.T) {
 	}
 	assertOrder("after reorder", []string{nginx, nodejs})
 
-	result = reorderTask.Execute()
+	result = reorderTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent reorder failed: %v", result.Error)
 	}

--- a/tasks/buildpacks_task_test.go
+++ b/tasks/buildpacks_task_test.go
@@ -34,7 +34,7 @@ func assertBuildpacksReplaceInOrder(t *testing.T, plan PlanResult, want []string
 
 func TestBuildpacksTaskInvalidState(t *testing.T) {
 	task := BuildpacksTask{App: "test-app", Buildpacks: []string{"https://example.com/bp.git"}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -42,7 +42,7 @@ func TestBuildpacksTaskInvalidState(t *testing.T) {
 
 func TestBuildpacksTaskPresentMissingApp(t *testing.T) {
 	task := BuildpacksTask{Buildpacks: []string{"https://example.com/bp.git"}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -53,7 +53,7 @@ func TestBuildpacksTaskPresentMissingApp(t *testing.T) {
 
 func TestBuildpacksTaskAbsentMissingApp(t *testing.T) {
 	task := BuildpacksTask{State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -64,7 +64,7 @@ func TestBuildpacksTaskAbsentMissingApp(t *testing.T) {
 
 func TestBuildpacksTaskPresentEmptyBuildpacks(t *testing.T) {
 	task := BuildpacksTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty buildpacks and state=present should return an error")
 	}
@@ -78,7 +78,7 @@ func TestBuildpacksSameOrderInSync(t *testing.T) {
 		"--quiet buildpacks:report test-app --format json": `{"list":"nodejs,nginx"}`,
 	}))()
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan()
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -92,7 +92,7 @@ func TestBuildpacksReorderReportsDrift(t *testing.T) {
 		"--quiet buildpacks:report test-app --format json": `{"list":"nginx,nodejs"}`,
 	}))()
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan()
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -110,7 +110,7 @@ func TestBuildpacksPartialSetUsesReplaceInOrder(t *testing.T) {
 		"--quiet buildpacks:report test-app --format json": `{"list":"nginx"}`,
 	}))()
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan()
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -126,7 +126,7 @@ func TestBuildpacksCreateWhenEmpty(t *testing.T) {
 		"--quiet buildpacks:report test-app --format json": `{"list":""}`,
 	}))()
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs"}, State: StatePresent}.Plan()
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // BuildsPropertyTask manages the builds configuration for a given dokku application
 type BuildsPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t BuildsPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the builds property
-func (t BuildsPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t BuildsPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // buildsPropertyTable maps builds property names to the JSON keys emitted by
@@ -87,20 +89,20 @@ func (t BuildsPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the BuildsPropertyTask would produce.
-func (t BuildsPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t BuildsPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t BuildsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t BuildsPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return BuildsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t BuildsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t BuildsPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return BuildsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/builds_property_task_integration_test.go
+++ b/tasks/builds_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationBuildsPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-builds"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationBuildsPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := BuildsPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "builds global " + tc.property,
 					setTask:   BuildsPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/builds_property_task_test.go
+++ b/tasks/builds_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBuildsPropertyTaskInvalidState(t *testing.T) {
 	task := BuildsPropertyTask{App: "test-app", Property: "retention", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestBuildsPropertyTaskInvalidState(t *testing.T) {
 
 func TestBuildsPropertyTaskMissingApp(t *testing.T) {
 	task := BuildsPropertyTask{Property: "retention", Value: "50", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestBuildsPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "50",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestBuildsPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestBuildsPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "50",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // CaddyPropertyTask manages the caddy configuration for a given dokku application
 type CaddyPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t CaddyPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the caddy property
-func (t CaddyPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t CaddyPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // caddyPropertyTable maps caddy property names to the JSON keys emitted by
@@ -93,20 +95,20 @@ func (t CaddyPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the CaddyPropertyTask would produce.
-func (t CaddyPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t CaddyPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t CaddyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t CaddyPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return CaddyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t CaddyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t CaddyPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return CaddyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/caddy_property_task_integration_test.go
+++ b/tasks/caddy_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationCaddyPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-caddy"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -38,7 +38,7 @@ func TestIntegrationCaddyPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := CaddyPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "caddy global " + tc.property,
 					setTask:   CaddyPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/caddy_property_task_test.go
+++ b/tasks/caddy_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCaddyPropertyTaskInvalidState(t *testing.T) {
 	task := CaddyPropertyTask{App: "test-app", Property: "tls-internal", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestCaddyPropertyTaskInvalidState(t *testing.T) {
 
 func TestCaddyPropertyTaskMissingApp(t *testing.T) {
 	task := CaddyPropertyTask{Property: "tls-internal", Value: "true", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestCaddyPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "true",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestCaddyPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestCaddyPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "true",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -124,8 +125,8 @@ func (t CertsTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the SSL certificate
-func (t CertsTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t CertsTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the CertsTask's inputs without contacting the server.
@@ -144,14 +145,14 @@ func (t CertsTask) Validate() error {
 }
 
 // Plan reports the drift the CertsTask would produce.
-func (t CertsTask) Plan() PlanResult {
+func (t CertsTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			hasContent := t.CertContent != "" && t.KeyContent != ""
-			enabled, err := certsEnabled(t)
+			enabled, err := certsEnabled(ctx, t)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -187,14 +188,14 @@ func (t CertsTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "certificate not installed",
 				Mutations: []string{fmt.Sprintf("install certificate for %s", target)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			enabled, err := certsEnabled(t)
+			enabled, err := certsEnabled(ctx, t)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -215,9 +216,9 @@ func (t CertsTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "certificate present",
 				Mutations: []string{fmt.Sprintf("remove certificate for %s", target)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -276,7 +277,7 @@ func buildCertTarball(certPEM, keyPEM string) ([]byte, error) {
 }
 
 // certsEnabled checks if a certificate is currently configured for an app or globally
-func certsEnabled(t CertsTask) (bool, error) {
+func certsEnabled(ctx context.Context, t CertsTask) (bool, error) {
 	args := []string{"--quiet", "certs:report", t.App, "--ssl-enabled"}
 	if t.Global {
 		// The `--global` scope is required: dokku-global-cert standardized
@@ -285,7 +286,7 @@ func certsEnabled(t CertsTask) (bool, error) {
 		args = []string{"--quiet", "global-cert:report", "--global", "--global-cert-enabled"}
 	}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    args,
 	})
@@ -298,15 +299,15 @@ func certsEnabled(t CertsTask) (bool, error) {
 
 // ExportApp reconstructs an app's SSL certificate via certs:show. The cert and
 // key PEM are sensitive and lifted into the vars-file by the engine.
-func (t CertsTask) ExportApp(app string) ([]interface{}, error) {
-	return exportCert(CertsTask{App: app})
+func (t CertsTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportCert(ctx, CertsTask{App: app})
 }
 
 // ExportGlobal reconstructs the global SSL certificate via global-cert:show
 // (dokku-global-cert 0.4.x+). The cert and key PEM are sensitive and lifted into
 // the vars-file by the engine.
-func (t CertsTask) ExportGlobal() ([]interface{}, error) {
-	return exportCert(CertsTask{Global: true})
+func (t CertsTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportCert(ctx, CertsTask{Global: true})
 }
 
 // exportCert probes whether a certificate is installed for the given scope (app
@@ -314,8 +315,8 @@ func (t CertsTask) ExportGlobal() ([]interface{}, error) {
 // A transport failure aborts the export; any other probe error (for example the
 // dokku-global-cert plugin not being installed) is swallowed so the scope is
 // skipped silently.
-func exportCert(t CertsTask) ([]interface{}, error) {
-	enabled, err := certsEnabled(t)
+func exportCert(ctx context.Context, t CertsTask) ([]interface{}, error) {
+	enabled, err := certsEnabled(ctx, t)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -334,7 +335,7 @@ func exportCert(t CertsTask) ([]interface{}, error) {
 	// A missing dokku-letsencrypt plugin (a non-SSH probe error) means the cert is
 	// not letsencrypt-managed, so fall through and export it as a manual cert.
 	if !t.Global {
-		active, lerr := letsencryptActive(t.App)
+		active, lerr := letsencryptActive(ctx, t.App)
 		if lerr != nil {
 			var sshErr *subprocess.SSHError
 			if errors.As(lerr, &sshErr) {
@@ -345,11 +346,11 @@ func exportCert(t CertsTask) ([]interface{}, error) {
 		}
 	}
 
-	crt, err := certsShow(t, "crt")
+	crt, err := certsShow(ctx, t, "crt")
 	if err != nil {
 		return nil, err
 	}
-	key, err := certsShow(t, "key")
+	key, err := certsShow(ctx, t, "key")
 	if err != nil {
 		return nil, err
 	}
@@ -362,12 +363,12 @@ func exportCert(t CertsTask) ([]interface{}, error) {
 // certsShow returns the scope's server.crt or server.key PEM. The per-app scope
 // uses core certs:show; the global scope uses global-cert:show (dokku-global-cert
 // 0.4.x+), mirroring the app/global branch in certsEnabled.
-func certsShow(t CertsTask, kind string) (string, error) {
+func certsShow(ctx context.Context, t CertsTask, kind string) (string, error) {
 	args := []string{"--quiet", "certs:show", t.App, kind}
 	if t.Global {
 		args = []string{"--quiet", "global-cert:show", kind}
 	}
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    args,
 	})

--- a/tasks/certs_task_integration_test.go
+++ b/tasks/certs_task_integration_test.go
@@ -78,12 +78,12 @@ func TestIntegrationCertsApp(t *testing.T) {
 	appName := "docket-test-certs"
 	certPath, keyPath := generateSelfSignedCert(t, appName+".example.com")
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// initial state - no cert
-	enabled, err := certsEnabled(CertsTask{App: appName})
+	enabled, err := certsEnabled(testCtx(), CertsTask{App: appName})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestIntegrationCertsApp(t *testing.T) {
 
 	// add cert
 	addTask := CertsTask{App: appName, Cert: certPath, Key: keyPath, State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add cert: %v", result.Error)
 	}
@@ -103,7 +103,7 @@ func TestIntegrationCertsApp(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	enabled, err = certsEnabled(CertsTask{App: appName})
+	enabled, err = certsEnabled(testCtx(), CertsTask{App: appName})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestIntegrationCertsApp(t *testing.T) {
 	}
 
 	// add again - should be idempotent (does not update; matches ansible-dokku semantics)
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -122,7 +122,7 @@ func TestIntegrationCertsApp(t *testing.T) {
 
 	// remove cert
 	removeTask := CertsTask{App: appName, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove cert: %v", result.Error)
 	}
@@ -132,7 +132,7 @@ func TestIntegrationCertsApp(t *testing.T) {
 	if result.State != StateAbsent {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
-	enabled, err = certsEnabled(CertsTask{App: appName})
+	enabled, err = certsEnabled(testCtx(), CertsTask{App: appName})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestIntegrationCertsApp(t *testing.T) {
 	}
 
 	// remove again - idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -164,11 +164,11 @@ func TestIntegrationCertsAppInline(t *testing.T) {
 		t.Fatalf("read key: %v", err)
 	}
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
-	enabled, err := certsEnabled(CertsTask{App: appName})
+	enabled, err := certsEnabled(testCtx(), CertsTask{App: appName})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestIntegrationCertsAppInline(t *testing.T) {
 	}
 
 	addTask := CertsTask{App: appName, CertContent: string(certPEM), KeyContent: string(keyPEM), State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add cert inline: %v", result.Error)
 	}
@@ -187,7 +187,7 @@ func TestIntegrationCertsAppInline(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	enabled, err = certsEnabled(CertsTask{App: appName})
+	enabled, err = certsEnabled(testCtx(), CertsTask{App: appName})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestIntegrationCertsAppInline(t *testing.T) {
 		t.Errorf("expected cert to be enabled after inline add")
 	}
 
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second inline add: %v", result.Error)
 	}
@@ -204,7 +204,7 @@ func TestIntegrationCertsAppInline(t *testing.T) {
 	}
 
 	removeTask := CertsTask{App: appName, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove inline cert: %v", result.Error)
 	}
@@ -228,20 +228,20 @@ func TestIntegrationCertsGlobalInline(t *testing.T) {
 	}
 
 	cleanup := func() {
-		(CertsTask{Global: true, State: StateAbsent}).Execute()
+		(CertsTask{Global: true, State: StateAbsent}).Execute(testCtx())
 	}
 	cleanup()
 	defer cleanup()
 
 	addTask := CertsTask{Global: true, CertContent: string(certPEM), KeyContent: string(keyPEM), State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add global cert inline: %v", result.Error)
 	}
 	if !result.Changed {
 		t.Errorf("expected Changed=true on first global inline add")
 	}
-	enabled, err := certsEnabled(CertsTask{Global: true})
+	enabled, err := certsEnabled(testCtx(), CertsTask{Global: true})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestIntegrationCertsGlobalInline(t *testing.T) {
 		t.Errorf("expected global cert to be enabled after inline add")
 	}
 
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second global inline add: %v", result.Error)
 	}
@@ -266,14 +266,14 @@ func TestIntegrationCertsGlobal(t *testing.T) {
 
 	// best-effort cleanup before and after
 	cleanup := func() {
-		(CertsTask{Global: true, State: StateAbsent}).Execute()
+		(CertsTask{Global: true, State: StateAbsent}).Execute(testCtx())
 	}
 	cleanup()
 	defer cleanup()
 
 	// add global cert
 	addTask := CertsTask{Global: true, Cert: certPath, Key: keyPath, State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add global cert: %v", result.Error)
 	}
@@ -283,7 +283,7 @@ func TestIntegrationCertsGlobal(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	enabled, err := certsEnabled(CertsTask{Global: true})
+	enabled, err := certsEnabled(testCtx(), CertsTask{Global: true})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestIntegrationCertsGlobal(t *testing.T) {
 	}
 
 	// add again - idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second global add: %v", result.Error)
 	}
@@ -302,14 +302,14 @@ func TestIntegrationCertsGlobal(t *testing.T) {
 
 	// remove global cert
 	removeTask := CertsTask{Global: true, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove global cert: %v", result.Error)
 	}
 	if !result.Changed {
 		t.Errorf("expected Changed=true on first global remove")
 	}
-	enabled, err = certsEnabled(CertsTask{Global: true})
+	enabled, err = certsEnabled(testCtx(), CertsTask{Global: true})
 	if err != nil {
 		t.Fatalf("certsEnabled failed: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestIntegrationCertsGlobal(t *testing.T) {
 	}
 
 	// remove again - idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second global remove: %v", result.Error)
 	}

--- a/tasks/certs_task_test.go
+++ b/tasks/certs_task_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCertsTaskInvalidState(t *testing.T) {
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", Key: "/tmp/key", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -21,7 +21,7 @@ func TestCertsTaskInvalidState(t *testing.T) {
 
 func TestCertsTaskMissingApp(t *testing.T) {
 	task := CertsTask{Cert: "/tmp/cert", Key: "/tmp/key", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -32,7 +32,7 @@ func TestCertsTaskMissingApp(t *testing.T) {
 
 func TestCertsTaskGlobalWithApp(t *testing.T) {
 	task := CertsTask{App: "test-app", Global: true, Cert: "/tmp/cert", Key: "/tmp/key", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -43,7 +43,7 @@ func TestCertsTaskGlobalWithApp(t *testing.T) {
 
 func TestCertsTaskPresentMissingCert(t *testing.T) {
 	task := CertsTask{App: "test-app", Key: "/tmp/key", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without cert should return an error")
 	}
@@ -54,7 +54,7 @@ func TestCertsTaskPresentMissingCert(t *testing.T) {
 
 func TestCertsTaskPresentMissingKey(t *testing.T) {
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without key should return an error")
 	}
@@ -65,7 +65,7 @@ func TestCertsTaskPresentMissingKey(t *testing.T) {
 
 func TestCertsTaskInlineMissingKeyContent(t *testing.T) {
 	task := CertsTask{App: "test-app", CertContent: "cert-pem", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with cert_content but no key should return an error")
 	}
@@ -76,7 +76,7 @@ func TestCertsTaskInlineMissingKeyContent(t *testing.T) {
 
 func TestCertsTaskInlineMixedSources(t *testing.T) {
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", KeyContent: "key-pem", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with cert + key_content should return a validation error")
 	}
@@ -87,7 +87,7 @@ func TestCertsTaskInlineMixedSources(t *testing.T) {
 
 func TestCertsTaskInlineBothCertForms(t *testing.T) {
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", CertContent: "cert-pem", Key: "/tmp/key", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with both cert and cert_content should return a validation error")
 	}
@@ -234,7 +234,7 @@ func TestCertsEnabledGlobalUsesGlobalScope(t *testing.T) {
 		return subprocess.ExecCommandResponse{Stdout: "true"}, nil
 	})()
 
-	enabled, err := certsEnabled(CertsTask{Global: true})
+	enabled, err := certsEnabled(testCtx(), CertsTask{Global: true})
 	if err != nil {
 		t.Fatalf("certsEnabled: %v", err)
 	}

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // ChecksPropertyTask manages the checks configuration for a given dokku application
 type ChecksPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t ChecksPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the checks property
-func (t ChecksPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ChecksPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // checksPropertyTable maps checks property names to the JSON keys emitted by
@@ -87,20 +89,20 @@ func (t ChecksPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the ChecksPropertyTask would produce.
-func (t ChecksPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t ChecksPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t ChecksPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t ChecksPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return ChecksPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t ChecksPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t ChecksPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return ChecksPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/checks_property_task_integration_test.go
+++ b/tasks/checks_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationChecksPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-checks-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -33,7 +33,7 @@ func TestIntegrationChecksPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := ChecksPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "checks global " + tc.property,
 					setTask:   ChecksPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/checks_property_task_test.go
+++ b/tasks/checks_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestChecksPropertyTaskInvalidState(t *testing.T) {
 	task := ChecksPropertyTask{App: "test-app", Property: "wait-to-retire", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestChecksPropertyTaskInvalidState(t *testing.T) {
 
 func TestChecksPropertyTaskMissingApp(t *testing.T) {
 	task := ChecksPropertyTask{Property: "wait-to-retire", Value: "60", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestChecksPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "60",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestChecksPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestChecksPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "60",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 
@@ -13,10 +14,10 @@ import (
 // "none" means every process has checks enabled. The JSON report is used
 // because dokku 0.38.21 renamed the flag-based `--checks-disabled` probe to
 // `--checks-disabled-list`; the report key is stable across those versions.
-func checksEnabled(ctx ToggleContext) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func checksEnabled(ctx context.Context, tc ToggleContext) (bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    []string{"checks:report", ctx.App, "--format", "json"},
+		Args:    []string{"checks:report", tc.App, "--format", "json"},
 	})
 	if err != nil {
 		return false, err
@@ -32,8 +33,8 @@ func checksEnabled(ctx ToggleContext) (bool, error) {
 
 // ExportApp emits a dokku_checks_toggle task only when checks are disabled
 // (they are enabled by default).
-func (t ChecksToggleTask) ExportApp(app string) ([]interface{}, error) {
-	enabled, err := checksEnabled(ToggleContext{App: app})
+func (t ChecksToggleTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	enabled, err := checksEnabled(ctx, ToggleContext{App: app})
 	if err != nil {
 		return nil, err
 	}
@@ -96,13 +97,13 @@ func (t ChecksToggleTask) Examples() ([]Doc, error) {
 }
 
 // Execute enables or disables the checks plugin
-func (t ChecksToggleTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ChecksToggleTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the ChecksToggleTask would produce.
-func (t ChecksToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, "checks:enable", "checks:disable", checksEnabled)
+func (t ChecksToggleTask) Plan(ctx context.Context) PlanResult {
+	return planToggle(ctx, t.State, t.App, "checks:enable", "checks:disable", checksEnabled)
 }
 
 // init registers the ChecksToggleTask with the task registry

--- a/tasks/checks_toggle_task_integration_test.go
+++ b/tasks/checks_toggle_task_integration_test.go
@@ -9,13 +9,13 @@ func TestIntegrationChecksToggle(t *testing.T) {
 
 	appName := "docket-test-checks"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// enable checks
 	enableTask := ChecksToggleTask{App: appName, State: StatePresent}
-	result := enableTask.Execute()
+	result := enableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to enable checks: %v", result.Error)
 	}
@@ -25,7 +25,7 @@ func TestIntegrationChecksToggle(t *testing.T) {
 
 	// disable checks
 	disableTask := ChecksToggleTask{App: appName, State: StateAbsent}
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to disable checks: %v", result.Error)
 	}

--- a/tasks/checks_toggle_task_test.go
+++ b/tasks/checks_toggle_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestChecksToggleTaskInvalidState(t *testing.T) {
 	task := ChecksToggleTask{App: "test-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -27,7 +27,7 @@ func TestChecksToggleTaskPlanSurfacesSSHError(t *testing.T) {
 		}
 	})()
 
-	plan := ChecksToggleTask{App: "web", State: StatePresent}.Plan()
+	plan := ChecksToggleTask{App: "web", State: StatePresent}.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -84,8 +85,8 @@ func (t ConfigTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the configuration for a given dokku application
-func (t ConfigTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ConfigTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // SensitiveValues returns every non-empty value in the Config map together
@@ -106,10 +107,10 @@ func (t ConfigTask) SensitiveValues() []string {
 }
 
 // Plan reports the drift the ConfigTask would produce.
-func (t ConfigTask) Plan() PlanResult {
+func (t ConfigTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planConfigSet(t) },
-		StateAbsent:  func() PlanResult { return planConfigUnset(t) },
+		StatePresent: func() PlanResult { return planConfigSet(ctx, t) },
+		StateAbsent:  func() PlanResult { return planConfigUnset(ctx, t) },
 	})
 }
 
@@ -141,8 +142,8 @@ func configKeysToUnset(current, desired map[string]string) []string {
 
 // planConfigSet probes current config once, computes the diff, and embeds
 // an apply closure that runs `dokku config:set` with only the changed keys.
-func planConfigSet(t ConfigTask) PlanResult {
-	currentConfig, err := getConfig(t)
+func planConfigSet(ctx context.Context, t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(ctx, t)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -178,17 +179,17 @@ func planConfigSet(t ConfigTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("%d key(s) to set", len(keys)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
 
 // planConfigUnset probes current config once, computes the diff, and embeds
 // an apply closure that runs `dokku config:unset` with only existing keys.
-func planConfigUnset(t ConfigTask) PlanResult {
-	currentConfig, err := getConfig(t)
+func planConfigUnset(ctx context.Context, t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(ctx, t)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -212,9 +213,9 @@ func planConfigUnset(t ConfigTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d key(s) to unset", len(keys)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }
@@ -229,15 +230,15 @@ func planConfigUnset(t ConfigTask) PlanResult {
 // apply with the new server's credentials, so re-exporting the stale value
 // would clobber the fresh one. The exclusion happens here, before the engine
 // lifts values, so those DSNs never reach the vars-file.
-func (t ConfigTask) ExportApp(app string) ([]interface{}, error) {
-	config, err := getConfig(ConfigTask{App: app})
+func (t ConfigTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	config, err := getConfig(ctx, ConfigTask{App: app})
 	if err != nil {
 		return nil, err
 	}
 	if len(config) == 0 {
 		return nil, nil
 	}
-	dsns, err := linkedServiceDSNs(app)
+	dsns, err := linkedServiceDSNs(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -255,9 +256,9 @@ func (t ConfigTask) ExportApp(app string) ([]interface{}, error) {
 }
 
 // getConfig retrieves the current configuration for a given dokku application
-func getConfig(t ConfigTask) (map[string]string, error) {
+func getConfig(ctx context.Context, t ConfigTask) (map[string]string, error) {
 	var config map[string]string
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",

--- a/tasks/config_task_integration_test.go
+++ b/tasks/config_task_integration_test.go
@@ -10,9 +10,9 @@ func TestIntegrationConfigSetAndUnset(t *testing.T) {
 	appName := "docket-test-config"
 
 	// ensure clean state
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// set config
 	setTask := ConfigTask{
@@ -21,7 +21,7 @@ func TestIntegrationConfigSetAndUnset(t *testing.T) {
 		Config:  map[string]string{"TEST_KEY": "test_value"},
 		State:   StatePresent,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set config: %v", result.Error)
 	}
@@ -33,7 +33,7 @@ func TestIntegrationConfigSetAndUnset(t *testing.T) {
 	}
 
 	// setting same config again should be idempotent
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent set failed: %v", result.Error)
 	}
@@ -48,7 +48,7 @@ func TestIntegrationConfigSetAndUnset(t *testing.T) {
 		Config:  map[string]string{"TEST_KEY": ""},
 		State:   StateAbsent,
 	}
-	result = unsetTask.Execute()
+	result = unsetTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unset config: %v", result.Error)
 	}
@@ -60,7 +60,7 @@ func TestIntegrationConfigSetAndUnset(t *testing.T) {
 	}
 
 	// unset again should be idempotent
-	result = unsetTask.Execute()
+	result = unsetTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent unset failed: %v", result.Error)
 	}
@@ -74,9 +74,9 @@ func TestIntegrationConfigMultipleKeys(t *testing.T) {
 
 	appName := "docket-test-multiconfig"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// set 3 keys
 	setTask := ConfigTask{
@@ -85,7 +85,7 @@ func TestIntegrationConfigMultipleKeys(t *testing.T) {
 		Config:  map[string]string{"KEY_A": "val_a", "KEY_B": "val_b", "KEY_C": "val_c"},
 		State:   StatePresent,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set config: %v", result.Error)
 	}
@@ -100,7 +100,7 @@ func TestIntegrationConfigMultipleKeys(t *testing.T) {
 		Config:  map[string]string{"KEY_A": "val_a", "KEY_B": "val_b_updated", "KEY_C": "val_c"},
 		State:   StatePresent,
 	}
-	result = updateTask.Execute()
+	result = updateTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to update config: %v", result.Error)
 	}
@@ -109,7 +109,7 @@ func TestIntegrationConfigMultipleKeys(t *testing.T) {
 	}
 
 	// set same values again (idempotent)
-	result = updateTask.Execute()
+	result = updateTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent update failed: %v", result.Error)
 	}
@@ -124,7 +124,7 @@ func TestIntegrationConfigMultipleKeys(t *testing.T) {
 		Config:  map[string]string{"KEY_A": "", "KEY_B": "", "KEY_C": ""},
 		State:   StateAbsent,
 	}
-	result = unsetTask.Execute()
+	result = unsetTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unset config: %v", result.Error)
 	}

--- a/tasks/config_task_test.go
+++ b/tasks/config_task_test.go
@@ -14,7 +14,7 @@ func TestConfigTaskInvalidState(t *testing.T) {
 		Config: map[string]string{"KEY": "VALUE"},
 		State:  "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -106,7 +106,7 @@ func TestConfigTaskRestartFlag(t *testing.T) {
 				Restart: tc.restart,
 				Config:  map[string]string{"KEY": "val"},
 				State:   tc.state,
-			}.Plan()
+			}.Plan(testCtx())
 			if plan.Error != nil {
 				t.Fatalf("unexpected plan error: %v", plan.Error)
 			}
@@ -149,7 +149,7 @@ func TestConfigTaskRestartFalseEndToEnd(t *testing.T) {
 	if task == nil {
 		t.Fatal("task 'set config' not found")
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}

--- a/tasks/context_propagation_test.go
+++ b/tasks/context_propagation_test.go
@@ -1,0 +1,89 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// ctxKey is the sentinel type used to prove which context reached a subprocess
+// call. A distinct unexported type keeps the value from colliding with anything
+// else riding on the context.
+type ctxKey struct{}
+
+// TestExecutePlanPassesItsContextToApply pins the one real design question
+// #424 raises: the apply closure is built during Plan and invoked later by
+// ExecutePlan, so it either captures a context or takes one. It takes one -
+// which means applying a plan uses the caller's current cancellation and
+// target rather than whatever was in scope when the plan was computed.
+func TestExecutePlanPassesItsContextToApply(t *testing.T) {
+	planCtx := context.WithValue(context.Background(), ctxKey{}, "plan")
+	applyCtx := context.WithValue(context.Background(), ctxKey{}, "apply")
+
+	var seen string
+	// buildPlan stands in for a task's Plan(): it runs under planCtx, so a
+	// closure that captured rather than took a context would capture that one.
+	buildPlan := func(planCtx context.Context) PlanResult {
+		return PlanResult{
+			Status:       PlanStatusCreate,
+			DesiredState: StatePresent,
+			Commands:     []string{"dokku apps:create demo"},
+			apply: func(ctx context.Context) TaskOutputState {
+				seen, _ = ctx.Value(ctxKey{}).(string)
+				return TaskOutputState{Changed: true, State: StatePresent}
+			},
+		}
+	}
+
+	state := ExecutePlan(applyCtx, buildPlan(planCtx))
+	if state.Error != nil {
+		t.Fatalf("ExecutePlan returned %v", state.Error)
+	}
+	if seen != "apply" {
+		t.Errorf("apply ran under context %q, want %q", seen, "apply")
+	}
+}
+
+// TestPlanUsesTheContextItWasGiven pins that the context reaches all the way
+// down to the subprocess call a task's probe makes. Before this, every task
+// bottomed out in a context.Background() manufactured inside subprocess, so a
+// caller's cancellation and deadline could not reach a running task at all.
+func TestPlanUsesTheContextItWasGiven(t *testing.T) {
+	var seen string
+	defer subprocess.SetExecRunner(func(ctx context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		seen, _ = ctx.Value(ctxKey{}).(string)
+		return subprocess.ExecCommandResponse{}, nil
+	})()
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "caller")
+	AppTask{App: "demo", State: StatePresent}.Plan(ctx)
+
+	if seen != "caller" {
+		t.Errorf("probe ran under context %q, want %q", seen, "caller")
+	}
+}
+
+// TestPlanReportsCancellationAsAnError pins that a probe cut short by a
+// cancelled context produces a plan error rather than reported drift. Reading
+// "the probe did not answer" as "the resource is missing" would have apply
+// mutate a server whose state was never established.
+func TestPlanReportsCancellationAsAnError(t *testing.T) {
+	defer subprocess.SetExecRunner(func(ctx context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{Cancelled: true}, &subprocess.ExecError{Err: context.Canceled}
+	})()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	plan := AppTask{App: "demo", State: StatePresent}.Plan(ctx)
+	if plan.Error == nil {
+		t.Fatal("expected a cancelled probe to surface as a plan error")
+	}
+	if plan.Status != PlanStatusError {
+		t.Errorf("status = %q, want %q", plan.Status, PlanStatusError)
+	}
+	if plan.InSync {
+		t.Error("a plan that could not probe must not report in sync")
+	}
+}

--- a/tasks/context_test.go
+++ b/tasks/context_test.go
@@ -1,0 +1,14 @@
+package tasks
+
+import "context"
+
+// testCtx is the context unit tests pass to Plan, Execute and the helpers
+// below them. It exists so a test file can call `t.Plan(testCtx())` without
+// importing the context package, which matters because a great many of these
+// files already bind `context` to the sigil input map they build for
+// GetPlays - naming the package there would not compile.
+//
+// Tests that need cancellation or a target build their own context instead.
+func testCtx() context.Context {
+	return context.Background()
+}

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // CronPropertyTask manages the cron configuration for a given dokku application
 type CronPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t CronPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the cron property
-func (t CronPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t CronPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // cronPropertyTable maps cron property names to the JSON keys emitted by
@@ -90,20 +92,20 @@ func (t CronPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the CronPropertyTask would produce.
-func (t CronPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t CronPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t CronPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t CronPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return CronPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t CronPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t CronPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return CronPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/cron_property_task_integration_test.go
+++ b/tasks/cron_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationCronPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-cron"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -35,7 +35,7 @@ func TestIntegrationCronPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := CronPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "cron global " + tc.property,
 					setTask:   CronPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/cron_property_task_test.go
+++ b/tasks/cron_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCronPropertyTaskInvalidState(t *testing.T) {
 	task := CronPropertyTask{App: "test-app", Property: "mailto", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestCronPropertyTaskInvalidState(t *testing.T) {
 
 func TestCronPropertyTaskMissingApp(t *testing.T) {
 	task := CronPropertyTask{Property: "mailto", Value: "ops@example.com", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestCronPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "ops@example.com",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestCronPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestCronPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "true",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -11,10 +12,10 @@ import (
 // dispatch-aware command lines apply would echo on execution. Tasks call
 // it from Plan() to populate PlanResult.Commands so plan output and
 // apply --verbose render byte-identical strings for the same operation.
-func resolveCommands(inputs []subprocess.ExecCommandInput) []string {
+func resolveCommands(ctx context.Context, inputs []subprocess.ExecCommandInput) []string {
 	out := make([]string, len(inputs))
 	for i, in := range inputs {
-		out[i] = subprocess.ResolveCommandString(in)
+		out[i] = subprocess.ResolveCommandString(ctx, in)
 	}
 	return out
 }
@@ -27,11 +28,11 @@ func resolveCommands(inputs []subprocess.ExecCommandInput) []string {
 // WithExecResult so callers can inspect what the underlying subprocess
 // produced. When inputs is empty (no-op apply), the new fields stay
 // zero-valued.
-func runExecInputs(initial TaskOutputState, finalState State, inputs []subprocess.ExecCommandInput) TaskOutputState {
+func runExecInputs(ctx context.Context, initial TaskOutputState, finalState State, inputs []subprocess.ExecCommandInput) TaskOutputState {
 	state := initial
 	var last subprocess.ExecCommandResponse
 	for _, in := range inputs {
-		result, err := subprocess.CallExecCommand(in)
+		result, err := subprocess.CallExecCommand(ctx, in)
 		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
@@ -78,7 +79,7 @@ func DispatchPlan(state State, funcMap map[State]func() PlanResult) PlanResult {
 
 // ExecutePlan applies a PlanResult to the server. It is the canonical
 // implementation of Task.Execute(): each task's Execute body is
-// `return ExecutePlan(t.Plan())`. ExecutePlan ensures the existing
+// `return ExecutePlan(ctx, t.Plan(ctx))`. ExecutePlan ensures the existing
 // `state.State == state.DesiredState` contract that commands/apply.go
 // relies on.
 //
@@ -91,7 +92,11 @@ func DispatchPlan(state State, funcMap map[State]func() PlanResult) PlanResult {
 //  3. otherwise       - invoke p.apply (must be non-nil) and return its
 //     TaskOutputState verbatim. apply is responsible for setting Changed
 //     and a final State that matches DesiredState on success.
-func ExecutePlan(p PlanResult) (out TaskOutputState) {
+//
+// ctx is handed to the apply closure rather than the closure capturing the
+// context Plan ran under, so applying a plan always uses the caller's current
+// cancellation and target.
+func ExecutePlan(ctx context.Context, p PlanResult) (out TaskOutputState) {
 	// Probe diagnostics raised during planning ride out on every returned
 	// state so the apply run loop can drain them through the emitter, even on
 	// the error / in-sync branches that never invoke the apply closure.
@@ -136,7 +141,7 @@ func ExecutePlan(p PlanResult) (out TaskOutputState) {
 			State:        p.DesiredState,
 		}
 	}
-	out = p.apply()
+	out = p.apply(ctx)
 	if out.DesiredState == "" {
 		out.DesiredState = p.DesiredState
 	}

--- a/tasks/dispatch_integration_test.go
+++ b/tasks/dispatch_integration_test.go
@@ -14,7 +14,7 @@ import (
 func TestIntegrationRunExecInputsPopulatesExitCodeAndStdout(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	state := runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, []subprocess.ExecCommandInput{{
+	state := runExecInputs(testCtx(), TaskOutputState{State: StateAbsent}, StatePresent, []subprocess.ExecCommandInput{{
 		Command: "dokku",
 		Args:    []string{"version"},
 	}})
@@ -46,7 +46,7 @@ func TestIntegrationRunExecInputsPopulatesExitCodeAndStdout(t *testing.T) {
 func TestIntegrationRunExecInputsCapturesFailureOutput(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	state := runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, []subprocess.ExecCommandInput{{
+	state := runExecInputs(testCtx(), TaskOutputState{State: StateAbsent}, StatePresent, []subprocess.ExecCommandInput{{
 		Command: "dokku",
 		Args:    []string{"--quiet", "apps:create", ""},
 	}})

--- a/tasks/dispatch_test.go
+++ b/tasks/dispatch_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -62,7 +63,7 @@ func TestExecutePlanProbeErrorPopulatesStderrFromExecError(t *testing.T) {
 		},
 		Err: errors.New("App nonexistent does not exist"),
 	}
-	got := ExecutePlan(PlanResult{
+	got := ExecutePlan(testCtx(), PlanResult{
 		Status:       PlanStatusError,
 		Error:        execErr,
 		DesiredState: StatePresent,
@@ -92,7 +93,7 @@ func TestExecutePlanExplicitProbeFieldsTakePrecedence(t *testing.T) {
 		},
 		Err: errors.New("boom"),
 	}
-	got := ExecutePlan(PlanResult{
+	got := ExecutePlan(testCtx(), PlanResult{
 		Status:       PlanStatusError,
 		Error:        execErr,
 		DesiredState: StatePresent,
@@ -120,14 +121,14 @@ func TestExecutePlanCopiesWarnings(t *testing.T) {
 		}
 	}
 
-	assertWarned("error branch", ExecutePlan(PlanResult{
+	assertWarned("error branch", ExecutePlan(testCtx(), PlanResult{
 		Status:       PlanStatusError,
 		Error:        errors.New("boom"),
 		DesiredState: StatePresent,
 		Warnings:     []PlanWarning{warn},
 	}))
 
-	assertWarned("in-sync branch", ExecutePlan(PlanResult{
+	assertWarned("in-sync branch", ExecutePlan(testCtx(), PlanResult{
 		InSync:       true,
 		DesiredState: StatePresent,
 		Warnings:     []PlanWarning{warn},
@@ -135,11 +136,11 @@ func TestExecutePlanCopiesWarnings(t *testing.T) {
 
 	// The apply closure returns a state with no warnings of its own; ExecutePlan
 	// appends the plan's warnings so the apply path still surfaces them.
-	assertWarned("apply branch", ExecutePlan(PlanResult{
+	assertWarned("apply branch", ExecutePlan(testCtx(), PlanResult{
 		Status:       PlanStatusModify,
 		DesiredState: StatePresent,
 		Warnings:     []PlanWarning{warn},
-		apply: func() TaskOutputState {
+		apply: func(ctx context.Context) TaskOutputState {
 			return TaskOutputState{Changed: true, State: StatePresent}
 		},
 	}))

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -70,8 +71,8 @@ func (t DockerOptionsTask) ProbeSupport() ProbeSupport {
 // `<phase>-list` report keys (dokku/dokku#8799), so each stored option -
 // including values that contain spaces - is emitted as a discrete task without
 // whitespace splitting.
-func (t DockerOptionsTask) ExportApp(app string) ([]interface{}, error) {
-	scoped, err := getDockerOptions(app)
+func (t DockerOptionsTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	scoped, err := getDockerOptions(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -138,8 +139,8 @@ func (t DockerOptionsTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the docker option
-func (t DockerOptionsTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t DockerOptionsTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the DockerOptionsTask's inputs without contacting the server.
@@ -151,13 +152,13 @@ func (t DockerOptionsTask) Validate() error {
 }
 
 // Plan reports the drift the DockerOptionsTask would produce.
-func (t DockerOptionsTask) Plan() PlanResult {
+func (t DockerOptionsTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			current, err := getDockerOptions(t.App)
+			current, err := getDockerOptions(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -174,14 +175,14 @@ func (t DockerOptionsTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("missing on %s", describeDockerOptionsScope(scope)),
 				Mutations: []string{fmt.Sprintf("add %s option %q", describeDockerOptionsScope(scope), t.Option)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			current, err := getDockerOptions(t.App)
+			current, err := getDockerOptions(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -198,9 +199,9 @@ func (t DockerOptionsTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("present on %s", describeDockerOptionsScope(scope)),
 				Mutations: []string{fmt.Sprintf("remove %s option %q", describeDockerOptionsScope(scope), t.Option)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -271,8 +272,8 @@ func validateDockerOptionsTask(t DockerOptionsTask) error {
 // of truth here, so options are recovered as discrete entries even when their
 // values contain spaces. The space-joined shorthand keys and the legacy
 // `docker-options-*` duplicates are ignored.
-func getDockerOptions(app string) (map[dockerOptionsScope][]string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getDockerOptions(ctx context.Context, app string) (map[dockerOptionsScope][]string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "docker-options:report", app, "--format", "json"},
 	})

--- a/tasks/docker_options_task_integration_test.go
+++ b/tasks/docker_options_task_integration_test.go
@@ -10,16 +10,16 @@ func TestIntegrationDockerOptions(t *testing.T) {
 
 	appName := "docket-test-docker-options"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	option := "-v /tmp/docket-test:/tmp/docket-test"
 	phase := "deploy"
 	scope := dockerOptionsScope{Phase: phase}
 
 	// initial state - option not present
-	current, err := getDockerOptions(appName)
+	current, err := getDockerOptions(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestIntegrationDockerOptions(t *testing.T) {
 
 	// add option
 	addTask := DockerOptionsTask{App: appName, Phase: phase, Option: option, State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add option: %v", result.Error)
 	}
@@ -39,7 +39,7 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	current, err = getDockerOptions(appName)
+	current, err = getDockerOptions(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	}
 
 	// add same option - idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -58,7 +58,7 @@ func TestIntegrationDockerOptions(t *testing.T) {
 
 	// remove option
 	removeTask := DockerOptionsTask{App: appName, Phase: phase, Option: option, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove option: %v", result.Error)
 	}
@@ -68,7 +68,7 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	if result.State != StateAbsent {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
-	current, err = getDockerOptions(appName)
+	current, err = getDockerOptions(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	}
 
 	// remove again - idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -95,9 +95,9 @@ func TestIntegrationDockerOptionsExportRoundTrip(t *testing.T) {
 
 	appName := "docket-test-docker-options-export"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	phase := "deploy"
 	plainOption := "-v /tmp/docket-test:/tmp/docket-test"
@@ -107,12 +107,12 @@ func TestIntegrationDockerOptionsExportRoundTrip(t *testing.T) {
 
 	for _, option := range []string{plainOption, spacedOption} {
 		add := DockerOptionsTask{App: appName, Phase: phase, Option: option, State: StatePresent}
-		if r := add.Execute(); r.Error != nil {
+		if r := add.Execute(testCtx()); r.Error != nil {
 			t.Fatalf("failed to add option %q: %v", option, r.Error)
 		}
 	}
 
-	bodies, err := DockerOptionsTask{}.ExportApp(appName)
+	bodies, err := DockerOptionsTask{}.ExportApp(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestIntegrationDockerOptionsExportRoundTrip(t *testing.T) {
 	for _, body := range bodies {
 		task := body.(DockerOptionsTask)
 		task.State = StatePresent
-		if plan := task.Plan(); !plan.InSync {
+		if plan := task.Plan(testCtx()); !plan.InSync {
 			t.Errorf("exported task %+v should report no drift, got status %v reason %q", task, plan.Status, plan.Reason)
 		}
 	}
@@ -148,9 +148,9 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 
 	appName := "docket-test-docker-options-proc"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	option := "--memory=512m"
 	phase := "deploy"
@@ -159,7 +159,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 	defaultScope := dockerOptionsScope{Phase: phase}
 
 	// initial state - option not present in either scope
-	current, err := getDockerOptions(appName)
+	current, err := getDockerOptions(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 		Option:      option,
 		State:       StatePresent,
 	}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add scoped option: %v", result.Error)
 	}
@@ -183,7 +183,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 		t.Errorf("expected Changed=true on first add")
 	}
 
-	current, err = getDockerOptions(appName)
+	current, err = getDockerOptions(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 	}
 
 	// adding the same scoped option is idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second scoped add: %v", result.Error)
 	}
@@ -212,7 +212,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 		Option: option,
 		State:  StatePresent,
 	}
-	result = defaultAddTask.Execute()
+	result = defaultAddTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add default-scope option: %v", result.Error)
 	}
@@ -220,7 +220,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 		t.Errorf("expected Changed=true when adding the same option in the default scope")
 	}
 
-	current, err = getDockerOptions(appName)
+	current, err = getDockerOptions(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 		Option:      option,
 		State:       StateAbsent,
 	}
-	result = removeScopedTask.Execute()
+	result = removeScopedTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove scoped option: %v", result.Error)
 	}
@@ -247,7 +247,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 		t.Errorf("expected Changed=true on first scoped remove")
 	}
 
-	current, err = getDockerOptions(appName)
+	current, err = getDockerOptions(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestIntegrationDockerOptionsProcessType(t *testing.T) {
 	}
 
 	// idempotent scoped remove
-	result = removeScopedTask.Execute()
+	result = removeScopedTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second scoped remove: %v", result.Error)
 	}

--- a/tasks/docker_options_task_test.go
+++ b/tasks/docker_options_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestDockerOptionsTaskInvalidState(t *testing.T) {
 	task := DockerOptionsTask{App: "test-app", Phase: "deploy", Option: "-v /a:/a", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestDockerOptionsTaskInvalidState(t *testing.T) {
 
 func TestDockerOptionsTaskMissingApp(t *testing.T) {
 	task := DockerOptionsTask{Phase: "deploy", Option: "-v /a:/a", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -27,7 +27,7 @@ func TestDockerOptionsTaskMissingApp(t *testing.T) {
 func TestDockerOptionsTaskInvalidPhase(t *testing.T) {
 	for _, phase := range []string{"", "start", "any"} {
 		task := DockerOptionsTask{App: "test-app", Phase: phase, Option: "-v /a:/a", State: StatePresent}
-		result := task.Execute()
+		result := task.Execute(testCtx())
 		if result.Error == nil {
 			t.Fatalf("Execute with invalid phase %q should return an error", phase)
 		}
@@ -39,7 +39,7 @@ func TestDockerOptionsTaskInvalidPhase(t *testing.T) {
 
 func TestDockerOptionsTaskMissingOption(t *testing.T) {
 	task := DockerOptionsTask{App: "test-app", Phase: "deploy", Option: "  ", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without option should return an error")
 	}
@@ -56,7 +56,7 @@ func TestDockerOptionsTaskProcessTypeRejectsDefaultSentinel(t *testing.T) {
 		Option:      "-v /a:/a",
 		State:       StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with process_type='_default_' should return an error")
 	}
@@ -74,7 +74,7 @@ func TestDockerOptionsTaskProcessTypeRejectsNonDeployPhase(t *testing.T) {
 			Option:      "-v /a:/a",
 			State:       StatePresent,
 		}
-		result := task.Execute()
+		result := task.Execute(testCtx())
 		if result.Error == nil {
 			t.Fatalf("Execute with process_type set and phase=%q should return an error", phase)
 		}

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"github.com/dokku/docket/subprocess"
 	"sort"
@@ -88,8 +89,8 @@ func (t DomainsTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the domains
-func (t DomainsTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t DomainsTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the DomainsTask's inputs without contacting the server.
@@ -101,21 +102,21 @@ func (t DomainsTask) Validate() error {
 }
 
 // Plan reports the drift the DomainsTask would produce.
-func (t DomainsTask) Plan() PlanResult {
+func (t DomainsTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planDomainsPresent(t) },
-		StateAbsent:  func() PlanResult { return planDomainsAbsent(t) },
-		StateSet:     func() PlanResult { return planDomainsSet(t) },
-		StateClear:   func() PlanResult { return planDomainsClear(t) },
+		StatePresent: func() PlanResult { return planDomainsPresent(ctx, t) },
+		StateAbsent:  func() PlanResult { return planDomainsAbsent(ctx, t) },
+		StateSet:     func() PlanResult { return planDomainsSet(ctx, t) },
+		StateClear:   func() PlanResult { return planDomainsClear(ctx, t) },
 	})
 }
 
 // planDomainsPresent reports drift for the present-state domain add.
-func planDomainsPresent(t DomainsTask) PlanResult {
-	currentDomains, err := getDomains(t.App, t.Global)
+func planDomainsPresent(ctx context.Context, t DomainsTask) PlanResult {
+	currentDomains, err := getDomains(ctx, t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -146,14 +147,14 @@ func planDomainsPresent(t DomainsTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("%d domain(s) to add", len(toAdd)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs(subcommand, appName, toAdd, StatePresent, StateAbsent),
 	}
 }
 
 // planDomainsAbsent reports drift for the absent-state domain remove.
-func planDomainsAbsent(t DomainsTask) PlanResult {
-	currentDomains, err := getDomains(t.App, t.Global)
+func planDomainsAbsent(ctx context.Context, t DomainsTask) PlanResult {
+	currentDomains, err := getDomains(ctx, t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -180,14 +181,14 @@ func planDomainsAbsent(t DomainsTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d domain(s) to remove", len(toRemove)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs(subcommand, appName, toRemove, StateAbsent, StatePresent),
 	}
 }
 
 // planDomainsSet reports drift for the set-state full replacement.
-func planDomainsSet(t DomainsTask) PlanResult {
-	currentDomains, err := getDomains(t.App, t.Global)
+func planDomainsSet(ctx context.Context, t DomainsTask) PlanResult {
+	currentDomains, err := getDomains(ctx, t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -221,14 +222,14 @@ func planDomainsSet(t DomainsTask) PlanResult {
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d domain change(s)", len(mutations)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs(subcommand, appName, t.Domains, StateSet, StateAbsent),
 	}
 }
 
 // planDomainsClear reports drift for the clear-state operation.
-func planDomainsClear(t DomainsTask) PlanResult {
-	currentDomains, err := getDomains(t.App, t.Global)
+func planDomainsClear(ctx context.Context, t DomainsTask) PlanResult {
+	currentDomains, err := getDomains(ctx, t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -251,7 +252,7 @@ func planDomainsClear(t DomainsTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("clear %d domain(s)", len(currentDomains)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs(subcommand, appName, nil, StateClear, StatePresent),
 	}
 }
@@ -272,10 +273,10 @@ func dokkuArgsInputs(subcommand, target string, extra []string) []subprocess.Exe
 // applyDokkuArgs returns a closure that runs `dokku --quiet <subcommand>
 // <target> <extra...>`. It is used by domains plan paths to share the
 // boilerplate around constructing the subprocess call.
-func applyDokkuArgs(subcommand, target string, extra []string, finalState State, errState State) func() TaskOutputState {
+func applyDokkuArgs(subcommand, target string, extra []string, finalState State, errState State) func(ctx context.Context) TaskOutputState {
 	inputs := dokkuArgsInputs(subcommand, target, extra)
-	return func() TaskOutputState {
-		return runExecInputs(TaskOutputState{State: errState}, finalState, inputs)
+	return func(ctx context.Context) TaskOutputState {
+		return runExecInputs(ctx, TaskOutputState{State: errState}, finalState, inputs)
 	}
 }
 
@@ -300,8 +301,8 @@ func validateDomainsTask(t DomainsTask, requireDomains bool) error {
 
 // ExportApp reads the app's vhosts and returns a dokku_domains task that sets
 // exactly that set, or nil when the app has no custom domains.
-func (t DomainsTask) ExportApp(app string) ([]interface{}, error) {
-	domains, err := getDomains(app, false)
+func (t DomainsTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	domains, err := getDomains(ctx, app, false)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +318,7 @@ func (t DomainsTask) ExportApp(app string) ([]interface{}, error) {
 }
 
 // getDomains fetches current domains for an app or globally
-func getDomains(app string, global bool) (map[string]bool, error) {
+func getDomains(ctx context.Context, app string, global bool) (map[string]bool, error) {
 	reportFlag := "--domains-app-vhosts"
 	args := []string{
 		"domains:report",
@@ -332,7 +333,7 @@ func getDomains(app string, global bool) (map[string]bool, error) {
 		}
 	}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    args,
 	})

--- a/tasks/domains_task_integration_test.go
+++ b/tasks/domains_task_integration_test.go
@@ -8,7 +8,7 @@ import (
 
 // getReportedDomains queries dokku domains:report to get the current domain list for an app
 func getReportedDomains(appName string) []string {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"domains:report", appName, "--domains-app-vhosts"},
 	})
@@ -24,9 +24,9 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 
 	appName := "docket-test-domains-task"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// add domains
 	addTask := DomainsTask{
@@ -34,7 +34,7 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 		Domains: []string{"example.com", "www.example.com"},
 		State:   StatePresent,
 	}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add domains: %v", result.Error)
 	}
@@ -59,7 +59,7 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 	}
 
 	// add same domains again (idempotent)
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent add failed: %v", result.Error)
 	}
@@ -73,7 +73,7 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 		Domains: []string{"www.example.com"},
 		State:   StateAbsent,
 	}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove domain: %v", result.Error)
 	}
@@ -98,7 +98,7 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 	}
 
 	// remove same domain again (idempotent)
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent remove failed: %v", result.Error)
 	}
@@ -112,7 +112,7 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 		Domains: []string{"new.example.com"},
 		State:   StateSet,
 	}
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set domains: %v", result.Error)
 	}
@@ -137,7 +137,7 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 		App:   appName,
 		State: StateClear,
 	}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear domains: %v", result.Error)
 	}

--- a/tasks/domains_task_test.go
+++ b/tasks/domains_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDomainsTaskInvalidState(t *testing.T) {
 	task := DomainsTask{App: "test-app", Domains: []string{"example.com"}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -18,7 +18,7 @@ func TestDomainsTaskInvalidState(t *testing.T) {
 
 func TestDomainsTaskMissingApp(t *testing.T) {
 	task := DomainsTask{Domains: []string{"example.com"}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -26,7 +26,7 @@ func TestDomainsTaskMissingApp(t *testing.T) {
 
 func TestDomainsTaskGlobalWithApp(t *testing.T) {
 	task := DomainsTask{App: "test-app", Global: true, Domains: []string{"example.com"}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -39,7 +39,7 @@ func TestDomainsTaskEmptyDomains(t *testing.T) {
 	states := []State{StatePresent, StateAbsent, StateSet}
 	for _, s := range states {
 		task := DomainsTask{App: "test-app", Domains: []string{}, State: s}
-		result := task.Execute()
+		result := task.Execute(testCtx())
 		if result.Error == nil {
 			t.Fatalf("Execute with empty domains and state=%s should return an error", s)
 		}
@@ -61,7 +61,7 @@ func TestDomainsTaskClearRejectsDomains(t *testing.T) {
 
 func TestDomainsTaskClearNoDomains(t *testing.T) {
 	task := DomainsTask{App: "test-app", State: StateClear}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	// Should fail because dokku isn't running, but NOT because of missing domains
 	if result.Error != nil && strings.Contains(result.Error.Error(), "must not be empty") {
 		t.Error("clear state should not require domains")
@@ -90,7 +90,7 @@ func TestDomainsGlobalSetOmitsGlobalPositional(t *testing.T) {
 		"domains:report --global --domains-global-vhosts": "",
 	}))()
 
-	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan()
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -111,7 +111,7 @@ func TestDomainsGlobalSetConvergesWhenReportMatches(t *testing.T) {
 		"domains:report --global --domains-global-vhosts": "global.example.com",
 	}))()
 
-	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan()
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -125,7 +125,7 @@ func TestDomainsGlobalAddOmitsGlobalPositional(t *testing.T) {
 		"domains:report --global --domains-global-vhosts": "",
 	}))()
 
-	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StatePresent}.Plan()
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -143,7 +143,7 @@ func TestDomainsGlobalClearOmitsGlobalPositional(t *testing.T) {
 		"domains:report --global --domains-global-vhosts": "old.example.com",
 	}))()
 
-	plan := DomainsTask{Global: true, State: StateClear}.Plan()
+	plan := DomainsTask{Global: true, State: StateClear}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -8,10 +9,10 @@ import (
 
 // domainsEnabled probes whether the domains plugin is enabled for an app
 // via `dokku --quiet domains:report <app> --domains-app-enabled`.
-func domainsEnabled(ctx ToggleContext) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func domainsEnabled(ctx context.Context, tc ToggleContext) (bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    []string{"--quiet", "domains:report", ctx.App, "--domains-app-enabled"},
+		Args:    []string{"--quiet", "domains:report", tc.App, "--domains-app-enabled"},
 	})
 	if err != nil {
 		return false, err
@@ -21,8 +22,8 @@ func domainsEnabled(ctx ToggleContext) (bool, error) {
 
 // ExportApp emits a dokku_domains_toggle task only when the domains plugin is
 // disabled for the app (it is enabled by default).
-func (t DomainsToggleTask) ExportApp(app string) ([]interface{}, error) {
-	enabled, err := domainsEnabled(ToggleContext{App: app})
+func (t DomainsToggleTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	enabled, err := domainsEnabled(ctx, ToggleContext{App: app})
 	if err != nil {
 		return nil, err
 	}
@@ -84,13 +85,13 @@ func (t DomainsToggleTask) Examples() ([]Doc, error) {
 }
 
 // Execute enables or disables the domains plugin
-func (t DomainsToggleTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t DomainsToggleTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the DomainsToggleTask would produce.
-func (t DomainsToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, "domains:enable", "domains:disable", domainsEnabled)
+func (t DomainsToggleTask) Plan(ctx context.Context) PlanResult {
+	return planToggle(ctx, t.State, t.App, "domains:enable", "domains:disable", domainsEnabled)
 }
 
 // init registers the DomainsToggleTask with the task registry

--- a/tasks/domains_toggle_task_integration_test.go
+++ b/tasks/domains_toggle_task_integration_test.go
@@ -9,13 +9,13 @@ func TestIntegrationDomainsToggle(t *testing.T) {
 
 	appName := "docket-test-domains"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// enable domains
 	enableTask := DomainsToggleTask{App: appName, State: StatePresent}
-	result := enableTask.Execute()
+	result := enableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to enable domains: %v", result.Error)
 	}
@@ -25,7 +25,7 @@ func TestIntegrationDomainsToggle(t *testing.T) {
 
 	// disable domains
 	disableTask := DomainsToggleTask{App: appName, State: StateAbsent}
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to disable domains: %v", result.Error)
 	}

--- a/tasks/domains_toggle_task_test.go
+++ b/tasks/domains_toggle_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDomainsToggleTaskInvalidState(t *testing.T) {
 	task := DomainsToggleTask{App: "test-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -27,7 +27,7 @@ func TestDomainsToggleTaskPlanSurfacesSSHError(t *testing.T) {
 		}
 	})()
 
-	plan := DomainsToggleTask{App: "web", State: StatePresent}.Plan()
+	plan := DomainsToggleTask{App: "web", State: StatePresent}.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}

--- a/tasks/example_integration_test.go
+++ b/tasks/example_integration_test.go
@@ -165,19 +165,19 @@ func TestIntegrationTaskExamples(t *testing.T) {
 			created := map[string]bool{}
 			t.Cleanup(func() {
 				for app := range created {
-					destroyApp(app)
+					destroyApp(testCtx(), app)
 				}
 				for _, app := range policy.cleanupApps {
-					destroyApp(app)
+					destroyApp(testCtx(), app)
 				}
 				for _, svc := range policy.cleanupServices {
 					if parts := strings.SplitN(svc, ":", 2); len(parts) == 2 {
-						destroyService(parts[0], parts[1])
+						destroyService(testCtx(), parts[0], parts[1])
 					}
 				}
 			})
 			for _, app := range policy.ensureApps {
-				createApp(app)
+				createApp(testCtx(), app)
 				created[app] = true
 			}
 			for _, app := range policy.deployApps {
@@ -231,9 +231,9 @@ func ensureExampleApp(t *testing.T, taskName string, task Task, created map[stri
 		return
 	}
 	if fresh {
-		destroyApp(app)
+		destroyApp(testCtx(), app)
 	}
-	createApp(app)
+	createApp(testCtx(), app)
 	created[app] = true
 }
 
@@ -241,8 +241,8 @@ func ensureExampleApp(t *testing.T, taskName string, task Task, created map[stri
 // a running app (ps:scale, service:link, app:clone source, letsencrypt) have one.
 func deployExampleApp(t *testing.T, app string) {
 	t.Helper()
-	createApp(app)
-	result := GitFromImageTask{App: app, Image: exampleDeployImage, State: StateDeployed}.Execute()
+	createApp(testCtx(), app)
+	result := GitFromImageTask{App: app, Image: exampleDeployImage, State: StateDeployed}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to deploy placeholder app %q: %v", app, result.Error)
 	}
@@ -309,21 +309,21 @@ func ensureExampleService(t *testing.T, taskName string, task Task) {
 	if service == "" || name == "" {
 		return
 	}
-	result := ServiceCreateTask{Service: service, Name: name, State: StatePresent}.Execute()
+	result := ServiceCreateTask{Service: service, Name: name, State: StatePresent}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create backing service %s/%s: %v", service, name, result.Error)
 	}
-	t.Cleanup(func() { destroyService(service, name) })
+	t.Cleanup(func() { destroyService(testCtx(), service, name) })
 }
 
 // applyExample runs Plan then apply for one decoded example, asserting the plan
 // did not error and the applied state converged on the desired state.
 func applyExample(t *testing.T, name string, task Task) {
 	t.Helper()
-	if plan := task.Plan(); plan.Status == PlanStatusError {
+	if plan := task.Plan(testCtx()); plan.Status == PlanStatusError {
 		t.Fatalf("example %q: Plan returned error status: %v", name, plan.Error)
 	}
-	state := task.Execute()
+	state := task.Execute(testCtx())
 	if state.Error != nil {
 		t.Fatalf("example %q: apply returned error: %v\n  commands: %v\n  exit: %d\n  stdout: %s\n  stderr: %s",
 			name, state.Error, state.Commands, state.ExitCode, state.Stdout, state.Stderr)
@@ -406,7 +406,7 @@ func setupHttpAuthEnabledExample(t *testing.T) (func(Task) Task, func()) {
 func setupHttpAuthDomainExample(t *testing.T) (func(Task) Task, func()) {
 	t.Helper()
 	enableHttpAuthExampleApp(t)
-	result := DomainsTask{App: "hello-world", Domains: []string{"app.example.com", "www.example.com"}, State: StateSet}.Execute()
+	result := DomainsTask{App: "hello-world", Domains: []string{"app.example.com", "www.example.com"}, State: StateSet}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add http-auth-domain example domains: %v", result.Error)
 	}
@@ -417,7 +417,7 @@ func setupHttpAuthDomainExample(t *testing.T) (func(Task) Task, func()) {
 // app (created via the task's ensureApps).
 func enableHttpAuthExampleApp(t *testing.T) {
 	t.Helper()
-	result := HttpAuthTask{App: "hello-world", Username: "admin", Password: "secret", State: StatePresent}.Execute()
+	result := HttpAuthTask{App: "hello-world", Username: "admin", Password: "secret", State: StatePresent}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to enable http-auth on example app: %v", result.Error)
 	}
@@ -427,12 +427,12 @@ func enableHttpAuthExampleApp(t *testing.T) {
 // named-entry examples attach, and removes it afterward.
 func setupStorageMountExample(t *testing.T) (func(Task) Task, func()) {
 	t.Helper()
-	result := StorageEntryTask{Name: "node-js-app-data", Chown: "herokuish", State: StatePresent}.Execute()
+	result := StorageEntryTask{Name: "node-js-app-data", Chown: "herokuish", State: StatePresent}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create storage entry for storage_mount example: %v", result.Error)
 	}
 	return nil, func() {
-		StorageEntryTask{Name: "node-js-app-data", State: StateAbsent}.Execute()
+		StorageEntryTask{Name: "node-js-app-data", State: StateAbsent}.Execute(testCtx())
 	}
 }
 
@@ -474,12 +474,12 @@ const (
 func setupLetsencryptExample(t *testing.T) (func(Task) Task, func()) {
 	t.Helper()
 	registerChalltestsrvA(t, letsencryptExampleDomain, "172.17.0.1")
-	result := DomainsTask{App: letsencryptExampleApp, Domains: []string{letsencryptExampleDomain}, State: StateSet}.Execute()
+	result := DomainsTask{App: letsencryptExampleApp, Domains: []string{letsencryptExampleDomain}, State: StateSet}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set domain %q for letsencrypt example: %v", letsencryptExampleDomain, result.Error)
 	}
 	cleanup := func() {
-		DomainsTask{App: letsencryptExampleApp, State: StateClear}.Execute()
+		DomainsTask{App: letsencryptExampleApp, State: StateClear}.Execute(testCtx())
 		clearChalltestsrvA(letsencryptExampleDomain)
 	}
 	return nil, cleanup
@@ -491,7 +491,7 @@ func setupLetsencryptExample(t *testing.T) (func(Task) Task, func()) {
 func registerChalltestsrvA(t *testing.T, host, target string) {
 	t.Helper()
 	body := fmt.Sprintf(`{"host":"%s.","addresses":["%s"]}`, host, target)
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "curl",
 		Args:    []string{"-sf", "-X", "POST", "-H", "Content-Type: application/json", "-d", body, challtestsrvURL + "/add-a"},
 	})
@@ -503,7 +503,7 @@ func registerChalltestsrvA(t *testing.T, host, target string) {
 // clearChalltestsrvA removes a published A record; best effort during cleanup.
 func clearChalltestsrvA(host string) {
 	body := fmt.Sprintf(`{"host":"%s."}`, host)
-	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "curl",
 		Args:    []string{"-sf", "-X", "POST", "-H", "Content-Type: application/json", "-d", body, challtestsrvURL + "/clear-a"},
 	})
@@ -546,7 +546,7 @@ func registerGlobalPropertyRevert(t *testing.T, task Task) {
 	if !ok {
 		return
 	}
-	t.Cleanup(func() { clearTask.Execute() })
+	t.Cleanup(func() { clearTask.Execute(testCtx()) })
 }
 
 // taskStringField returns the value of a string field on a task struct, or ""

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -17,14 +18,14 @@ import (
 // values); the engine wraps each under the task's type-key and applies
 // vars-extraction/redaction uniformly afterwards.
 type AppExporter interface {
-	ExportApp(app string) ([]interface{}, error)
+	ExportApp(ctx context.Context, app string) ([]interface{}, error)
 }
 
 // GlobalExporter is the not-app-scoped counterpart of AppExporter (global
 // certs, networks, ssh keys, ...). It is defined here so global resources can
 // be added the same way; the engine runs these into a leading global play.
 type GlobalExporter interface {
-	ExportGlobal() ([]interface{}, error)
+	ExportGlobal(ctx context.Context) ([]interface{}, error)
 }
 
 // appExportReporter is an optional richer form of AppExporter: an exporter that
@@ -33,7 +34,7 @@ type GlobalExporter interface {
 // log line. exportAppPlay passes a warn callback wired to res.Report.Warnings
 // and prefers this method when the task implements it.
 type appExportReporter interface {
-	ExportAppReport(app string, warn func(msg string)) ([]interface{}, error)
+	ExportAppReport(ctx context.Context, app string, warn func(msg string)) ([]interface{}, error)
 }
 
 // globalExportReporter is the not-app-scoped counterpart of appExportReporter:
@@ -47,7 +48,7 @@ type appExportReporter interface {
 // asserts GlobalExporter first, so a task carrying only the reporting form is
 // skipped entirely.
 type globalExportReporter interface {
-	ExportGlobalReport(warn func(msg string)) ([]interface{}, error)
+	ExportGlobalReport(ctx context.Context, warn func(msg string)) ([]interface{}, error)
 }
 
 // globalExportOrder is the fixed order in which not-app-scoped task types are
@@ -288,7 +289,7 @@ func (res *ExportResult) SensitiveValues() []string {
 // before the app list is read, so a failure there still hands back what was
 // already collected - and with it the sensitive values the caller has to
 // register before it prints the failure (#488).
-func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
+func ExportRecipe(ctx context.Context, opts ExportOptions) (*ExportResult, error) {
 	res := &ExportResult{
 		Vars:         map[string]string{},
 		usedVarNames: map[string]bool{},
@@ -300,7 +301,7 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 	// the export is narrowed to specific apps with --app, and when every
 	// --resource address is app-scoped.
 	if len(opts.Apps) == 0 && res.filter.wantsGlobalScope(inGlobal) {
-		if global := res.exportGlobalPlay(opts); global != nil {
+		if global := res.exportGlobalPlay(ctx, opts); global != nil {
 			res.plays = append(res.plays, global)
 		}
 	}
@@ -319,7 +320,7 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 		wantApps = selectedApps
 	}
 
-	apps, err := listApps()
+	apps, err := listApps(ctx)
 	if err != nil {
 		return res, err
 	}
@@ -333,7 +334,7 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 	sort.Strings(apps)
 
 	for _, app := range apps {
-		play := res.exportAppPlay(app, opts)
+		play := res.exportAppPlay(ctx, app, opts)
 		if play != nil {
 			res.plays = append(res.plays, play)
 		}
@@ -346,7 +347,7 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 
 // exportGlobalPlay builds the leading global play by running every registered
 // GlobalExporter. Returns nil when there are no global resources.
-func (res *ExportResult) exportGlobalPlay(opts ExportOptions) map[string]interface{} {
+func (res *ExportResult) exportGlobalPlay(ctx context.Context, opts ExportOptions) map[string]interface{} {
 	var taskList []map[string]interface{}
 	var inputs []map[string]interface{}
 
@@ -365,12 +366,12 @@ func (res *ExportResult) exportGlobalPlay(opts ExportOptions) map[string]interfa
 		var bodies []interface{}
 		var err error
 		if reporter, ok := proto.(globalExportReporter); ok {
-			bodies, err = reporter.ExportGlobalReport(func(msg string) {
+			bodies, err = reporter.ExportGlobalReport(ctx, func(msg string) {
 				res.Report.Warnings = append(res.Report.Warnings,
 					fmt.Sprintf("global: %s: %s", typeKey, msg))
 			})
 		} else {
-			bodies, err = exporter.ExportGlobal()
+			bodies, err = exporter.ExportGlobal(ctx)
 		}
 		if err != nil {
 			res.Report.Warnings = append(res.Report.Warnings,
@@ -406,7 +407,7 @@ func (res *ExportResult) exportGlobalPlay(opts ExportOptions) map[string]interfa
 
 // exportAppPlay builds one play for a single app by running each app-scoped
 // exporter in appExportOrder. Returns nil when the app yields no tasks.
-func (res *ExportResult) exportAppPlay(app string, opts ExportOptions) map[string]interface{} {
+func (res *ExportResult) exportAppPlay(ctx context.Context, app string, opts ExportOptions) map[string]interface{} {
 	var taskList []map[string]interface{}
 	var inputs []map[string]interface{}
 
@@ -425,12 +426,12 @@ func (res *ExportResult) exportAppPlay(app string, opts ExportOptions) map[strin
 		var bodies []interface{}
 		var err error
 		if reporter, ok := proto.(appExportReporter); ok {
-			bodies, err = reporter.ExportAppReport(app, func(msg string) {
+			bodies, err = reporter.ExportAppReport(ctx, app, func(msg string) {
 				res.Report.Warnings = append(res.Report.Warnings,
 					fmt.Sprintf("%s: %s: %s", app, typeKey, msg))
 			})
 		} else {
-			bodies, err = exporter.ExportApp(app)
+			bodies, err = exporter.ExportApp(ctx, app)
 		}
 		if err != nil {
 			res.Report.Warnings = append(res.Report.Warnings,
@@ -883,8 +884,8 @@ func (res *ExportResult) AppCount() int {
 }
 
 // listApps returns every app on the server via `dokku apps:list`.
-func listApps() ([]string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func listApps(ctx context.Context) ([]string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "apps:list"},
 	})

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -14,16 +14,16 @@ func TestIntegrationExportConfigRoundTrip(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	app := "docket-test-export-config"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
 	set := ConfigTask{App: app, Restart: boolPtr(false), Config: map[string]string{"EXPORT_KEY": "export_value"}, State: StatePresent}
-	if r := set.Execute(); r.Error != nil {
+	if r := set.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set config: %v", r.Error)
 	}
 
-	bodies, err := ConfigTask{}.ExportApp(app)
+	bodies, err := ConfigTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestIntegrationExportConfigRoundTrip(t *testing.T) {
 	// The exporter omits state (the recipe loader defaults it to present); set
 	// it here since we plan the body directly without going through the loader.
 	cfg.State = StatePresent
-	if plan := cfg.Plan(); !plan.InSync {
+	if plan := cfg.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported config should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -49,18 +49,18 @@ func TestIntegrationExportReconstructsApp(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	app := "docket-test-export-app"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
-	if r := (ConfigTask{App: app, Config: map[string]string{"SECRET": "s3cr3t"}, State: StatePresent}).Execute(); r.Error != nil {
+	if r := (ConfigTask{App: app, Config: map[string]string{"SECRET": "s3cr3t"}, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set config: %v", r.Error)
 	}
-	if r := (DomainsTask{App: app, Domains: []string{"exp.example.com"}, State: StateSet}).Execute(); r.Error != nil {
+	if r := (DomainsTask{App: app, Domains: []string{"exp.example.com"}, State: StateSet}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set domains: %v", r.Error)
 	}
 
-	res, err := ExportRecipe(ExportOptions{Apps: []string{app}})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Apps: []string{app}})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -92,16 +92,16 @@ func TestIntegrationExportCerts(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	app := "docket-test-export-certs"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
 	certPath, keyPath := generateSelfSignedCert(t, app+".example.com")
-	if r := (CertsTask{App: app, Cert: certPath, Key: keyPath, State: StatePresent}).Execute(); r.Error != nil {
+	if r := (CertsTask{App: app, Cert: certPath, Key: keyPath, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("add cert: %v", r.Error)
 	}
 
-	bodies, err := CertsTask{}.ExportApp(app)
+	bodies, err := CertsTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestIntegrationExportCerts(t *testing.T) {
 		t.Errorf("exported key_content missing PEM: %q", c.KeyContent)
 	}
 	c.State = StatePresent
-	if plan := c.Plan(); !plan.InSync {
+	if plan := c.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported certs should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -132,16 +132,16 @@ func TestIntegrationExportGlobalCerts(t *testing.T) {
 
 	// best-effort cleanup before and after
 	cleanup := func() {
-		(CertsTask{Global: true, State: StateAbsent}).Execute()
+		(CertsTask{Global: true, State: StateAbsent}).Execute(testCtx())
 	}
 	cleanup()
 	defer cleanup()
 
-	if r := (CertsTask{Global: true, Cert: certPath, Key: keyPath, State: StatePresent}).Execute(); r.Error != nil {
+	if r := (CertsTask{Global: true, Cert: certPath, Key: keyPath, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("add global cert: %v", r.Error)
 	}
 
-	bodies, err := CertsTask{}.ExportGlobal()
+	bodies, err := CertsTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestIntegrationExportGlobalCerts(t *testing.T) {
 		t.Errorf("exported key_content missing PEM: %q", c.KeyContent)
 	}
 	c.State = StatePresent
-	if plan := c.Plan(); !plan.InSync {
+	if plan := c.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported global certs should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -177,15 +177,15 @@ func TestIntegrationExportGitPropertyGlobal(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	cleanup := GitPropertyTask{Global: true, Property: "archive-max-files", State: StateAbsent}
-	cleanup.Execute()
-	defer cleanup.Execute()
+	cleanup.Execute(testCtx())
+	defer cleanup.Execute(testCtx())
 
 	set := GitPropertyTask{Global: true, Property: "archive-max-files", Value: "4242", State: StatePresent}
-	if r := set.Execute(); r.Error != nil {
+	if r := set.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set global git property: %v", r.Error)
 	}
 
-	bodies, err := GitPropertyTask{}.ExportGlobal()
+	bodies, err := GitPropertyTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestIntegrationExportGitPropertyGlobal(t *testing.T) {
 
 	// The exporter omits state; set it as the recipe loader would before planning.
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported global property should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -229,15 +229,15 @@ func TestIntegrationExportSchedulerK3sProfile(t *testing.T) {
 
 	name := "docket-test-export-prof"
 	cleanup := SchedulerK3sProfileTask{Name: name, Role: "worker", State: StateAbsent}
-	cleanup.Execute()
-	defer cleanup.Execute()
+	cleanup.Execute(testCtx())
+	defer cleanup.Execute(testCtx())
 
 	set := SchedulerK3sProfileTask{Name: name, Role: "worker", KubeletArgs: []string{"foo=bar"}, TaintScheduling: true, State: StatePresent}
-	if r := set.Execute(); r.Error != nil {
+	if r := set.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("add profile: %v", r.Error)
 	}
 
-	bodies, err := SchedulerK3sProfileTask{}.ExportGlobal()
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestIntegrationExportSchedulerK3sProfile(t *testing.T) {
 	if found.State != StatePresent {
 		t.Errorf("exported state = %q, want %q", found.State, StatePresent)
 	}
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported profile should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -279,7 +279,7 @@ func TestIntegrationExportSchedulerK3sProfileLeavesOutUnappliableName(t *testing
 
 	name := "DocketTestExportBad"
 	removeProfile := func() {
-		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "dokku",
 			Args:    []string{"--quiet", "scheduler-k3s:profiles:remove", name},
 		})
@@ -287,7 +287,7 @@ func TestIntegrationExportSchedulerK3sProfileLeavesOutUnappliableName(t *testing
 	removeProfile()
 	defer removeProfile()
 
-	if _, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	if _, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "scheduler-k3s:profiles:add", name, "--role", "worker"},
 	}); err != nil {
@@ -295,7 +295,7 @@ func TestIntegrationExportSchedulerK3sProfileLeavesOutUnappliableName(t *testing
 	}
 
 	var warnings []string
-	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(func(msg string) {
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(testCtx(), func(msg string) {
 		warnings = append(warnings, msg)
 	})
 	if err != nil {
@@ -326,15 +326,15 @@ func TestIntegrationExportSchedulerK3sChart(t *testing.T) {
 
 	chart := "ingress-nginx"
 	cleanup := SchedulerK3sChartTask{Chart: chart, Values: map[string]any{"docket-test-key": ""}, State: StateAbsent}
-	cleanup.Execute()
-	defer cleanup.Execute()
+	cleanup.Execute(testCtx())
+	defer cleanup.Execute(testCtx())
 
 	set := SchedulerK3sChartTask{Chart: chart, Values: map[string]any{"docket-test-key": "docket-test-value"}, State: StatePresent}
-	if r := set.Execute(); r.Error != nil {
+	if r := set.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set chart value: %v", r.Error)
 	}
 
-	bodies, err := SchedulerK3sChartTask{}.ExportGlobal()
+	bodies, err := SchedulerK3sChartTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestIntegrationExportSchedulerK3sChart(t *testing.T) {
 		t.Errorf("exported chart value mismatch: %+v", found.Values)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported chart should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -366,9 +366,9 @@ func TestIntegrationSchedulerK3sAnnotationsExport(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	app := "docket-test-export-k3s-annotations"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
 	cleanup := SchedulerK3sAnnotationsTask{
 		App:          app,
@@ -376,7 +376,7 @@ func TestIntegrationSchedulerK3sAnnotationsExport(t *testing.T) {
 		Annotations:  map[string]string{"prometheus.io/scrape": "", "prometheus.io/port": ""},
 		State:        StateAbsent,
 	}
-	defer cleanup.Execute()
+	defer cleanup.Execute(testCtx())
 
 	set := SchedulerK3sAnnotationsTask{
 		App:          app,
@@ -384,11 +384,11 @@ func TestIntegrationSchedulerK3sAnnotationsExport(t *testing.T) {
 		Annotations:  map[string]string{"prometheus.io/scrape": "true", "prometheus.io/port": "9090"},
 		State:        StatePresent,
 	}
-	if r := set.Execute(); r.Error != nil {
+	if r := set.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set annotations: %v", r.Error)
 	}
 
-	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(app)
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestIntegrationSchedulerK3sAnnotationsExport(t *testing.T) {
 		t.Errorf("exported annotations mismatch: %+v", found.Annotations)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported annotations should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -420,9 +420,9 @@ func TestIntegrationSchedulerK3sLabelsExport(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	app := "docket-test-export-k3s-labels"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
 	cleanup := SchedulerK3sLabelsTask{
 		App:          app,
@@ -431,7 +431,7 @@ func TestIntegrationSchedulerK3sLabelsExport(t *testing.T) {
 		Labels:       map[string]string{"tier": "", "app.kubernetes.io/component": ""},
 		State:        StateAbsent,
 	}
-	defer cleanup.Execute()
+	defer cleanup.Execute(testCtx())
 
 	set := SchedulerK3sLabelsTask{
 		App:          app,
@@ -440,11 +440,11 @@ func TestIntegrationSchedulerK3sLabelsExport(t *testing.T) {
 		Labels:       map[string]string{"tier": "edge", "app.kubernetes.io/component": "api"},
 		State:        StatePresent,
 	}
-	if r := set.Execute(); r.Error != nil {
+	if r := set.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set labels: %v", r.Error)
 	}
 
-	bodies, err := SchedulerK3sLabelsTask{}.ExportApp(app)
+	bodies, err := SchedulerK3sLabelsTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -462,7 +462,7 @@ func TestIntegrationSchedulerK3sLabelsExport(t *testing.T) {
 		t.Errorf("exported labels mismatch: %+v", found.Labels)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported labels should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -476,9 +476,9 @@ func TestIntegrationSchedulerK3sAutoscalingAuthExport(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	app := "docket-test-export-k3s-autoscaling-auth"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
 	cleanup := SchedulerK3sAutoscalingAuthTask{
 		App:      app,
@@ -486,7 +486,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthExport(t *testing.T) {
 		Metadata: map[string]string{"awsRegion": "", "secretName": ""},
 		State:    StateAbsent,
 	}
-	defer cleanup.Execute()
+	defer cleanup.Execute(testCtx())
 
 	set := SchedulerK3sAutoscalingAuthTask{
 		App:      app,
@@ -494,11 +494,11 @@ func TestIntegrationSchedulerK3sAutoscalingAuthExport(t *testing.T) {
 		Metadata: map[string]string{"awsRegion": "us-east-1", "secretName": "my-secret"},
 		State:    StatePresent,
 	}
-	if r := set.Execute(); r.Error != nil {
+	if r := set.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("set autoscaling-auth: %v", r.Error)
 	}
 
-	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp(app)
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthExport(t *testing.T) {
 		t.Errorf("exported metadata mismatch: %+v", found.Metadata)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported trigger auth should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -531,13 +531,13 @@ func TestIntegrationExportServiceCreate(t *testing.T) {
 
 	serviceType := "redis"
 	serviceName := "docket-test-export-svc-create"
-	destroyService(serviceType, serviceName)
-	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	destroyService(testCtx(), serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("create service: %v", r.Error)
 	}
-	defer destroyService(serviceType, serviceName)
+	defer destroyService(testCtx(), serviceType, serviceName)
 
-	bodies, err := ServiceCreateTask{}.ExportGlobal()
+	bodies, err := ServiceCreateTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -552,7 +552,7 @@ func TestIntegrationExportServiceCreate(t *testing.T) {
 		t.Fatalf("exported services do not include %s:%s: %+v", serviceType, serviceName, bodies)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported service create should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -567,16 +567,16 @@ func TestIntegrationExportServiceExpose(t *testing.T) {
 	serviceType := "redis"
 	serviceName := "docket-test-export-svc-expose"
 	hostPort := "16379"
-	destroyService(serviceType, serviceName)
-	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	destroyService(testCtx(), serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("create service: %v", r.Error)
 	}
-	defer destroyService(serviceType, serviceName)
-	if r := (ServiceExposeTask{Service: serviceType, Name: serviceName, Ports: []string{hostPort}, State: StatePresent}).Execute(); r.Error != nil {
+	defer destroyService(testCtx(), serviceType, serviceName)
+	if r := (ServiceExposeTask{Service: serviceType, Name: serviceName, Ports: []string{hostPort}, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("expose service: %v", r.Error)
 	}
 
-	bodies, err := ServiceExposeTask{}.ExportGlobal()
+	bodies, err := ServiceExposeTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -594,7 +594,7 @@ func TestIntegrationExportServiceExpose(t *testing.T) {
 		t.Errorf("exported expose ports = %v, want [%s]", found.Ports, hostPort)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported service expose should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -611,22 +611,22 @@ func TestIntegrationExportServiceLink(t *testing.T) {
 	appName := "docket-test-export-svc-link-app"
 	serviceType := "redis"
 	serviceName := "docket-test-export-svc-link"
-	destroyApp(appName)
-	destroyService(serviceType, serviceName)
-	createApp(appName)
-	defer destroyApp(appName)
-	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	destroyApp(testCtx(), appName)
+	destroyService(testCtx(), serviceType, serviceName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("create service: %v", r.Error)
 	}
 	defer func() {
-		(ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StateAbsent}).Execute()
-		destroyService(serviceType, serviceName)
+		(ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StateAbsent}).Execute(testCtx())
+		destroyService(testCtx(), serviceType, serviceName)
 	}()
-	if r := (ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	if r := (ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("link service: %v", r.Error)
 	}
 
-	bodies, err := ServiceLinkTask{}.ExportApp(appName)
+	bodies, err := ServiceLinkTask{}.ExportApp(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -641,13 +641,13 @@ func TestIntegrationExportServiceLink(t *testing.T) {
 		t.Fatalf("exported links do not include %s:%s for %s: %+v", serviceType, serviceName, appName, bodies)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported service link should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 
 	// The link injects REDIS_URL into the app's config; config export must drop
 	// it, since the link recreates it on apply with the new server's creds.
-	cfgBodies, err := ConfigTask{}.ExportApp(appName)
+	cfgBodies, err := ConfigTask{}.ExportApp(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("config ExportApp: %v", err)
 	}
@@ -669,20 +669,20 @@ func TestIntegrationExportServiceBackup(t *testing.T) {
 
 	serviceType := "redis"
 	serviceName := "docket-test-export-svc-backup"
-	destroyService(serviceType, serviceName)
-	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	destroyService(testCtx(), serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("create service: %v", r.Error)
 	}
-	defer destroyService(serviceType, serviceName)
+	defer destroyService(testCtx(), serviceType, serviceName)
 
 	schedule := "0 3 * * *"
 	bucket := "docket-test-bucket"
-	if r := (ServiceBackupTask{Service: serviceType, Name: serviceName, Schedule: schedule, Bucket: bucket, UseIam: true, State: StatePresent}).Execute(); r.Error != nil {
+	if r := (ServiceBackupTask{Service: serviceType, Name: serviceName, Schedule: schedule, Bucket: bucket, UseIam: true, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		// not every datastore plugin implements backup-schedule
 		t.Skipf("skipping: could not schedule backup (%v)", r.Error)
 	}
 
-	bodies, err := ServiceBackupTask{}.ExportGlobal()
+	bodies, err := ServiceBackupTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -703,7 +703,7 @@ func TestIntegrationExportServiceBackup(t *testing.T) {
 		t.Errorf("backup export should not include write-only credentials: %+v", *found)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported service backup should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -720,17 +720,17 @@ func TestIntegrationExportAclService(t *testing.T) {
 	serviceType := "redis"
 	serviceName := "docket-test-export-acl-svc"
 	user := "docket-test-acl-user"
-	destroyService(serviceType, serviceName)
-	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	destroyService(testCtx(), serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("create service: %v", r.Error)
 	}
-	defer destroyService(serviceType, serviceName)
+	defer destroyService(testCtx(), serviceType, serviceName)
 
-	if r := (AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{user}, State: StatePresent}).Execute(); r.Error != nil {
+	if r := (AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{user}, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Skipf("skipping: could not add acl user (%v)", r.Error)
 	}
 
-	bodies, err := AclServiceTask{}.ExportGlobal()
+	bodies, err := AclServiceTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -754,7 +754,7 @@ func TestIntegrationExportAclService(t *testing.T) {
 		t.Errorf("exported acl users %v missing %q", found.Users, user)
 	}
 	found.State = StatePresent
-	if plan := found.Plan(); !plan.InSync {
+	if plan := found.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported acl service should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
@@ -768,11 +768,11 @@ func TestIntegrationExportLetsencrypt(t *testing.T) {
 	skipIfPluginMissingT(t, "letsencrypt")
 
 	app := "docket-test-export-letsencrypt"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
-	bodies, err := LetsencryptTask{}.ExportApp(app)
+	bodies, err := LetsencryptTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -790,13 +790,13 @@ func TestIntegrationExportHttpAuth(t *testing.T) {
 	skipIfPluginMissingT(t, "http-auth")
 
 	app := "docket-test-export-http-auth"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
 	exported := func(t *testing.T, label string) []interface{} {
 		t.Helper()
-		bodies, err := HttpAuthTask{}.ExportApp(app)
+		bodies, err := HttpAuthTask{}.ExportApp(testCtx(), app)
 		if err != nil {
 			t.Fatalf("%s: ExportApp: %v", label, err)
 		}
@@ -814,24 +814,24 @@ func TestIntegrationExportHttpAuth(t *testing.T) {
 		if err := auth.Validate(); err != nil {
 			t.Errorf("%s: exported task must be valid, got: %v", label, err)
 		}
-		if plan := auth.Plan(); !plan.InSync {
+		if plan := auth.Plan(testCtx()); !plan.InSync {
 			t.Errorf("%s: exported task should report no drift, got status %v reason %q", label, plan.Status, plan.Reason)
 		}
 	}
 
-	if r := (HttpAuthTask{App: app, Username: "admin", Password: "secret", State: StatePresent}).Execute(); r.Error != nil {
+	if r := (HttpAuthTask{App: app, Username: "admin", Password: "secret", State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("enable http auth: %v", r.Error)
 	}
 	assertState(t, "enabled", exported(t, "enabled"), StatePresent)
 
 	// http-auth:disable only writes enabled=false; the htpasswd survives, so
 	// re-applying the exported users would turn auth back on without this.
-	if r := (HttpAuthTask{App: app, State: StateAbsent}).Execute(); r.Error != nil {
+	if r := (HttpAuthTask{App: app, State: StateAbsent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("disable http auth: %v", r.Error)
 	}
 	assertState(t, "disabled with users", exported(t, "disabled with users"), StateAbsent)
 
-	if r := (HttpAuthUserTask{App: app, State: StateAbsent}).Execute(); r.Error != nil {
+	if r := (HttpAuthUserTask{App: app, State: StateAbsent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("remove http auth users: %v", r.Error)
 	}
 	if bodies := exported(t, "disabled and unconfigured"); len(bodies) != 0 {
@@ -848,21 +848,21 @@ func TestIntegrationExportHttpAuthUserHashes(t *testing.T) {
 	skipIfPluginMissingT(t, "http-auth")
 
 	app := "docket-test-export-http-auth-user"
-	destroyApp(app)
-	createApp(app)
-	defer destroyApp(app)
+	destroyApp(testCtx(), app)
+	createApp(testCtx(), app)
+	defer destroyApp(testCtx(), app)
 
-	if bodies, err := (HttpAuthUserTask{}).ExportApp(app); err != nil {
+	if bodies, err := (HttpAuthUserTask{}).ExportApp(testCtx(), app); err != nil {
 		t.Fatalf("ExportApp on a fresh app: %v", err)
 	} else if len(bodies) != 0 {
 		t.Errorf("expected no exported task before any user exists, got %v", bodies)
 	}
 
-	if r := (HttpAuthTask{App: app, Username: "admin", Password: "secret", State: StatePresent}).Execute(); r.Error != nil {
+	if r := (HttpAuthTask{App: app, Username: "admin", Password: "secret", State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("enable http auth: %v", r.Error)
 	}
 
-	bodies, err := HttpAuthUserTask{}.ExportApp(app)
+	bodies, err := HttpAuthUserTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -882,7 +882,7 @@ func TestIntegrationExportHttpAuthUserHashes(t *testing.T) {
 	if err := users.Validate(); err != nil {
 		t.Errorf("exported task must be valid, got: %v", err)
 	}
-	if plan := users.Plan(); !plan.InSync {
+	if plan := users.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported task should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }

--- a/tasks/export_masking_test.go
+++ b/tasks/export_masking_test.go
@@ -43,7 +43,7 @@ func assertNotRegistered(t *testing.T, res *ExportResult, unwanted string) {
 func TestExportRegistersConfigValues(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestExportRegistersConfigValues(t *testing.T) {
 func TestExportRedactStillRegistersTheRealValue(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{Redact: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestExportRedactStillRegistersTheRealValue(t *testing.T) {
 func TestExportInlineRegistersValuesItDoesNotLift(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{Inline: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestExportRegistersSensitivePropertyValue(t *testing.T) {
 		"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken","global-ingress-class":"nginx-ingress"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestExportRegistersSensitivePropertyValue(t *testing.T) {
 func TestExportRegistersHttpAuthHashes(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
-	res, err := ExportRecipe(ExportOptions{Inline: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestExportRegistersEveryLetsencryptPropertyValue(t *testing.T) {
 		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"tok3n"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestExportRegistersNothingForBenignProperties(t *testing.T) {
 		"--quiet git:report --global --format json": `{"global-deploy-branch":"main","global-archive-max-files":"100","global-keep-git-dir":""}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/export_resource_test.go
+++ b/tasks/export_resource_test.go
@@ -15,7 +15,7 @@ func exportResource(t *testing.T, addresses ...string) (string, ExportReport) {
 	if err != nil {
 		t.Fatalf("ParseResourceSelectors(%v): %v", addresses, err)
 	}
-	res, err := ExportRecipe(ExportOptions{Resources: selectors, Inline: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Resources: selectors, Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestParseResourceSelectorsAcceptsValidAddresses(t *testing.T) {
 func TestExportedRecipeLoadsWithoutNameCollisions(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{Inline: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -64,7 +64,7 @@ func TestExportPluginsBecomeTasks(t *testing.T) {
 		]`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestExportPluginsBecomeTasks(t *testing.T) {
 func TestExportRecipeFileMode(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -189,7 +189,7 @@ func httpAuthExportFixture(users, entries string) map[string]string {
 func TestExportHttpAuthUserHashesBecomeVars(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
-	bodies, err := HttpAuthUserTask{}.ExportApp("web")
+	bodies, err := HttpAuthUserTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -210,11 +210,11 @@ func TestExportHttpAuthUserHashesBecomeVars(t *testing.T) {
 	if err := users.Validate(); err != nil {
 		t.Errorf("exported task must be valid, got: %v", err)
 	}
-	if plan := users.Plan(); !plan.InSync {
+	if plan := users.Plan(testCtx()); !plan.InSync {
 		t.Errorf("re-planning the exported task should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestExportHttpAuthUserHashesBecomeVars(t *testing.T) {
 func TestExportHttpAuthUserRedactBlanksTheVar(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
-	res, err := ExportRecipe(ExportOptions{Redact: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestExportHttpAuthUserRedactBlanksTheVar(t *testing.T) {
 func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
-	bodies, err := HttpAuthTask{}.ExportApp("web")
+	bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
 		t.Errorf("exported http-auth task must be valid, got: %v", err)
 	}
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestExportHttpAuthEnabledWithoutUsersBecomesTask(t *testing.T) {
 	// assertion below tests the empty htpasswd rather than a missing fixture.
 	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("", "")))()
 
-	bodies, err := HttpAuthTask{}.ExportApp("web")
+	bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -337,7 +337,7 @@ func TestExportHttpAuthEnabledWithoutUsersBecomesTask(t *testing.T) {
 		t.Errorf("exported http-auth task must be valid, got: %v", err)
 	}
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestExportHttpAuthDisabledWithConfigBecomesAbsentTask(t *testing.T) {
 				"http-auth:report web --format json": tc.report,
 			}))()
 
-			bodies, err := HttpAuthTask{}.ExportApp("web")
+			bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
 			if err != nil {
 				t.Fatalf("ExportApp: %v", err)
 			}
@@ -385,7 +385,7 @@ func TestExportHttpAuthDisabledWithConfigBecomesAbsentTask(t *testing.T) {
 				t.Errorf("exported http-auth task must be valid, got: %v", err)
 			}
 
-			res, err := ExportRecipe(ExportOptions{})
+			res, err := ExportRecipe(testCtx(), ExportOptions{})
 			if err != nil {
 				t.Fatalf("ExportRecipe: %v", err)
 			}
@@ -410,7 +410,7 @@ func TestExportHttpAuthDisabledEmitsNoTask(t *testing.T) {
 		"http-auth:report web --format json": `{"enabled":"false","users":"","allowed-ips":"","domains":""}`,
 	}))()
 
-	bodies, err := HttpAuthTask{}.ExportApp("web")
+	bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestExportHttpAuthDisabledEmitsNoTask(t *testing.T) {
 		t.Errorf("expected no exported task for an unconfigured app, got %v", bodies)
 	}
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestExportMaintenanceCustomPageBecomesInput(t *testing.T) {
 		"maintenance:report web --format json": `{"enabled":"false","custom-page-sha256":"7b645f273842a941c68302a4022ed03e219bd8db318ef32a92dddb148a72ef05"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestExportMaintenanceCustomPageAbsentEmitsNothing(t *testing.T) {
 				"maintenance:report web --format json": tc.report,
 			}))()
 
-			res, err := ExportRecipe(ExportOptions{})
+			res, err := ExportRecipe(testCtx(), ExportOptions{})
 			if err != nil {
 				t.Fatalf("ExportRecipe: %v", err)
 			}
@@ -499,7 +499,7 @@ func TestExportMaintenanceCustomPageAbsentEmitsNothing(t *testing.T) {
 func TestExportRecipeRedactBlanksVars(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{Redact: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestExportRecipeRedactBlanksVars(t *testing.T) {
 func TestExportRecipeInlineKeepsValues(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{Inline: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -536,7 +536,7 @@ func TestExportRecipeInlineKeepsValues(t *testing.T) {
 func TestExportRecipeAppFilter(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{Apps: []string{"app-two"}})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Apps: []string{"app-two"}})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -559,7 +559,7 @@ func TestExportGlobalCertBecomesGlobalTask(t *testing.T) {
 		"--quiet global-cert:show key":                              keyPEM,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -607,7 +607,7 @@ func TestExportInlineRedactBlanksSensitiveScalar(t *testing.T) {
 		"--quiet global-cert:show key":                              keyPEM,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{Inline: true, Redact: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true, Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestExportAppCertSkippedWhenLetsencryptActive(t *testing.T) {
 		"--quiet certs:show web key":             keyPEM,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -665,7 +665,7 @@ func TestExportAppCertExportedWhenLetsencryptInactive(t *testing.T) {
 		"--quiet certs:show web key":             keyPEM,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -695,7 +695,7 @@ func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
 	}))()
 
 	// The task ExportApp yields a valid task carrying the real content.
-	bodies, err := MaintenanceCustomPageTask{}.ExportApp("web")
+	bodies, err := MaintenanceCustomPageTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -711,9 +711,9 @@ func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
 	}
 
 	for _, inline := range []bool{false, true} {
-		res, err := ExportRecipe(ExportOptions{Inline: inline})
+		res, err := ExportRecipe(testCtx(), ExportOptions{Inline: inline})
 		if err != nil {
-			t.Fatalf("ExportRecipe(inline=%v): %v", inline, err)
+			t.Fatalf("ExportRecipe(testCtx(), inline=%v): %v", inline, err)
 		}
 		if _, ok := res.Vars["web_maintenance_custom_page"]; ok {
 			t.Errorf("inline=%v: content should be inlined, not lifted into a var", inline)
@@ -736,7 +736,7 @@ func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
 func TestExportHttpAuthUserInlineKeepsTheHash(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
-	res, err := ExportRecipe(ExportOptions{Inline: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -766,7 +766,7 @@ func TestExportHttpAuthUserInlineKeepsTheHash(t *testing.T) {
 func TestExportHttpAuthUserInlineRedactLiftsAndWarns(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
-	res, err := ExportRecipe(ExportOptions{Inline: true, Redact: true})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true, Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -803,7 +803,7 @@ func TestAppCountExcludesGlobalPlay(t *testing.T) {
 	responses["--quiet plugin:list --format json"] = `[{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"c0ffee","branch":"master"}]`
 	defer subprocess.SetExecRunner(fakeDokku(responses))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -820,7 +820,7 @@ func TestExportMissingAppsRecorded(t *testing.T) {
 	// existing app still exports.
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{Apps: []string{"app-one", "nope"}})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Apps: []string{"app-one", "nope"}})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -840,7 +840,7 @@ func TestExportGlobalPropertiesReadsGlobalScope(t *testing.T) {
 		"--quiet git:report --global --format json": `{"global-deploy-branch":"main","global-archive-max-files":"100","global-keep-git-dir":""}`,
 	}))()
 
-	bodies, err := exportGlobalProperties(GitPropertyTask{}, func(property, value string) interface{} {
+	bodies, err := exportGlobalProperties(testCtx(), GitPropertyTask{}, func(property, value string) interface{} {
 		return GitPropertyTask{Global: true, Property: property, Value: value}
 	})
 	if err != nil {
@@ -874,7 +874,7 @@ func TestExportLetsencryptDynamicPropertiesFromAppReport(t *testing.T) {
 		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider":"namecheap","dns-provider-NAMECHEAP_API_USER":"deploy-bot","global-dns-provider-NAMECHEAP_API_KEY":"globalkey","computed-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
 	}))()
 
-	bodies, err := exportProperties(LetsencryptPropertyTask{}, "web", func(app, property, value string) interface{} {
+	bodies, err := exportProperties(testCtx(), LetsencryptPropertyTask{}, "web", func(app, property, value string) interface{} {
 		return LetsencryptPropertyTask{App: app, Property: property, Value: value}
 	})
 	if err != nil {
@@ -903,7 +903,7 @@ func TestExportGlobalLetsencryptDynamicProperties(t *testing.T) {
 		"--quiet letsencrypt:report --global --format json": `{"global-email":"","global-dns-provider":"namecheap","global-dns-provider-NAMECHEAP_API_KEY":"globalkey"}`,
 	}))()
 
-	bodies, err := exportGlobalProperties(LetsencryptPropertyTask{}, func(property, value string) interface{} {
+	bodies, err := exportGlobalProperties(testCtx(), LetsencryptPropertyTask{}, func(property, value string) interface{} {
 		return LetsencryptPropertyTask{Global: true, Property: property, Value: value}
 	})
 	if err != nil {
@@ -937,7 +937,7 @@ func TestExportGlobalLetsencryptCredentialLiftedAsSensitiveInput(t *testing.T) {
 		"--quiet letsencrypt:report --global --format json": `{"global-email":"admin@example.com","global-dns-provider":"namecheap","global-dns-provider-NAMECHEAP_API_KEY":"s3cr3tkey"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -975,7 +975,7 @@ func TestExportLetsencryptBenignPropertyNotLifted(t *testing.T) {
 		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"tok3n"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -1001,7 +1001,7 @@ func TestExportGlobalK3sTokenLiftedAsSensitiveInput(t *testing.T) {
 		"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken","global-ingress-class":"nginx-ingress"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -1035,7 +1035,7 @@ func TestExportGlobalTraefikPasswordLiftedAsSensitiveInput(t *testing.T) {
 		"--quiet traefik:report --global --format json": `{"global-basic-auth-password":"hunter2"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -1064,7 +1064,7 @@ func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
 		"--quiet global-cert:report --global --global-cert-enabled": "false",
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -1085,7 +1085,7 @@ func TestExportPortsUsesStateSet(t *testing.T) {
 
 	// state:set replaces the whole mapping list, so re-applying an export
 	// converges an app that has extra mappings rather than adding to them.
-	bodies, err := PortsTask{}.ExportApp("web")
+	bodies, err := PortsTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -1115,7 +1115,7 @@ func TestExportPortsEmitsNoTaskWithoutMappings(t *testing.T) {
 		"--quiet ports:report web --ports-map": "",
 	}))()
 
-	bodies, err := PortsTask{}.ExportApp("web")
+	bodies, err := PortsTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -78,8 +79,8 @@ func (t GitAuthTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the netrc entry for a host
-func (t GitAuthTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t GitAuthTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the GitAuthTask's inputs without contacting the server.
@@ -95,7 +96,7 @@ func (t GitAuthTask) Validate() error {
 
 // Plan reports the drift the GitAuthTask would produce. dokku has no public
 // way to query netrc state, so the plan reports drift unconditionally.
-func (t GitAuthTask) Plan() PlanResult {
+func (t GitAuthTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
@@ -110,9 +111,9 @@ func (t GitAuthTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "netrc state not probed",
 				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " " + t.Password},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -126,9 +127,9 @@ func (t GitAuthTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "netrc state not probed",
 				Mutations: []string{"git:auth " + t.Host + " (clear)"},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/git_auth_task_integration_test.go
+++ b/tasks/git_auth_task_integration_test.go
@@ -11,7 +11,7 @@ func TestIntegrationGitAuth(t *testing.T) {
 
 	// best-effort cleanup before and after
 	cleanup := func() {
-		(&GitAuthTask{Host: host, State: StateAbsent}).Execute()
+		(&GitAuthTask{Host: host, State: StateAbsent}).Execute(testCtx())
 	}
 	cleanup()
 	t.Cleanup(cleanup)
@@ -23,7 +23,7 @@ func TestIntegrationGitAuth(t *testing.T) {
 		Password: "secret-token",
 		State:    StatePresent,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set git auth: %v", result.Error)
 	}
@@ -36,7 +36,7 @@ func TestIntegrationGitAuth(t *testing.T) {
 
 	// remove credentials
 	unsetTask := GitAuthTask{Host: host, State: StateAbsent}
-	result = unsetTask.Execute()
+	result = unsetTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unset git auth: %v", result.Error)
 	}

--- a/tasks/git_auth_task_test.go
+++ b/tasks/git_auth_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGitAuthTaskInvalidState(t *testing.T) {
 	task := GitAuthTask{Host: "github.com", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -16,7 +16,7 @@ func TestGitAuthTaskInvalidState(t *testing.T) {
 func TestGitAuthTaskMissingHost(t *testing.T) {
 	for _, st := range []State{StatePresent, StateAbsent} {
 		task := GitAuthTask{Username: "u", Password: "p", State: st}
-		result := task.Execute()
+		result := task.Execute(testCtx())
 		if result.Error == nil {
 			t.Fatalf("Execute without host (state=%s) should return an error", st)
 		}
@@ -28,7 +28,7 @@ func TestGitAuthTaskMissingHost(t *testing.T) {
 
 func TestGitAuthTaskPresentMissingUsername(t *testing.T) {
 	task := GitAuthTask{Host: "github.com", Password: "p", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without username should return an error")
 	}
@@ -39,7 +39,7 @@ func TestGitAuthTaskPresentMissingUsername(t *testing.T) {
 
 func TestGitAuthTaskPresentMissingPassword(t *testing.T) {
 	task := GitAuthTask{Host: "github.com", Username: "u", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without password should return an error")
 	}

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -85,8 +86,8 @@ func (t GitFromArchiveTask) Examples() ([]Doc, error) {
 var validGitFromArchiveTypes = map[string]bool{"tar": true, "tar.gz": true, "zip": true}
 
 // Execute deploys a git repository from an archive URL
-func (t GitFromArchiveTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t GitFromArchiveTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the GitFromArchiveTask's inputs without contacting the server.
@@ -111,7 +112,7 @@ func (t GitFromArchiveTask) Validate() error {
 }
 
 // Plan reports the drift the GitFromArchiveTask would produce.
-func (t GitFromArchiveTask) Plan() PlanResult {
+func (t GitFromArchiveTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
@@ -121,7 +122,7 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 			if archiveType == "" {
 				archiveType = "tar"
 			}
-			match, err := checkAppSourceArchive(t.App, archiveType, t.ArchiveURL)
+			match, err := checkAppSourceArchive(ctx, t.App, archiveType, t.ArchiveURL)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -138,9 +139,9 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "archive source drift",
 				Mutations: []string{fmt.Sprintf("git:from-archive %s %s (%s)", t.App, t.ArchiveURL, archiveType)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: "undeployed"}, StateDeployed, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: "undeployed"}, StateDeployed, inputs)
 				},
 			}
 		},
@@ -153,8 +154,8 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 // deploy reports source "tar.gz". A transport-level failure
 // (`*subprocess.SSHError`) is propagated; any other error is treated
 // as "no match" so the planner proposes a re-deploy.
-func checkAppSourceArchive(app, expectedType, expectedURL string) (bool, error) {
-	source, err := getAppDeploySource(app)
+func checkAppSourceArchive(ctx context.Context, app, expectedType, expectedURL string) (bool, error) {
+	source, err := getAppDeploySource(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -168,8 +169,8 @@ func checkAppSourceArchive(app, expectedType, expectedURL string) (bool, error) 
 // ExportApp reconstructs a git-from-archive deploy source from apps:report.
 // dokku records the archive type (tar/tar.gz/zip) as the source and the URL as
 // the metadata; the URL is sensitive, so the engine lifts it into the vars-file.
-func (t GitFromArchiveTask) ExportApp(app string) ([]interface{}, error) {
-	source, err := getAppDeploySource(app)
+func (t GitFromArchiveTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	source, err := getAppDeploySource(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/git_from_archive_task_integration_test.go
+++ b/tasks/git_from_archive_task_integration_test.go
@@ -10,9 +10,9 @@ func TestIntegrationGitFromArchive(t *testing.T) {
 	appName := "docket-test-git-from-archive"
 	archiveURL := "https://github.com/dokku/smoke-test-app/archive/refs/heads/master.tar.gz"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// initial deploy
 	task := GitFromArchiveTask{
@@ -21,7 +21,7 @@ func TestIntegrationGitFromArchive(t *testing.T) {
 		ArchiveType: "tar.gz",
 		State:       "deployed",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to deploy archive: %v", result.Error)
 	}
@@ -33,7 +33,7 @@ func TestIntegrationGitFromArchive(t *testing.T) {
 	}
 
 	// verify deploy-source metadata reflects the archive
-	source, err := getAppDeploySource(appName)
+	source, err := getAppDeploySource(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getAppDeploySource failed: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestIntegrationGitFromArchive(t *testing.T) {
 	}
 
 	// re-deploy with same archive - should be idempotent
-	result = task.Execute()
+	result = task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second deploy: %v", result.Error)
 	}

--- a/tasks/git_from_archive_task_test.go
+++ b/tasks/git_from_archive_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGitFromArchiveTaskInvalidState(t *testing.T) {
 	task := GitFromArchiveTask{App: "test-app", ArchiveURL: "https://example.com/a.tar", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestGitFromArchiveTaskInvalidState(t *testing.T) {
 
 func TestGitFromArchiveTaskMissingApp(t *testing.T) {
 	task := GitFromArchiveTask{ArchiveURL: "https://example.com/a.tar", State: "deployed"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -26,7 +26,7 @@ func TestGitFromArchiveTaskMissingApp(t *testing.T) {
 
 func TestGitFromArchiveTaskMissingArchiveURL(t *testing.T) {
 	task := GitFromArchiveTask{App: "test-app", State: "deployed"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without archive_url should return an error")
 	}
@@ -42,7 +42,7 @@ func TestGitFromArchiveTaskInvalidArchiveType(t *testing.T) {
 		ArchiveType: "bz2",
 		State:       "deployed",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error for invalid archive_type")
 	}
@@ -58,7 +58,7 @@ func TestGitFromArchiveTaskOnlyGitUsername(t *testing.T) {
 		GitUsername: "deploy-bot",
 		State:       "deployed",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when git_username is set without git_email")
 	}
@@ -74,7 +74,7 @@ func TestGitFromArchiveTaskOnlyGitEmail(t *testing.T) {
 		GitEmail:   "deploy@example.com",
 		State:      "deployed",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when git_email is set without git_username")
 	}

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -83,8 +84,8 @@ func (t GitFromImageTask) Examples() ([]Doc, error) {
 }
 
 // Execute deploys a git repository from a docker image
-func (t GitFromImageTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t GitFromImageTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the GitFromImageTask's inputs without contacting the server.
@@ -106,13 +107,13 @@ func (t GitFromImageTask) Validate() error {
 }
 
 // Plan reports the drift the GitFromImageTask would produce.
-func (t GitFromImageTask) Plan() PlanResult {
+func (t GitFromImageTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StateDeployed: func() PlanResult {
-			match, err := checkAppSourceImage(t.App, t.Image)
+			match, err := checkAppSourceImage(ctx, t.App, t.Image)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -135,9 +136,9 @@ func (t GitFromImageTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "image source drift",
 				Mutations: []string{fmt.Sprintf("git:from-image %s %s", t.App, t.Image)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: "undeployed"}, StateDeployed, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: "undeployed"}, StateDeployed, inputs)
 				},
 			}
 		},
@@ -148,8 +149,8 @@ func (t GitFromImageTask) Plan() PlanResult {
 // docker image. A transport-level failure (`*subprocess.SSHError`) is
 // propagated; any other error is treated as "no match" so the planner
 // proposes a re-deploy.
-func checkAppSourceImage(app, expectedImage string) (bool, error) {
-	source, err := getAppDeploySource(app)
+func checkAppSourceImage(ctx context.Context, app, expectedImage string) (bool, error) {
+	source, err := getAppDeploySource(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -163,8 +164,8 @@ func checkAppSourceImage(app, expectedImage string) (bool, error) {
 
 // ExportApp reconstructs a docker-image deploy source from apps:report. The
 // image reference is sensitive, so the engine lifts it into the vars-file.
-func (t GitFromImageTask) ExportApp(app string) ([]interface{}, error) {
-	source, err := getAppDeploySource(app)
+func (t GitFromImageTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	source, err := getAppDeploySource(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/git_from_image_task_integration_test.go
+++ b/tasks/git_from_image_task_integration_test.go
@@ -9,16 +9,16 @@ func TestIntegrationGitFromImage(t *testing.T) {
 
 	appName := "docket-test-fromimage"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	task := GitFromImageTask{
 		App:   appName,
 		Image: "dokku/smoke-test-app:dockerfile",
 		State: StateDeployed,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to deploy from image: %v", result.Error)
 	}
@@ -30,7 +30,7 @@ func TestIntegrationGitFromImage(t *testing.T) {
 	}
 
 	// deploy same image again (idempotent)
-	result = task.Execute()
+	result = task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent deploy failed: %v", result.Error)
 	}

--- a/tasks/git_from_image_task_test.go
+++ b/tasks/git_from_image_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGitFromImageTaskInvalidState(t *testing.T) {
 	task := GitFromImageTask{App: "test-app", Image: "nginx", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -71,7 +71,7 @@ func TestGitFromImageTaskNonDeployedStates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			task := GitFromImageTask{App: "test-app", Image: "nginx", State: tt.state}
-			result := task.Execute()
+			result := task.Execute(testCtx())
 			if result.Error == nil {
 				t.Fatal("expected error for non-deployed state")
 			}

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // GitPropertyTask manages the git configuration for a given dokku application
 type GitPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t GitPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the git property
-func (t GitPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t GitPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // gitPropertyTable maps git property names to the JSON keys emitted by
@@ -102,20 +104,20 @@ func (t GitPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the GitPropertyTask would produce.
-func (t GitPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t GitPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t GitPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t GitPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return GitPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t GitPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t GitPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return GitPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/git_property_task_integration_test.go
+++ b/tasks/git_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationGitPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-git-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -38,7 +38,7 @@ func TestIntegrationGitPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := GitPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "git global " + tc.property,
 					setTask:   GitPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/git_property_task_test.go
+++ b/tasks/git_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGitPropertyTaskInvalidState(t *testing.T) {
 	task := GitPropertyTask{App: "test-app", Property: "deploy-branch", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestGitPropertyTaskInvalidState(t *testing.T) {
 
 func TestGitPropertyTaskMissingApp(t *testing.T) {
 	task := GitPropertyTask{Property: "deploy-branch", Value: "main", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestGitPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "main",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestGitPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestGitPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "main",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,15 +86,15 @@ func (t GitSyncTask) Examples() ([]Doc, error) {
 }
 
 // Execute syncs a git repository to a dokku application
-func (t GitSyncTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t GitSyncTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the GitSyncTask would produce.
-func (t GitSyncTask) Plan() PlanResult {
+func (t GitSyncTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			match, err := checkAppSyncState(t.App, t.Remote, t.GitRef, t.SkipDeployBranch)
+			match, err := checkAppSyncState(ctx, t.App, t.Remote, t.GitRef, t.SkipDeployBranch)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -124,9 +125,9 @@ func (t GitSyncTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "remote/ref drift",
 				Mutations: []string{fmt.Sprintf("git:sync %s %s %s", t.App, t.Remote, ref)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -142,8 +143,8 @@ func (t GitSyncTask) Plan() PlanResult {
 // which case a matching remote is the most that can be verified offline). A
 // transport-level failure (`*subprocess.SSHError`) is propagated; any other
 // error is treated as "no match" so the planner proposes a re-sync.
-func checkAppSyncState(app, expectedRemote, expectedRef string, skipDeployBranch bool) (bool, error) {
-	source, err := getAppDeploySource(app)
+func checkAppSyncState(ctx context.Context, app, expectedRemote, expectedRef string, skipDeployBranch bool) (bool, error) {
+	source, err := getAppDeploySource(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -167,7 +168,7 @@ func checkAppSyncState(app, expectedRemote, expectedRef string, skipDeployBranch
 		return true, nil
 	}
 
-	deployBranch, err := getGitDeployBranch(app)
+	deployBranch, err := getGitDeployBranch(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -182,8 +183,8 @@ func checkAppSyncState(app, expectedRemote, expectedRef string, skipDeployBranch
 // read from `git:report --format json` (JSON key `deploy-branch`). git:sync
 // sets it from the synced ref by default, so it is the offline signal for which
 // ref the app currently tracks.
-func getGitDeployBranch(app string) (string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getGitDeployBranch(ctx context.Context, app string) (string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"git:report", app, "--format", "json"},
 	})
@@ -204,8 +205,8 @@ func getGitDeployBranch(app string) (string, error) {
 // before the last "#" and the ref from the deploy-branch git:sync persisted -
 // not the SHA, which the probe cannot match against a branch or tag. It only
 // emits when the app was last deployed via git:sync.
-func (t GitSyncTask) ExportApp(app string) ([]interface{}, error) {
-	source, err := getAppDeploySource(app)
+func (t GitSyncTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	source, err := getAppDeploySource(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (t GitSyncTask) ExportApp(app string) ([]interface{}, error) {
 	if i := strings.LastIndex(source.SourceMetadata, "#"); i >= 0 {
 		remote = source.SourceMetadata[:i]
 	}
-	ref, err := getGitDeployBranch(app)
+	ref, err := getGitDeployBranch(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/git_sync_task_integration_test.go
+++ b/tasks/git_sync_task_integration_test.go
@@ -9,9 +9,9 @@ func TestIntegrationGitSync(t *testing.T) {
 
 	appName := "docket-test-gitsync"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// Build so dokku records the git-sync deploy source (its metadata is only
 	// written when a build is triggered), which is what the probe reads back.
@@ -21,7 +21,7 @@ func TestIntegrationGitSync(t *testing.T) {
 		Build:  true,
 		State:  StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to sync git: %v", result.Error)
 	}
@@ -34,7 +34,7 @@ func TestIntegrationGitSync(t *testing.T) {
 
 	// A second apply with no pinned ref must converge on the matching remote
 	// rather than re-syncing every time (issue #310).
-	result = task.Execute()
+	result = task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent git sync failed: %v", result.Error)
 	}

--- a/tasks/git_sync_task_test.go
+++ b/tasks/git_sync_task_test.go
@@ -12,7 +12,7 @@ func TestGitSyncTaskInvalidState(t *testing.T) {
 		Remote: "https://example.com/repo",
 		State:  "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -26,7 +26,7 @@ func TestGitSyncInSyncOnRemoteAndDeployBranch(t *testing.T) {
 		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
 	}))()
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", Build: true, State: StatePresent}.Plan()
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", Build: true, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -41,7 +41,7 @@ func TestGitSyncDriftOnRefChange(t *testing.T) {
 		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
 	}))()
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "develop", Build: true, State: StatePresent}.Plan()
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "develop", Build: true, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -55,7 +55,7 @@ func TestGitSyncDriftOnRemoteChange(t *testing.T) {
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/other.git#abc123"}`,
 	}))()
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan()
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan(testCtx())
 	if plan.InSync {
 		t.Fatal("expected drift when the remote differs")
 	}
@@ -66,7 +66,7 @@ func TestGitSyncInSyncWithoutRef(t *testing.T) {
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
 	}))()
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", State: StatePresent}.Plan()
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -82,7 +82,7 @@ func TestGitSyncSkipDeployBranchMatchesOnRemote(t *testing.T) {
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
 	}))()
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", SkipDeployBranch: true, State: StatePresent}.Plan()
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", SkipDeployBranch: true, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -96,7 +96,7 @@ func TestGitSyncDriftWhenNotGitSyncSource(t *testing.T) {
 		"apps:report test-app --format json": `{"app-deploy-source":"","app-deploy-source-metadata":""}`,
 	}))()
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan()
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan(testCtx())
 	if plan.InSync {
 		t.Fatal("expected drift when the app has no git-sync deploy source")
 	}
@@ -108,7 +108,7 @@ func TestGitSyncExportUsesDeployBranchAsRef(t *testing.T) {
 		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
 	}))()
 
-	bodies, err := GitSyncTask{}.ExportApp("test-app")
+	bodies, err := GitSyncTask{}.ExportApp(testCtx(), "test-app")
 	if err != nil {
 		t.Fatalf("ExportApp error: %v", err)
 	}

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // HaproxyPropertyTask manages the haproxy configuration for a given dokku application
 type HaproxyPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t HaproxyPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the haproxy property
-func (t HaproxyPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t HaproxyPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // haproxyPropertyTable maps haproxy property names to the JSON keys emitted
@@ -92,20 +94,20 @@ func (t HaproxyPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the HaproxyPropertyTask would produce.
-func (t HaproxyPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t HaproxyPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t HaproxyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t HaproxyPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return HaproxyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t HaproxyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t HaproxyPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return HaproxyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/haproxy_property_task_integration_test.go
+++ b/tasks/haproxy_property_task_integration_test.go
@@ -23,7 +23,7 @@ func TestIntegrationHaproxyPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := HaproxyPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "haproxy global " + tc.property,
 					setTask:   HaproxyPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/haproxy_property_task_test.go
+++ b/tasks/haproxy_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestHaproxyPropertyTaskInvalidState(t *testing.T) {
 	task := HaproxyPropertyTask{Global: true, Property: "letsencrypt-email", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestHaproxyPropertyTaskInvalidState(t *testing.T) {
 
 func TestHaproxyPropertyTaskMissingApp(t *testing.T) {
 	task := HaproxyPropertyTask{Property: "letsencrypt-email", Value: "admin@example.com", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestHaproxyPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "admin@example.com",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestHaproxyPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestHaproxyPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "admin@example.com",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/http_auth_allowed_ip_task.go
+++ b/tasks/http_auth_allowed_ip_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -86,8 +87,8 @@ func (t HttpAuthAllowedIpTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the app's HTTP auth allowed IPs
-func (t HttpAuthAllowedIpTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t HttpAuthAllowedIpTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the HttpAuthAllowedIpTask's inputs without contacting the server.
@@ -102,13 +103,13 @@ func (t HttpAuthAllowedIpTask) Validate() error {
 }
 
 // Plan reports the drift the HttpAuthAllowedIpTask would produce.
-func (t HttpAuthAllowedIpTask) Plan() PlanResult {
+func (t HttpAuthAllowedIpTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			current, err := getHttpAuthAllowedIps(t.App)
+			current, err := getHttpAuthAllowedIps(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -139,14 +140,14 @@ func (t HttpAuthAllowedIpTask) Plan() PlanResult {
 				Status:    status,
 				Reason:    fmt.Sprintf("%d allowed ip(s) to add", len(toAdd)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			current, err := getHttpAuthAllowedIps(t.App)
+			current, err := getHttpAuthAllowedIps(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -180,9 +181,9 @@ func (t HttpAuthAllowedIpTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%d allowed ip(s) to remove", len(toRemove)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -198,8 +199,8 @@ func (t HttpAuthAllowedIpTask) Plan() PlanResult {
 // fully drift-detectable. A transport-level failure (`*subprocess.SSHError`) is
 // propagated; a dokku-level non-zero exit (e.g. app does not exist) is treated
 // as "no allowed ips"; malformed JSON surfaces as an error.
-func getHttpAuthAllowedIps(appName string) (map[string]bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getHttpAuthAllowedIps(ctx context.Context, appName string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"http-auth:report",
@@ -232,8 +233,8 @@ func getHttpAuthAllowedIps(appName string) (map[string]bool, error) {
 
 // ExportApp reconstructs the app's HTTP-auth allowed IPs, or nil when none are
 // set.
-func (t HttpAuthAllowedIpTask) ExportApp(app string) ([]interface{}, error) {
-	ips, err := getHttpAuthAllowedIps(app)
+func (t HttpAuthAllowedIpTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	ips, err := getHttpAuthAllowedIps(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/http_auth_allowed_ip_task_integration_test.go
+++ b/tasks/http_auth_allowed_ip_task_integration_test.go
@@ -9,13 +9,13 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 	skipIfPluginMissingT(t, "http-auth")
 
 	appName := "docket-test-http-auth-allowed-ip"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	currentIps := func(t *testing.T, label string) map[string]bool {
 		t.Helper()
-		got, err := getHttpAuthAllowedIps(appName)
+		got, err := getHttpAuthAllowedIps(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getHttpAuthAllowedIps failed: %v", label, err)
 		}
@@ -30,7 +30,7 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 
 	// initialize auth so the app has a valid htpasswd/nginx config; add-allowed-ip
 	// flips enabled=true but does not create an htpasswd file on its own
-	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(); result.Error != nil {
+	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to enable http auth: %v", result.Error)
 	}
 
@@ -43,7 +43,7 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 		AllowedIps: []string{firstIp, secondIp},
 		State:      StatePresent,
 	}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add allowed ips: %v", result.Error)
 	}
@@ -57,7 +57,7 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 	assertHas(t, "after add", secondIp, true)
 
 	// adding the same allowed ips again is idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -67,7 +67,7 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 
 	// remove one allowed ip
 	removeTask := HttpAuthAllowedIpTask{App: appName, AllowedIps: []string{secondIp}, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove allowed ip: %v", result.Error)
 	}
@@ -81,7 +81,7 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 	assertHas(t, "after remove second", firstIp, true)
 
 	// removing the same allowed ip again is idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -91,7 +91,7 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 
 	// clearing with empty allowed_ips removes every remaining allowed ip
 	clearTask := HttpAuthAllowedIpTask{App: appName, State: StateAbsent}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear allowed ips: %v", result.Error)
 	}
@@ -103,7 +103,7 @@ func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
 	}
 
 	// clearing again is idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second clear: %v", result.Error)
 	}

--- a/tasks/http_auth_allowed_ip_task_test.go
+++ b/tasks/http_auth_allowed_ip_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestHttpAuthAllowedIpTaskInvalidState(t *testing.T) {
 	task := HttpAuthAllowedIpTask{App: "test-app", AllowedIps: []string{"192.0.2.1"}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestHttpAuthAllowedIpTaskInvalidState(t *testing.T) {
 
 func TestHttpAuthAllowedIpTaskPresentMissingApp(t *testing.T) {
 	task := HttpAuthAllowedIpTask{AllowedIps: []string{"192.0.2.1"}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -26,7 +26,7 @@ func TestHttpAuthAllowedIpTaskPresentMissingApp(t *testing.T) {
 
 func TestHttpAuthAllowedIpTaskAbsentMissingApp(t *testing.T) {
 	task := HttpAuthAllowedIpTask{State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -37,7 +37,7 @@ func TestHttpAuthAllowedIpTaskAbsentMissingApp(t *testing.T) {
 
 func TestHttpAuthAllowedIpTaskPresentEmptyAllowedIps(t *testing.T) {
 	task := HttpAuthAllowedIpTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty allowed_ips and state=present should return an error")
 	}

--- a/tasks/http_auth_domain_task.go
+++ b/tasks/http_auth_domain_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -94,8 +95,8 @@ func (t HttpAuthDomainTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the app's HTTP auth domains
-func (t HttpAuthDomainTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t HttpAuthDomainTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the HttpAuthDomainTask's inputs without contacting the server.
@@ -121,21 +122,21 @@ func (t HttpAuthDomainTask) Validate() error {
 }
 
 // Plan reports the drift the HttpAuthDomainTask would produce.
-func (t HttpAuthDomainTask) Plan() PlanResult {
+func (t HttpAuthDomainTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planHttpAuthDomainsPresent(t) },
-		StateAbsent:  func() PlanResult { return planHttpAuthDomainsAbsent(t) },
-		StateSet:     func() PlanResult { return planHttpAuthDomainsSet(t) },
-		StateClear:   func() PlanResult { return planHttpAuthDomainsClear(t) },
+		StatePresent: func() PlanResult { return planHttpAuthDomainsPresent(ctx, t) },
+		StateAbsent:  func() PlanResult { return planHttpAuthDomainsAbsent(ctx, t) },
+		StateSet:     func() PlanResult { return planHttpAuthDomainsSet(ctx, t) },
+		StateClear:   func() PlanResult { return planHttpAuthDomainsClear(ctx, t) },
 	})
 }
 
 // planHttpAuthDomainsPresent reports drift for the present-state domain add.
-func planHttpAuthDomainsPresent(t HttpAuthDomainTask) PlanResult {
-	current, err := getHttpAuthDomains(t.App)
+func planHttpAuthDomainsPresent(ctx context.Context, t HttpAuthDomainTask) PlanResult {
+	current, err := getHttpAuthDomains(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -166,16 +167,16 @@ func planHttpAuthDomainsPresent(t HttpAuthDomainTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("%d domain(s) to add", len(toAdd)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
 
 // planHttpAuthDomainsAbsent reports drift for the absent-state domain remove.
-func planHttpAuthDomainsAbsent(t HttpAuthDomainTask) PlanResult {
-	current, err := getHttpAuthDomains(t.App)
+func planHttpAuthDomainsAbsent(ctx context.Context, t HttpAuthDomainTask) PlanResult {
+	current, err := getHttpAuthDomains(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -202,16 +203,16 @@ func planHttpAuthDomainsAbsent(t HttpAuthDomainTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d domain(s) to remove", len(toRemove)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }
 
 // planHttpAuthDomainsSet reports drift for the set-state full replacement.
-func planHttpAuthDomainsSet(t HttpAuthDomainTask) PlanResult {
-	current, err := getHttpAuthDomains(t.App)
+func planHttpAuthDomainsSet(ctx context.Context, t HttpAuthDomainTask) PlanResult {
+	current, err := getHttpAuthDomains(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -244,14 +245,14 @@ func planHttpAuthDomainsSet(t HttpAuthDomainTask) PlanResult {
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d domain change(s)", len(mutations)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs("http-auth:set-domains", t.App, t.Domains, StateSet, StateAbsent),
 	}
 }
 
 // planHttpAuthDomainsClear reports drift for the clear-state operation.
-func planHttpAuthDomainsClear(t HttpAuthDomainTask) PlanResult {
-	current, err := getHttpAuthDomains(t.App)
+func planHttpAuthDomainsClear(ctx context.Context, t HttpAuthDomainTask) PlanResult {
+	current, err := getHttpAuthDomains(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -273,7 +274,7 @@ func planHttpAuthDomainsClear(t HttpAuthDomainTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("clear %d domain(s)", len(current)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs("http-auth:set-domains", t.App, nil, StateClear, StatePresent),
 	}
 }
@@ -289,8 +290,8 @@ func planHttpAuthDomainsClear(t HttpAuthDomainTask) PlanResult {
 // (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit (e.g. app
 // does not exist) is treated as "no domains"; malformed JSON surfaces as an
 // error.
-func getHttpAuthDomains(appName string) (map[string]bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getHttpAuthDomains(ctx context.Context, appName string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"http-auth:report",
@@ -323,8 +324,8 @@ func getHttpAuthDomains(appName string) (map[string]bool, error) {
 
 // ExportApp reconstructs the domains HTTP auth is restricted to, or nil when
 // none are set. state:set replaces the whole domain set for an exact match.
-func (t HttpAuthDomainTask) ExportApp(app string) ([]interface{}, error) {
-	domains, err := getHttpAuthDomains(app)
+func (t HttpAuthDomainTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	domains, err := getHttpAuthDomains(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/http_auth_domain_task_integration_test.go
+++ b/tasks/http_auth_domain_task_integration_test.go
@@ -9,13 +9,13 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 	skipIfPluginMissingT(t, "http-auth")
 
 	appName := "docket-test-http-auth-domain"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	currentDomains := func(t *testing.T, label string) map[string]bool {
 		t.Helper()
-		got, err := getHttpAuthDomains(appName)
+		got, err := getHttpAuthDomains(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getHttpAuthDomains failed: %v", label, err)
 		}
@@ -33,13 +33,13 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 
 	// initialize auth so the app has a valid htpasswd/nginx config; add-domain
 	// flips enabled=true but does not create an htpasswd file on its own
-	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(); result.Error != nil {
+	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to enable http auth: %v", result.Error)
 	}
 
 	// http-auth:add-domain / set-domains only accept domains already attached to
 	// the app as nginx vhosts, so attach them first
-	if result := (DomainsTask{App: appName, Domains: []string{firstDomain, secondDomain}, State: StatePresent}).Execute(); result.Error != nil {
+	if result := (DomainsTask{App: appName, Domains: []string{firstDomain, secondDomain}, State: StatePresent}).Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to attach app domains: %v", result.Error)
 	}
 
@@ -49,7 +49,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 		Domains: []string{firstDomain, secondDomain},
 		State:   StatePresent,
 	}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add auth domains: %v", result.Error)
 	}
@@ -63,7 +63,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 	assertHas(t, "after add", secondDomain, true)
 
 	// adding the same auth domains again is idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -73,7 +73,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 
 	// remove one auth domain
 	removeTask := HttpAuthDomainTask{App: appName, Domains: []string{secondDomain}, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove auth domain: %v", result.Error)
 	}
@@ -87,7 +87,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 	assertHas(t, "after remove second", firstDomain, true)
 
 	// removing the same auth domain again is idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -97,7 +97,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 
 	// set replaces the whole list; from {first} to {first, second} adds second
 	setTask := HttpAuthDomainTask{App: appName, Domains: []string{firstDomain, secondDomain}, State: StateSet}
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set auth domains: %v", result.Error)
 	}
@@ -111,7 +111,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 	assertHas(t, "after set", secondDomain, true)
 
 	// setting the same list again is idempotent
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second set: %v", result.Error)
 	}
@@ -121,7 +121,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 
 	// clear removes every auth domain
 	clearTask := HttpAuthDomainTask{App: appName, State: StateClear}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear auth domains: %v", result.Error)
 	}
@@ -136,7 +136,7 @@ func TestIntegrationHttpAuthDomain(t *testing.T) {
 	}
 
 	// clearing again is idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second clear: %v", result.Error)
 	}

--- a/tasks/http_auth_domain_task_test.go
+++ b/tasks/http_auth_domain_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestHttpAuthDomainTaskInvalidState(t *testing.T) {
 	task := HttpAuthDomainTask{App: "test-app", Domains: []string{"app.example.com"}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestHttpAuthDomainTaskInvalidState(t *testing.T) {
 
 func TestHttpAuthDomainTaskPresentMissingApp(t *testing.T) {
 	task := HttpAuthDomainTask{Domains: []string{"app.example.com"}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -26,7 +26,7 @@ func TestHttpAuthDomainTaskPresentMissingApp(t *testing.T) {
 
 func TestHttpAuthDomainTaskAbsentMissingApp(t *testing.T) {
 	task := HttpAuthDomainTask{Domains: []string{"app.example.com"}, State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -37,7 +37,7 @@ func TestHttpAuthDomainTaskAbsentMissingApp(t *testing.T) {
 
 func TestHttpAuthDomainTaskClearMissingApp(t *testing.T) {
 	task := HttpAuthDomainTask{State: StateClear}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -48,7 +48,7 @@ func TestHttpAuthDomainTaskClearMissingApp(t *testing.T) {
 
 func TestHttpAuthDomainTaskPresentEmptyDomains(t *testing.T) {
 	task := HttpAuthDomainTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty domains and state=present should return an error")
 	}
@@ -59,7 +59,7 @@ func TestHttpAuthDomainTaskPresentEmptyDomains(t *testing.T) {
 
 func TestHttpAuthDomainTaskAbsentEmptyDomains(t *testing.T) {
 	task := HttpAuthDomainTask{App: "test-app", State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty domains and state=absent should return an error")
 	}
@@ -70,7 +70,7 @@ func TestHttpAuthDomainTaskAbsentEmptyDomains(t *testing.T) {
 
 func TestHttpAuthDomainTaskSetEmptyDomains(t *testing.T) {
 	task := HttpAuthDomainTask{App: "test-app", State: StateSet}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty domains and state=set should return an error")
 	}

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -86,8 +87,8 @@ func (t HttpAuthTask) Examples() ([]Doc, error) {
 }
 
 // Execute enables or disables HTTP authentication for an app
-func (t HttpAuthTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t HttpAuthTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the HttpAuthTask's inputs without contacting the server.
@@ -111,13 +112,13 @@ func (t HttpAuthTask) Validate() error {
 }
 
 // Plan reports the drift the HttpAuthTask would produce.
-func (t HttpAuthTask) Plan() PlanResult {
+func (t HttpAuthTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			enabled, err := httpAuthEnabled(t.App)
+			enabled, err := httpAuthEnabled(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -140,14 +141,14 @@ func (t HttpAuthTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "http-auth disabled",
 				Mutations: []string{"http-auth:enable " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			enabled, err := httpAuthEnabled(t.App)
+			enabled, err := httpAuthEnabled(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -163,9 +164,9 @@ func (t HttpAuthTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "http-auth enabled",
 				Mutations: []string{"http-auth:disable " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -178,8 +179,8 @@ func (t HttpAuthTask) Plan() PlanResult {
 // proxy property plugins). A transport-level failure (`*subprocess.SSHError`)
 // is propagated; a dokku-level non-zero exit (e.g. app does not exist) is
 // treated as "disabled"; malformed JSON surfaces as an error.
-func httpAuthEnabled(appName string) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func httpAuthEnabled(ctx context.Context, appName string) (bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"http-auth:report",
@@ -222,8 +223,8 @@ type httpAuthState struct {
 // matches those readers: a transport-level failure (`*subprocess.SSHError`) is
 // propagated, a dokku-level non-zero exit (e.g. app does not exist) is treated
 // as "nothing set", and malformed JSON surfaces as an error.
-func getHttpAuthState(appName string) (httpAuthState, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getHttpAuthState(ctx context.Context, appName string) (httpAuthState, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"http-auth:report",
@@ -269,8 +270,8 @@ func getHttpAuthState(appName string) (httpAuthState, error) {
 // an input. A disabled app that still carries users, allowed IPs or auth
 // domains emits `state: absent`, undoing the enable those tasks force; a
 // disabled app with nothing configured emits no task at all.
-func (t HttpAuthTask) ExportApp(app string) ([]interface{}, error) {
-	state, err := getHttpAuthState(app)
+func (t HttpAuthTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	state, err := getHttpAuthState(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/http_auth_task_integration_test.go
+++ b/tasks/http_auth_task_integration_test.go
@@ -10,9 +10,9 @@ func TestIntegrationHttpAuth(t *testing.T) {
 
 	appName := "docket-test-http-auth"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// enable http auth
 	enableTask := HttpAuthTask{
@@ -21,7 +21,7 @@ func TestIntegrationHttpAuth(t *testing.T) {
 		Password: "testpass",
 		State:    StatePresent,
 	}
-	result := enableTask.Execute()
+	result := enableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to enable http auth: %v", result.Error)
 	}
@@ -33,12 +33,12 @@ func TestIntegrationHttpAuth(t *testing.T) {
 	}
 
 	// verify auth is enabled via http-auth:report
-	if enabled, _ := httpAuthEnabled(appName); !enabled {
+	if enabled, _ := httpAuthEnabled(testCtx(), appName); !enabled {
 		t.Error("expected http auth to be enabled after enable")
 	}
 
 	// enabling again should be idempotent
-	result = enableTask.Execute()
+	result = enableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent enable failed: %v", result.Error)
 	}
@@ -54,7 +54,7 @@ func TestIntegrationHttpAuth(t *testing.T) {
 		App:   appName,
 		State: StateAbsent,
 	}
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to disable http auth: %v", result.Error)
 	}
@@ -66,12 +66,12 @@ func TestIntegrationHttpAuth(t *testing.T) {
 	}
 
 	// verify auth is disabled via http-auth:report
-	if enabled, _ := httpAuthEnabled(appName); enabled {
+	if enabled, _ := httpAuthEnabled(testCtx(), appName); enabled {
 		t.Error("expected http auth to be disabled after disable")
 	}
 
 	// disabling again should be idempotent
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent disable failed: %v", result.Error)
 	}
@@ -93,25 +93,25 @@ func TestIntegrationHttpAuthEnableWithoutCredentials(t *testing.T) {
 
 	appName := "docket-test-http-auth-bare"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	task := HttpAuthTask{App: appName, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to enable http auth without credentials: %v", result.Error)
 	}
 	if !result.Changed {
 		t.Error("expected changed=true for enabling http auth")
 	}
-	if enabled, _ := httpAuthEnabled(appName); !enabled {
+	if enabled, _ := httpAuthEnabled(testCtx(), appName); !enabled {
 		t.Error("expected http auth to be enabled after a credential-free enable")
 	}
 
 	// No user was seeded, so the app is enabled with an empty htpasswd - the
 	// state the exporter has to be able to represent.
-	users, err := getHttpAuthUsers(appName)
+	users, err := getHttpAuthUsers(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("getHttpAuthUsers failed: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestIntegrationHttpAuthEnableWithoutCredentials(t *testing.T) {
 		t.Errorf("expected no seeded users, got %v", users)
 	}
 
-	if result := task.Execute(); result.Error != nil {
+	if result := task.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("idempotent enable failed: %v", result.Error)
 	} else if result.Changed {
 		t.Error("expected changed=false for already-enabled http auth")

--- a/tasks/http_auth_task_test.go
+++ b/tasks/http_auth_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestHttpAuthTaskInvalidState(t *testing.T) {
 	task := HttpAuthTask{App: "test-app", Username: "admin", Password: "secret", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -18,7 +18,7 @@ func TestHttpAuthTaskInvalidState(t *testing.T) {
 
 func TestHttpAuthTaskPresentWithoutUsername(t *testing.T) {
 	task := HttpAuthTask{App: "test-app", Password: "secret", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no username")
 	}
@@ -29,7 +29,7 @@ func TestHttpAuthTaskPresentWithoutUsername(t *testing.T) {
 
 func TestHttpAuthTaskPresentWithoutPassword(t *testing.T) {
 	task := HttpAuthTask{App: "test-app", Username: "admin", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no password")
 	}
@@ -55,7 +55,7 @@ func TestHttpAuthTaskEnableOmitsEmptyCredentials(t *testing.T) {
 		"http-auth:report test-app --format json": `{"enabled":"false"}`,
 	}))()
 
-	plan := HttpAuthTask{App: "test-app", State: StatePresent}.Plan()
+	plan := HttpAuthTask{App: "test-app", State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("Plan: %v", plan.Error)
 	}

--- a/tasks/http_auth_user_task.go
+++ b/tasks/http_auth_user_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -180,8 +181,8 @@ func (t HttpAuthUserTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the app's HTTP auth users
-func (t HttpAuthUserTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t HttpAuthUserTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the HttpAuthUserTask's inputs without contacting the server.
@@ -233,15 +234,15 @@ func (t HttpAuthUserTask) Validate() error {
 }
 
 // Plan reports the drift the HttpAuthUserTask would produce.
-func (t HttpAuthUserTask) Plan() PlanResult {
+func (t HttpAuthUserTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planHttpAuthUsersPresent(t) },
-		StateSet:     func() PlanResult { return planHttpAuthUsersSet(t) },
+		StatePresent: func() PlanResult { return planHttpAuthUsersPresent(ctx, t) },
+		StateSet:     func() PlanResult { return planHttpAuthUsersSet(ctx, t) },
 		StateAbsent: func() PlanResult {
-			current, err := getHttpAuthUsers(t.App)
+			current, err := getHttpAuthUsers(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -275,9 +276,9 @@ func (t HttpAuthUserTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -291,8 +292,8 @@ func (t HttpAuthUserTask) Plan() PlanResult {
 // only when update_password forces it. A hash is readable, so a hash user
 // converges on its own - the stored-hash comparison is evaluated first, which
 // also stops update_password from re-importing a hash that already matches.
-func planHttpAuthUsersPresent(t HttpAuthUserTask) PlanResult {
-	current, hashes, res := readHttpAuthUserState(t)
+func planHttpAuthUsersPresent(ctx context.Context, t HttpAuthUserTask) PlanResult {
+	current, hashes, res := readHttpAuthUserState(ctx, t)
 	if res != nil {
 		return *res
 	}
@@ -328,9 +329,9 @@ func planHttpAuthUsersPresent(t HttpAuthUserTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("%d user(s) to add or update", len(toApply)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
@@ -342,8 +343,8 @@ func planHttpAuthUsersPresent(t HttpAuthUserTask) PlanResult {
 // `http-auth:import-users --replace`, which is what that flag is for. A
 // cleartext password cannot be written into the htpasswd stream, so a list with
 // any password user falls back to removing the strays and upserting the rest.
-func planHttpAuthUsersSet(t HttpAuthUserTask) PlanResult {
-	current, hashes, res := readHttpAuthUserState(t)
+func planHttpAuthUsersSet(ctx context.Context, t HttpAuthUserTask) PlanResult {
+	current, hashes, res := readHttpAuthUserState(ctx, t)
 	if res != nil {
 		return *res
 	}
@@ -414,9 +415,9 @@ func planHttpAuthUsersSet(t HttpAuthUserTask) PlanResult {
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d user change(s)", len(mutations)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateSet, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateSet, inputs)
 		},
 	}
 }
@@ -429,8 +430,8 @@ func planHttpAuthUsersSet(t HttpAuthUserTask) PlanResult {
 // plugin answers, so a password-only recipe costs exactly one round trip and is
 // unaffected by the newer export-users command. The hash overlay is read only
 // when it is needed.
-func readHttpAuthUserState(t HttpAuthUserTask) (map[string]bool, map[string]string, *PlanResult) {
-	current, err := getHttpAuthUsers(t.App)
+func readHttpAuthUserState(ctx context.Context, t HttpAuthUserTask) (map[string]bool, map[string]string, *PlanResult) {
+	current, err := getHttpAuthUsers(ctx, t.App)
 	if err != nil {
 		return nil, nil, &PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -446,7 +447,7 @@ func readHttpAuthUserState(t HttpAuthUserTask) (map[string]bool, map[string]stri
 		return current, map[string]string{}, nil
 	}
 
-	hashes, err := getHttpAuthUserHashes(t.App)
+	hashes, err := getHttpAuthUserHashes(ctx, t.App)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -528,8 +529,8 @@ func httpAuthUserUpsertInputs(app string, users []HttpAuthUser, replace bool) []
 // Comparison against a desired hash is byte-exact. A future plugin that
 // normalized entries on import would surface as perpetual drift rather than
 // silent divergence.
-func getHttpAuthUserHashes(appName string) (map[string]string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getHttpAuthUserHashes(ctx context.Context, appName string) (map[string]string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -563,8 +564,8 @@ func getHttpAuthUserHashes(appName string) (map[string]string, error) {
 // string. A transport-level failure (`*subprocess.SSHError`) is propagated; a
 // dokku-level non-zero exit (e.g. app does not exist) is treated as "no users";
 // malformed JSON surfaces as an error.
-func getHttpAuthUsers(appName string) (map[string]bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getHttpAuthUsers(ctx context.Context, appName string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"http-auth:report",
@@ -611,8 +612,8 @@ func getHttpAuthUsers(appName string) (map[string]bool, error) {
 // though every listed user is exported and the sibling exact-set exporters
 // (dokku_http_auth_domain, dokku_domains, dokku_ports) emit `set`: an exported
 // recipe should not silently delete a user that exists only on the destination.
-func (t HttpAuthUserTask) ExportApp(app string) ([]interface{}, error) {
-	hashes, err := getHttpAuthUserHashes(app)
+func (t HttpAuthUserTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	hashes, err := getHttpAuthUserHashes(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {

--- a/tasks/http_auth_user_task_integration_test.go
+++ b/tasks/http_auth_user_task_integration_test.go
@@ -11,13 +11,13 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	skipIfPluginMissingT(t, "http-auth")
 
 	appName := "docket-test-http-auth-user"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	currentUsers := func(t *testing.T, label string) map[string]bool {
 		t.Helper()
-		got, err := getHttpAuthUsers(appName)
+		got, err := getHttpAuthUsers(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getHttpAuthUsers failed: %v", label, err)
 		}
@@ -31,7 +31,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	}
 
 	// enable http auth so the app has an initialized auth config
-	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(); result.Error != nil {
+	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to enable http auth: %v", result.Error)
 	}
 
@@ -44,7 +44,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 		},
 		State: StatePresent,
 	}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add users: %v", result.Error)
 	}
@@ -58,7 +58,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	assertHas(t, "after add", "bob", true)
 
 	// adding the same users again is idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -68,7 +68,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 
 	// present for an existing user without update_password is in sync
 	noop := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "ignored"}}, State: StatePresent}
-	result = noop.Execute()
+	result = noop.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed present no-op: %v", result.Error)
 	}
@@ -78,7 +78,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 
 	// update_password re-issues add-user for an existing user
 	rotate := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "new-pass"}}, UpdatePassword: boolPtr(true), State: StatePresent}
-	result = rotate.Execute()
+	result = rotate.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to rotate password: %v", result.Error)
 	}
@@ -88,7 +88,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 
 	// remove one user
 	removeTask := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "bob"}}, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove user: %v", result.Error)
 	}
@@ -102,7 +102,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	assertHas(t, "after remove bob", "alice", true)
 
 	// removing the same user again is idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -112,7 +112,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 
 	// clearing with empty users removes every remaining user
 	clearTask := HttpAuthUserTask{App: appName, State: StateAbsent}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear users: %v", result.Error)
 	}
@@ -124,7 +124,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	}
 
 	// clearing again is idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second clear: %v", result.Error)
 	}
@@ -144,13 +144,13 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 	skipIfPluginMissingT(t, "http-auth")
 
 	appName := "docket-test-http-auth-hash"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	storedHashes := func(t *testing.T, label string) map[string]string {
 		t.Helper()
-		got, err := getHttpAuthUserHashes(appName)
+		got, err := getHttpAuthUserHashes(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getHttpAuthUserHashes failed: %v", label, err)
 		}
@@ -158,7 +158,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 	}
 	usernames := func(t *testing.T, label string) []string {
 		t.Helper()
-		got, err := getHttpAuthUsers(appName)
+		got, err := getHttpAuthUsers(testCtx(), appName)
 		if err != nil {
 			t.Fatalf("%s: getHttpAuthUsers failed: %v", label, err)
 		}
@@ -175,7 +175,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 		},
 		State: StatePresent,
 	}
-	if result := seed.Execute(); result.Error != nil {
+	if result := seed.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to seed users: %v", result.Error)
 	}
 	seeded := storedHashes(t, "after seed")
@@ -193,7 +193,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 		},
 		State: StatePresent,
 	}
-	if plan := byHash.Plan(); !plan.InSync {
+	if plan := byHash.Plan(testCtx()); !plan.InSync {
 		t.Errorf("a task rebuilt from the stored hashes should be in sync, got status %v reason %q", plan.Status, plan.Reason)
 	}
 
@@ -205,7 +205,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 		Users: []HttpAuthUser{{Username: "carol", Hash: carolHash}},
 		State: StatePresent,
 	}
-	result := addCarol.Execute()
+	result := addCarol.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to import carol: %v", result.Error)
 	}
@@ -230,7 +230,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 		UpdatePassword: boolPtr(true),
 		State:          StatePresent,
 	}
-	if result := repeat.Execute(); result.Error != nil {
+	if result := repeat.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed idempotent import: %v", result.Error)
 	} else if result.Changed {
 		t.Error("expected Changed=false when the stored hash already matches")
@@ -243,7 +243,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 		Users: []HttpAuthUser{{Username: "carol", Hash: seeded["bob"]}},
 		State: StatePresent,
 	}
-	if result := rotate.Execute(); result.Error != nil {
+	if result := rotate.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to rotate carol's hash: %v", result.Error)
 	} else if !result.Changed {
 		t.Error("expected Changed=true when the desired hash differs from the stored one")
@@ -259,7 +259,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 		Users: []HttpAuthUser{{Username: "alice", Hash: seeded["alice"]}},
 		State: StateSet,
 	}
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set users: %v", result.Error)
 	}
@@ -273,7 +273,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 	if got := usernames(t, "after set"); !reflect.DeepEqual(got, []string{"alice"}) {
 		t.Errorf("users after set = %v, want [alice]", got)
 	}
-	if result := setTask.Execute(); result.Error != nil {
+	if result := setTask.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed idempotent set: %v", result.Error)
 	} else if result.Changed {
 		t.Error("expected Changed=false on idempotent set")
@@ -290,7 +290,7 @@ func TestIntegrationHttpAuthUserHashes(t *testing.T) {
 		},
 		State: StateSet,
 	}
-	result = mixed.Execute()
+	result = mixed.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed mixed set: %v", result.Error)
 	}

--- a/tasks/http_auth_user_task_test.go
+++ b/tasks/http_auth_user_task_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestHttpAuthUserTaskInvalidState(t *testing.T) {
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin", Password: "secret"}}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -23,7 +23,7 @@ func TestHttpAuthUserTaskInvalidState(t *testing.T) {
 
 func TestHttpAuthUserTaskPresentMissingApp(t *testing.T) {
 	task := HttpAuthUserTask{Users: []HttpAuthUser{{Username: "admin", Password: "secret"}}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -34,7 +34,7 @@ func TestHttpAuthUserTaskPresentMissingApp(t *testing.T) {
 
 func TestHttpAuthUserTaskAbsentMissingApp(t *testing.T) {
 	task := HttpAuthUserTask{State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -45,7 +45,7 @@ func TestHttpAuthUserTaskAbsentMissingApp(t *testing.T) {
 
 func TestHttpAuthUserTaskPresentEmptyUsers(t *testing.T) {
 	task := HttpAuthUserTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty users and state=present should return an error")
 	}
@@ -56,7 +56,7 @@ func TestHttpAuthUserTaskPresentEmptyUsers(t *testing.T) {
 
 func TestHttpAuthUserTaskPresentWithoutCredential(t *testing.T) {
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin"}}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when a present user has neither password nor hash")
 	}
@@ -67,7 +67,7 @@ func TestHttpAuthUserTaskPresentWithoutCredential(t *testing.T) {
 
 func TestHttpAuthUserTaskSetWithoutCredential(t *testing.T) {
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin"}}, State: StateSet}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when a set user has neither password nor hash")
 	}
@@ -78,7 +78,7 @@ func TestHttpAuthUserTaskSetWithoutCredential(t *testing.T) {
 
 func TestHttpAuthUserTaskSetEmptyUsers(t *testing.T) {
 	task := HttpAuthUserTask{App: "test-app", State: StateSet}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when state=set has no users")
 	}
@@ -95,7 +95,7 @@ func TestHttpAuthUserTaskPasswordAndHashAreExclusive(t *testing.T) {
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "admin", Password: "secret", Hash: "$6$abc$def"}},
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when a user carries both password and hash")
 	}
@@ -114,7 +114,7 @@ func TestHttpAuthUserTaskDuplicateUsernameRejected(t *testing.T) {
 			{Username: "admin", Password: "secret"},
 		},
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when a username is listed twice")
 	}
@@ -150,7 +150,7 @@ func TestHttpAuthUserTaskHashFramingRejected(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{tc.user}}
-			result := task.Execute()
+			result := task.Execute(testCtx())
 			if result.Error == nil {
 				t.Fatalf("expected error for %s", tc.name)
 			}
@@ -173,7 +173,7 @@ func TestHttpAuthUserTaskPasswordUsernameColonAllowed(t *testing.T) {
 
 func TestHttpAuthUserTaskMissingUsername(t *testing.T) {
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Password: "secret"}}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when a user has no username")
 	}
@@ -228,7 +228,7 @@ func TestHttpAuthUserTaskHashInSync(t *testing.T) {
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -252,7 +252,7 @@ func TestHttpAuthUserTaskHashIgnoresUpdatePassword(t *testing.T) {
 		Users:          []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		UpdatePassword: boolPtr(true),
 		State:          StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -269,7 +269,7 @@ func TestHttpAuthUserTaskHashDriftPlansImport(t *testing.T) {
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: "$6$rotated$ROTATED"}},
 		State: StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -304,7 +304,7 @@ func TestHttpAuthUserTaskMixedPlansImportFirst(t *testing.T) {
 			{Username: "alice", Hash: aliceHash},
 		},
 		State: StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -343,7 +343,7 @@ func TestHttpAuthUserTaskPasswordOnlySkipsExportUsers(t *testing.T) {
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Password: "secret"}},
 		State: StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if asked {
 		t.Error("a password-only task must not probe http-auth:export-users")
 	}
@@ -382,7 +382,7 @@ func TestHttpAuthUserTaskExecuteStreamsEntries(t *testing.T) {
 			{Username: "carol", Hash: "$6$cccc$CCCC"},
 		},
 		State: StatePresent,
-	}.Execute()
+	}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("Execute: %v", result.Error)
 	}
@@ -401,7 +401,7 @@ func TestHttpAuthUserTaskSetAllHashesUsesReplace(t *testing.T) {
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StateSet,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -435,7 +435,7 @@ func TestHttpAuthUserTaskSetWithPasswordAvoidsReplace(t *testing.T) {
 			{Username: "carol", Password: "secret"},
 		},
 		State: StateSet,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -463,7 +463,7 @@ func TestHttpAuthUserTaskSetInSync(t *testing.T) {
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StateSet,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -479,7 +479,7 @@ func TestHttpAuthUserTaskSetReportsSetState(t *testing.T) {
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StateSet,
-	}.Execute()
+	}.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("Execute: %v", result.Error)
 	}
@@ -501,7 +501,7 @@ func TestGetHttpAuthUserHashesSkipsMalformedLines(t *testing.T) {
 		"--quiet http-auth:export-users test-app": "# a comment\n\nalice:" + aliceHash + "\ntruncated:\nnoseparator\nbob:$6$b:b$BB\n",
 	}))()
 
-	got, err := getHttpAuthUserHashes("test-app")
+	got, err := getHttpAuthUserHashes(testCtx(), "test-app")
 	if err != nil {
 		t.Fatalf("getHttpAuthUserHashes: %v", err)
 	}

--- a/tasks/integration_helpers_test.go
+++ b/tasks/integration_helpers_test.go
@@ -14,7 +14,7 @@ func TestMain(m *testing.M) {
 }
 
 func dokkuAvailable() bool {
-	_, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	_, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"version"},
 	})
@@ -30,7 +30,7 @@ func skipIfNoDokkuT(t *testing.T) {
 }
 
 func dokkuPluginInstalled(plugin string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"plugin:list"},
 	})
@@ -55,7 +55,7 @@ func skipIfPluginMissingT(t *testing.T, plugin string) {
 }
 
 func dockerLinkSupported() bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"version", "--format", "{{.Server.Version}}"},
 	})
@@ -82,24 +82,24 @@ func dockerLinkSupported() bool {
 	// Docker >= 29 requires DOCKER_KEEP_DEPRECATED_LEGACY_LINKS_ENV_VARS=1
 	// on the daemon. Test by creating two containers with --link and checking
 	// if the link env vars are present.
-	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"rm", "-f", "docket-link-test-target", "docket-link-test-client"},
 	})
 
-	_, err = subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	_, err = subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"run", "-d", "--name", "docket-link-test-target", "alpine", "sleep", "30"},
 	})
 	if err != nil {
 		return false
 	}
-	defer subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	defer subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"rm", "-f", "docket-link-test-target", "docket-link-test-client"},
 	})
 
-	result, err = subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err = subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"run", "--rm", "--name", "docket-link-test-client", "--link", "docket-link-test-target:target", "alpine", "env"},
 	})
@@ -121,7 +121,7 @@ func skipIfDockerLinkUnsupportedT(t *testing.T) {
 // CONTAINER files (e.g., /home/dokku/APP/CONTAINER.web.1) which are the
 // authoritative source for the current deployment's containers.
 func getCurrentContainerIDs(appName, processType string) ([]string, error) {
-	scale, err := getPsScale(appName)
+	scale, err := getPsScale(testCtx(), appName)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func getCurrentContainerIDs(appName, processType string) ([]string, error) {
 	}
 	var ids []string
 	for i := 1; i <= count; i++ {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "cat",
 			Args:    []string{fmt.Sprintf("/home/dokku/%s/CONTAINER.%s.%d", appName, processType, i)},
 		})

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -10,8 +10,8 @@ func TestIntegrationGetTasksFullWorkflow(t *testing.T) {
 	appName := "docket-test-workflow"
 
 	// ensure clean state
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	data := []byte(`---
 - tasks:
@@ -28,7 +28,7 @@ func TestIntegrationGetTasksFullWorkflow(t *testing.T) {
 
 	for _, name := range tasks.Keys() {
 		task := tasks.Get(name)
-		state := task.Execute()
+		state := task.Execute(testCtx())
 		if state.Error != nil {
 			t.Fatalf("task %q failed: %v", name, state.Error)
 		}
@@ -43,8 +43,8 @@ func TestIntegrationMultiTaskWorkflow(t *testing.T) {
 
 	appName := "docket-test-multi"
 
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	data := []byte(`---
 - tasks:
@@ -75,7 +75,7 @@ func TestIntegrationMultiTaskWorkflow(t *testing.T) {
 
 	for _, name := range tasks.Keys() {
 		task := tasks.Get(name)
-		state := task.Execute()
+		state := task.Execute(testCtx())
 		if state.Error != nil {
 			t.Fatalf("task %q failed: %v", name, state.Error)
 		}

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // LetsencryptPropertyTask manages the letsencrypt configuration for a given dokku application
 type LetsencryptPropertyTask SensitivePropertyFields
 
@@ -83,8 +85,8 @@ func (t LetsencryptPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the letsencrypt property
-func (t LetsencryptPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t LetsencryptPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // letsencryptPropertyTable maps letsencrypt property names to the JSON keys
@@ -115,20 +117,20 @@ func (t LetsencryptPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the LetsencryptPropertyTask would produce.
-func (t LetsencryptPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t LetsencryptPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t LetsencryptPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t LetsencryptPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return LetsencryptPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t LetsencryptPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t LetsencryptPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return LetsencryptPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/letsencrypt_property_task_integration_test.go
+++ b/tasks/letsencrypt_property_task_integration_test.go
@@ -9,9 +9,9 @@ func TestIntegrationLetsencryptPropertyAll(t *testing.T) {
 	skipIfPluginMissingT(t, "letsencrypt")
 
 	appName := "docket-test-letsencrypt"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -44,7 +44,7 @@ func TestIntegrationLetsencryptPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := LetsencryptPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "letsencrypt global " + tc.property,
 					setTask:   LetsencryptPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/letsencrypt_property_task_test.go
+++ b/tasks/letsencrypt_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLetsencryptPropertyTaskInvalidState(t *testing.T) {
 	task := LetsencryptPropertyTask{App: "test-app", Property: "email", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestLetsencryptPropertyTaskInvalidState(t *testing.T) {
 
 func TestLetsencryptPropertyTaskMissingApp(t *testing.T) {
 	task := LetsencryptPropertyTask{Property: "email", Value: "admin@example.com", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestLetsencryptPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "admin@example.com",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestLetsencryptPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestLetsencryptPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "admin@example.com",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -70,8 +71,8 @@ func (t LetsencryptTask) Examples() ([]Doc, error) {
 }
 
 // Execute enables or disables letsencrypt
-func (t LetsencryptTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t LetsencryptTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the LetsencryptTask's inputs without contacting the server.
@@ -83,13 +84,13 @@ func (t LetsencryptTask) Validate() error {
 }
 
 // Plan reports the drift the LetsencryptTask would produce.
-func (t LetsencryptTask) Plan() PlanResult {
+func (t LetsencryptTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			active, err := letsencryptActive(t.App)
+			active, err := letsencryptActive(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -105,14 +106,14 @@ func (t LetsencryptTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "letsencrypt not active",
 				Mutations: []string{"letsencrypt:enable " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			active, err := letsencryptActive(t.App)
+			active, err := letsencryptActive(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -128,9 +129,9 @@ func (t LetsencryptTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "letsencrypt active",
 				Mutations: []string{"letsencrypt:disable " + t.App},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -139,8 +140,8 @@ func (t LetsencryptTask) Plan() PlanResult {
 
 // ExportApp emits a dokku_letsencrypt task when letsencrypt is active for the
 // app (it is inactive by default, so a normal app needs no task).
-func (t LetsencryptTask) ExportApp(app string) ([]interface{}, error) {
-	active, err := letsencryptActive(app)
+func (t LetsencryptTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	active, err := letsencryptActive(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -152,8 +153,8 @@ func (t LetsencryptTask) ExportApp(app string) ([]interface{}, error) {
 
 // letsencryptActive reports whether letsencrypt is currently active for an app.
 // Mirrors the upstream `dokku letsencrypt:active <app>` output ("true"/"false").
-func letsencryptActive(app string) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func letsencryptActive(ctx context.Context, app string) (bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "letsencrypt:active", app},
 	})

--- a/tasks/letsencrypt_task_integration_test.go
+++ b/tasks/letsencrypt_task_integration_test.go
@@ -15,12 +15,12 @@ func TestIntegrationLetsencrypt(t *testing.T) {
 	skipIfPluginMissingT(t, "letsencrypt")
 
 	appName := "docket-test-letsencrypt"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// fresh app should not be active
-	active, err := letsencryptActive(appName)
+	active, err := letsencryptActive(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("letsencryptActive failed: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestIntegrationLetsencrypt(t *testing.T) {
 
 	// disable on a non-active app is a no-op
 	disableTask := LetsencryptTask{App: appName, State: StateAbsent}
-	result := disableTask.Execute()
+	result := disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("disable on inactive app returned error: %v", result.Error)
 	}
@@ -42,7 +42,7 @@ func TestIntegrationLetsencrypt(t *testing.T) {
 	}
 
 	// disable again - still idempotent
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("second disable returned error: %v", result.Error)
 	}

--- a/tasks/letsencrypt_task_test.go
+++ b/tasks/letsencrypt_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLetsencryptTaskInvalidState(t *testing.T) {
 	task := LetsencryptTask{App: "test-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestLetsencryptTaskInvalidState(t *testing.T) {
 
 func TestLetsencryptTaskPresentMissingApp(t *testing.T) {
 	task := LetsencryptTask{State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -26,7 +26,7 @@ func TestLetsencryptTaskPresentMissingApp(t *testing.T) {
 
 func TestLetsencryptTaskAbsentMissingApp(t *testing.T) {
 	task := LetsencryptTask{State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // LogsPropertyTask manages the logs configuration for a given dokku application
 type LogsPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t LogsPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the logs property
-func (t LogsPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t LogsPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // logsPropertyTable maps logs property names to the JSON keys emitted by
@@ -92,20 +94,20 @@ func (t LogsPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the LogsPropertyTask would produce.
-func (t LogsPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t LogsPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t LogsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t LogsPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return LogsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t LogsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t LogsPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return LogsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/logs_property_task_integration_test.go
+++ b/tasks/logs_property_task_integration_test.go
@@ -10,18 +10,18 @@ func TestIntegrationLogsPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-logs-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	networkName := "docket-test-logs-vector-net"
-	if _, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	if _, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"network", "create", networkName},
 	}); err != nil {
 		t.Logf("docker network create %s failed: %v (vector-networks subtest will be skipped)", networkName, err)
 	} else {
-		defer subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		defer subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "docker",
 			Args:    []string{"network", "rm", networkName},
 		})
@@ -52,7 +52,7 @@ func TestIntegrationLogsPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := LogsPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "logs global " + tc.property,
 					setTask:   LogsPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/logs_property_task_test.go
+++ b/tasks/logs_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLogsPropertyTaskInvalidState(t *testing.T) {
 	task := LogsPropertyTask{App: "test-app", Property: "max-size", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestLogsPropertyTaskInvalidState(t *testing.T) {
 
 func TestLogsPropertyTaskMissingApp(t *testing.T) {
 	task := LogsPropertyTask{Property: "max-size", Value: "100m", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestLogsPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "100m",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestLogsPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestLogsPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "100m",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -303,7 +304,12 @@ type PlanResult struct {
 	// server state. nil when InSync. Captures any probed state needed for
 	// the mutation so the apply path does not re-probe. Unexported so
 	// formatters and JSON consumers cannot accidentally invoke it.
-	apply func() TaskOutputState
+	//
+	// It takes the context rather than capturing the one Plan ran under,
+	// because ExecutePlan is invoked separately and could be handed a
+	// different one; capturing would silently apply against a stale target
+	// or an already-cancelled deadline.
+	apply func(ctx context.Context) TaskOutputState
 }
 
 // planErr wraps an input-validation error in a PlanResult. Tasks return it
@@ -324,12 +330,16 @@ type Task interface {
 
 	// Plan reports the drift the task would produce against the live server,
 	// without mutating it. Plan must never call mutating dokku commands.
-	Plan() PlanResult
+	//
+	// ctx carries the per-invocation state a task needs: cancellation, and the
+	// target the dokku commands run against. Pass it to every subprocess call
+	// rather than reaching for context.Background().
+	Plan(ctx context.Context) PlanResult
 
 	// Execute executes the task. Conventionally implemented as
-	// ExecutePlan(t.Plan()) so probing happens once and the per-state
+	// ExecutePlan(ctx, t.Plan(ctx)) so probing happens once and the per-state
 	// mutation logic lives only in Plan().
-	Execute() TaskOutputState
+	Execute(ctx context.Context) TaskOutputState
 }
 
 // InputValidator is an optional interface a task implements to expose

--- a/tasks/maintenance_custom_page_task.go
+++ b/tasks/maintenance_custom_page_task.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -98,8 +99,8 @@ func (t MaintenanceCustomPageTask) Examples() ([]Doc, error) {
 }
 
 // Execute installs or removes the custom maintenance page
-func (t MaintenanceCustomPageTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t MaintenanceCustomPageTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the MaintenanceCustomPageTask's inputs without contacting the server.
@@ -117,7 +118,7 @@ func (t MaintenanceCustomPageTask) Validate() error {
 }
 
 // Plan reports the drift the MaintenanceCustomPageTask would produce.
-func (t MaintenanceCustomPageTask) Plan() PlanResult {
+func (t MaintenanceCustomPageTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
@@ -132,7 +133,7 @@ func (t MaintenanceCustomPageTask) Plan() PlanResult {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 
-			current, reported, err := maintenanceCustomPageState(t.App)
+			current, reported, err := maintenanceCustomPageState(ctx, t.App)
 			if err != nil {
 				var sshErr *subprocess.SSHError
 				if errors.As(err, &sshErr) {
@@ -168,14 +169,14 @@ func (t MaintenanceCustomPageTask) Plan() PlanResult {
 				Status:    status,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("set custom maintenance page for %s", t.App)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			current, reported, err := maintenanceCustomPageState(t.App)
+			current, reported, err := maintenanceCustomPageState(ctx, t.App)
 			if err != nil {
 				var sshErr *subprocess.SSHError
 				if errors.As(err, &sshErr) {
@@ -200,9 +201,9 @@ func (t MaintenanceCustomPageTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("remove custom maintenance page for %s", t.App)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -329,8 +330,8 @@ func maintenanceTarballChecksum(tarBytes []byte) (string, error) {
 // the key is absent. A transport-level SSH failure is returned as an error so
 // Plan() can short-circuit; a dokku-level failure is also returned so callers
 // can fall back to applying unconditionally.
-func maintenanceCustomPageState(app string) (checksum string, reported bool, err error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func maintenanceCustomPageState(ctx context.Context, app string) (checksum string, reported bool, err error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"maintenance:report", app, "--format", "json"},
 	})
@@ -353,8 +354,8 @@ func maintenanceCustomPageState(app string) (checksum string, reported bool, err
 // callback. The export engine prefers ExportAppReport when present, so the
 // dropped-assets diagnostic reaches ExportReport.Warnings rather than being
 // discarded here.
-func (t MaintenanceCustomPageTask) ExportApp(app string) ([]interface{}, error) {
-	return t.exportApp(app, func(string) {})
+func (t MaintenanceCustomPageTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return t.exportApp(ctx, app, func(string) {})
 }
 
 // ExportAppReport is the diagnostics-aware form of ExportApp (the
@@ -362,8 +363,8 @@ func (t MaintenanceCustomPageTask) ExportApp(app string) ([]interface{}, error) 
 // through the engine's warn callback (wired to ExportReport.Warnings) instead
 // of a raw log line, so the warning is rendered and masked like every other
 // export diagnostic.
-func (t MaintenanceCustomPageTask) ExportAppReport(app string, warn func(msg string)) ([]interface{}, error) {
-	return t.exportApp(app, warn)
+func (t MaintenanceCustomPageTask) ExportAppReport(ctx context.Context, app string, warn func(msg string)) ([]interface{}, error) {
+	return t.exportApp(ctx, app, warn)
 }
 
 // exportApp emits a dokku_maintenance_custom_page task when the app has a custom
@@ -377,8 +378,8 @@ func (t MaintenanceCustomPageTask) ExportAppReport(app string, warn func(msg str
 // transport-level SSH failure propagates as a warning. When the archive carries
 // files beyond maintenance.html (which the single-Content task cannot represent)
 // warn is invoked with the dropped-assets notice.
-func (t MaintenanceCustomPageTask) exportApp(app string, warn func(msg string)) ([]interface{}, error) {
-	checksum, reported, err := maintenanceCustomPageState(app)
+func (t MaintenanceCustomPageTask) exportApp(ctx context.Context, app string, warn func(msg string)) ([]interface{}, error) {
+	checksum, reported, err := maintenanceCustomPageState(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -390,7 +391,7 @@ func (t MaintenanceCustomPageTask) exportApp(app string, warn func(msg string)) 
 		return nil, nil
 	}
 
-	content, extraAssets, err := maintenanceCustomPageExport(app)
+	content, extraAssets, err := maintenanceCustomPageExport(ctx, app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -410,8 +411,8 @@ func (t MaintenanceCustomPageTask) exportApp(app string, warn func(msg string)) 
 // returns the contents of the root-level maintenance.html and whether the archive
 // carried any additional files (which the single-content task shape cannot
 // represent, so they are dropped - see ExportSupport).
-func maintenanceCustomPageExport(app string) (content string, extraAssets bool, err error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func maintenanceCustomPageExport(ctx context.Context, app string) (content string, extraAssets bool, err error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "maintenance:custom-page-export", app},
 	})

--- a/tasks/maintenance_custom_page_task_integration_test.go
+++ b/tasks/maintenance_custom_page_task_integration_test.go
@@ -50,13 +50,13 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 
 	appName := "docket-test-maintenance-custom-page"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// A freshly-created app has no custom page. If the installed plugin does
 	// not report the checksum, idempotency cannot be verified, so skip.
-	checksum, reported, err := maintenanceCustomPageState(appName)
+	checksum, reported, err := maintenanceCustomPageState(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("maintenanceCustomPageState failed: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 	// --- inline content source ---
 	content := "<html><body>inline down for maintenance</body></html>\n"
 	setInline := MaintenanceCustomPageTask{App: appName, Content: content, State: StatePresent}
-	result := setInline.Execute()
+	result := setInline.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set inline custom page: %v", result.Error)
 	}
@@ -90,7 +90,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("maintenanceTarballChecksum failed: %v", err)
 	}
-	gotInline, _, err := maintenanceCustomPageState(appName)
+	gotInline, _, err := maintenanceCustomPageState(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("maintenanceCustomPageState failed: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 	}
 
 	// reapply identical content - idempotent
-	result = setInline.Execute()
+	result = setInline.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second inline set: %v", result.Error)
 	}
@@ -109,7 +109,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 
 	// change the content - should update
 	setInlineV2 := MaintenanceCustomPageTask{App: appName, Content: content + "<!-- v2 -->\n", State: StatePresent}
-	result = setInlineV2.Execute()
+	result = setInlineV2.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to update inline custom page: %v", result.Error)
 	}
@@ -123,7 +123,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 		"assets/style.css": "body { color: #333; }\n",
 	})
 	setTarball := MaintenanceCustomPageTask{App: appName, Tarball: tarPath, State: StatePresent}
-	result = setTarball.Execute()
+	result = setTarball.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set tarball custom page: %v", result.Error)
 	}
@@ -139,7 +139,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("maintenanceTarballChecksum failed: %v", err)
 	}
-	gotTarball, _, err := maintenanceCustomPageState(appName)
+	gotTarball, _, err := maintenanceCustomPageState(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("maintenanceCustomPageState failed: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 	}
 
 	// reapply identical tarball - idempotent
-	result = setTarball.Execute()
+	result = setTarball.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second tarball set: %v", result.Error)
 	}
@@ -158,7 +158,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 
 	// --- remove ---
 	removeTask := MaintenanceCustomPageTask{App: appName, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove custom page: %v", result.Error)
 	}
@@ -168,7 +168,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 	if result.State != StateAbsent {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
-	gotAfter, _, err := maintenanceCustomPageState(appName)
+	gotAfter, _, err := maintenanceCustomPageState(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("maintenanceCustomPageState failed: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 	}
 
 	// remove again - idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}
@@ -192,20 +192,20 @@ func TestIntegrationExportMaintenanceCustomPageRoundTrip(t *testing.T) {
 
 	appName := "docket-test-maintenance-custom-page-export"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// The export detects the page via the reported checksum. If the installed
 	// plugin does not report it, there is nothing to detect, so skip.
-	if _, reported, err := maintenanceCustomPageState(appName); err != nil {
+	if _, reported, err := maintenanceCustomPageState(testCtx(), appName); err != nil {
 		t.Fatalf("maintenanceCustomPageState failed: %v", err)
 	} else if !reported {
 		t.Skip("skipping: installed dokku-maintenance does not report custom-page-sha256")
 	}
 
 	// An app with no custom page exports nothing.
-	if bodies, err := (MaintenanceCustomPageTask{}).ExportApp(appName); err != nil {
+	if bodies, err := (MaintenanceCustomPageTask{}).ExportApp(testCtx(), appName); err != nil {
 		t.Fatalf("ExportApp with no custom page failed: %v", err)
 	} else if len(bodies) != 0 {
 		t.Fatalf("expected no export bodies for an app without a custom page, got %d", len(bodies))
@@ -213,7 +213,7 @@ func TestIntegrationExportMaintenanceCustomPageRoundTrip(t *testing.T) {
 
 	content := "<html><body>exported down for maintenance</body></html>\n"
 	set := MaintenanceCustomPageTask{App: appName, Content: content, State: StatePresent}
-	if result := set.Execute(); result.Error != nil {
+	if result := set.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to set custom page: %v", result.Error)
 	}
 
@@ -221,7 +221,7 @@ func TestIntegrationExportMaintenanceCustomPageRoundTrip(t *testing.T) {
 	// back via maintenance:custom-page-export, so the exported body carries the
 	// real Content. An older dokku-maintenance without the export command would
 	// instead carry an empty Content for the engine to lift into an input.
-	bodies, err := (MaintenanceCustomPageTask{}).ExportApp(appName)
+	bodies, err := (MaintenanceCustomPageTask{}).ExportApp(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("ExportApp failed: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestIntegrationExportMaintenanceCustomPageRoundTrip(t *testing.T) {
 		got.Content = content
 	}
 	got.State = StatePresent
-	plan := got.Plan()
+	plan := got.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("Plan after export failed: %v", plan.Error)
 	}

--- a/tasks/maintenance_custom_page_task_test.go
+++ b/tasks/maintenance_custom_page_task_test.go
@@ -31,7 +31,7 @@ func TestMaintenanceCustomPageExportReportWarnsOnExtraAssets(t *testing.T) {
 	}))()
 
 	var warnings []string
-	bodies, err := MaintenanceCustomPageTask{}.ExportAppReport("myapp", func(msg string) {
+	bodies, err := MaintenanceCustomPageTask{}.ExportAppReport(testCtx(), "myapp", func(msg string) {
 		warnings = append(warnings, msg)
 	})
 	if err != nil {
@@ -67,7 +67,7 @@ func TestMaintenanceCustomPageExportReportNoExtraAssets(t *testing.T) {
 	}))()
 
 	var warnings []string
-	if _, err := (MaintenanceCustomPageTask{}).ExportAppReport("myapp", func(msg string) {
+	if _, err := (MaintenanceCustomPageTask{}).ExportAppReport(testCtx(), "myapp", func(msg string) {
 		warnings = append(warnings, msg)
 	}); err != nil {
 		t.Fatalf("ExportAppReport error: %v", err)
@@ -117,7 +117,7 @@ const (
 
 func TestMaintenanceCustomPageTaskInvalidState(t *testing.T) {
 	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -125,7 +125,7 @@ func TestMaintenanceCustomPageTaskInvalidState(t *testing.T) {
 
 func TestMaintenanceCustomPageTaskMissingApp(t *testing.T) {
 	task := MaintenanceCustomPageTask{Content: maintenanceTestPage, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -136,7 +136,7 @@ func TestMaintenanceCustomPageTaskMissingApp(t *testing.T) {
 
 func TestMaintenanceCustomPageTaskPresentMissingSource(t *testing.T) {
 	task := MaintenanceCustomPageTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without content or tarball should return an error")
 	}
@@ -147,7 +147,7 @@ func TestMaintenanceCustomPageTaskPresentMissingSource(t *testing.T) {
 
 func TestMaintenanceCustomPageTaskPresentBothSources(t *testing.T) {
 	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, Tarball: "/tmp/page.tar", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with both content and tarball should return an error")
 	}
@@ -158,7 +158,7 @@ func TestMaintenanceCustomPageTaskPresentBothSources(t *testing.T) {
 
 func TestMaintenanceCustomPageTaskAbsentWithContent(t *testing.T) {
 	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute absent with content should return an error")
 	}
@@ -169,7 +169,7 @@ func TestMaintenanceCustomPageTaskAbsentWithContent(t *testing.T) {
 
 func TestMaintenanceCustomPageTaskAbsentWithTarball(t *testing.T) {
 	task := MaintenanceCustomPageTask{App: "test-app", Tarball: "/tmp/page.tar", State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute absent with tarball should return an error")
 	}

--- a/tasks/maintenance_task.go
+++ b/tasks/maintenance_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/dokku/docket/subprocess"
@@ -11,10 +12,10 @@ import (
 // strips the `maintenance-` prefix from JSON report keys). A probe failure
 // returns an error, which planToggle treats as drift unless it is an SSH
 // transport failure, which surfaces as a plan error.
-func maintenanceEnabled(ctx ToggleContext) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func maintenanceEnabled(ctx context.Context, tc ToggleContext) (bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    []string{"maintenance:report", ctx.App, "--format", "json"},
+		Args:    []string{"maintenance:report", tc.App, "--format", "json"},
 	})
 	if err != nil {
 		return false, err
@@ -30,8 +31,8 @@ func maintenanceEnabled(ctx ToggleContext) (bool, error) {
 
 // ExportApp emits a dokku_maintenance task only when maintenance mode is on
 // (it is off by default, so a normal app needs no task).
-func (t MaintenanceTask) ExportApp(app string) ([]interface{}, error) {
-	on, err := maintenanceEnabled(ToggleContext{App: app})
+func (t MaintenanceTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	on, err := maintenanceEnabled(ctx, ToggleContext{App: app})
 	if err != nil {
 		return nil, err
 	}
@@ -98,13 +99,13 @@ func (t MaintenanceTask) Examples() ([]Doc, error) {
 }
 
 // Execute enables or disables maintenance mode
-func (t MaintenanceTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t MaintenanceTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the MaintenanceTask would produce.
-func (t MaintenanceTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, "maintenance:enable", "maintenance:disable", maintenanceEnabled)
+func (t MaintenanceTask) Plan(ctx context.Context) PlanResult {
+	return planToggle(ctx, t.State, t.App, "maintenance:enable", "maintenance:disable", maintenanceEnabled)
 }
 
 // init registers the MaintenanceTask with the task registry

--- a/tasks/maintenance_task_integration_test.go
+++ b/tasks/maintenance_task_integration_test.go
@@ -10,13 +10,13 @@ func TestIntegrationMaintenance(t *testing.T) {
 
 	appName := "docket-test-maintenance"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// enable maintenance mode
 	enableTask := MaintenanceTask{App: appName, State: StatePresent}
-	result := enableTask.Execute()
+	result := enableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to enable maintenance: %v", result.Error)
 	}
@@ -25,7 +25,7 @@ func TestIntegrationMaintenance(t *testing.T) {
 	}
 
 	// enable again - idempotent
-	result = enableTask.Execute()
+	result = enableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second enable: %v", result.Error)
 	}
@@ -35,7 +35,7 @@ func TestIntegrationMaintenance(t *testing.T) {
 
 	// disable maintenance mode
 	disableTask := MaintenanceTask{App: appName, State: StateAbsent}
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to disable maintenance: %v", result.Error)
 	}
@@ -44,7 +44,7 @@ func TestIntegrationMaintenance(t *testing.T) {
 	}
 
 	// disable again - idempotent
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second disable: %v", result.Error)
 	}

--- a/tasks/maintenance_task_test.go
+++ b/tasks/maintenance_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestMaintenanceTaskInvalidState(t *testing.T) {
 	task := MaintenanceTask{App: "test-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -27,7 +27,7 @@ func TestMaintenanceTaskPlanSurfacesSSHError(t *testing.T) {
 		}
 	})()
 
-	plan := MaintenanceTask{App: "web", State: StatePresent}.Plan()
+	plan := MaintenanceTask{App: "web", State: StatePresent}.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // NetworkPropertyTask manages the network property for a given dokku application
 type NetworkPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t NetworkPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the network property
-func (t NetworkPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t NetworkPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // networkPropertyTable maps network property names to the JSON keys emitted
@@ -101,20 +103,20 @@ func (t NetworkPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the NetworkPropertyTask would produce.
-func (t NetworkPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t NetworkPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t NetworkPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t NetworkPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return NetworkPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t NetworkPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t NetworkPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return NetworkPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/network_property_task_integration_test.go
+++ b/tasks/network_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationNetworkPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-network"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -38,7 +38,7 @@ func TestIntegrationNetworkPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := NetworkPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "network global " + tc.property,
 					setTask:   NetworkPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/network_property_task_test.go
+++ b/tasks/network_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNetworkPropertyTaskInvalidState(t *testing.T) {
 	task := NetworkPropertyTask{App: "test-app", Property: "attach-post-create", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestNetworkPropertyTaskInvalidState(t *testing.T) {
 
 func TestNetworkPropertyTaskMissingApp(t *testing.T) {
 	task := NetworkPropertyTask{Property: "attach-post-create", Value: "test-network", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestNetworkPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "true",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestNetworkPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestNetworkPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "true",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"sort"
@@ -66,15 +67,15 @@ func (t NetworkTask) Examples() ([]Doc, error) {
 }
 
 // Execute creates or destroys a Docker network
-func (t NetworkTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t NetworkTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the NetworkTask would produce.
-func (t NetworkTask) Plan() PlanResult {
+func (t NetworkTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := networkExists(t.Name)
+			exists, err := networkExists(ctx, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -90,14 +91,14 @@ func (t NetworkTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "network missing",
 				Mutations: []string{"create network " + t.Name},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := networkExists(t.Name)
+			exists, err := networkExists(ctx, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -113,9 +114,9 @@ func (t NetworkTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "network present",
 				Mutations: []string{"destroy network " + t.Name},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -140,8 +141,8 @@ type networkListEntry struct {
 // dokku predating the DokkuManaged field reports it absent (decoding to false)
 // for every network, so nothing is exported rather than every network being
 // re-emitted.
-func (t NetworkTask) ExportGlobal() ([]interface{}, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func (t NetworkTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "network:list", "--format", "json"},
 	})
@@ -173,8 +174,8 @@ func (t NetworkTask) ExportGlobal() ([]interface{}, error) {
 // when the probe could not run - a transport failure, a missing dokku
 // binary, or a cancellation; (false, nil) when dokku reports the network
 // absent; (true, nil) when present.
-func networkExists(name string) (bool, error) {
-	return subprocess.Probe(subprocess.ExecCommandInput{
+func networkExists(ctx context.Context, name string) (bool, error) {
+	return subprocess.Probe(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -186,14 +187,14 @@ func networkExists(name string) (bool, error) {
 
 // destroyNetwork is retained as an integration-test helper. It runs the
 // destroy-network apply path synchronously.
-func destroyNetwork(name string) TaskOutputState {
+func destroyNetwork(ctx context.Context, name string) TaskOutputState {
 	state := TaskOutputState{Changed: false, State: StatePresent}
-	exists, _ := networkExists(name)
+	exists, _ := networkExists(ctx, name)
 	if !exists {
 		state.State = StateAbsent
 		return state
 	}
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "--force", "network:destroy", name},
 	})

--- a/tasks/network_task_integration_test.go
+++ b/tasks/network_task_integration_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func dockerNetworkExists(name string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"network", "inspect", name, "--format", "{{.Name}}"},
 	})
@@ -23,7 +23,7 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 	networkName := "docket-test-network"
 
 	// ensure clean state
-	destroyNetwork(networkName)
+	destroyNetwork(testCtx(), networkName)
 
 	// verify network does not exist via docker cli
 	if dockerNetworkExists(networkName) {
@@ -32,7 +32,7 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 
 	// create the network
 	task := NetworkTask{Name: networkName, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create network: %v", result.Error)
 	}
@@ -49,7 +49,7 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 	}
 
 	// verify network driver via docker cli
-	inspectResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	inspectResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"network", "inspect", networkName, "--format", "{{.Driver}}"},
 	})
@@ -62,7 +62,7 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 	}
 
 	// creating again should be idempotent
-	result = task.Execute()
+	result = task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent create failed: %v", result.Error)
 	}
@@ -75,7 +75,7 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 
 	// destroy the network
 	destroyTask := NetworkTask{Name: networkName, State: StateAbsent}
-	result = destroyTask.Execute()
+	result = destroyTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to destroy network: %v", result.Error)
 	}
@@ -92,7 +92,7 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 	}
 
 	// destroying again should be idempotent
-	result = destroyTask.Execute()
+	result = destroyTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent destroy failed: %v", result.Error)
 	}
@@ -112,7 +112,7 @@ func TestIntegrationExportNetwork(t *testing.T) {
 	// nothing to distinguish dokku-created networks. network:list --format json
 	// serializes DokkuManaged for every network (including the built-ins that
 	// always exist), so its presence in the raw output gates the test.
-	probe, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	probe, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "network:list", "--format", "json"},
 	})
@@ -124,14 +124,14 @@ func TestIntegrationExportNetwork(t *testing.T) {
 	}
 
 	networkName := "docket-test-export-network"
-	destroyNetwork(networkName)
-	defer destroyNetwork(networkName)
+	destroyNetwork(testCtx(), networkName)
+	defer destroyNetwork(testCtx(), networkName)
 
-	if r := (NetworkTask{Name: networkName, State: StatePresent}).Execute(); r.Error != nil {
+	if r := (NetworkTask{Name: networkName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to create network: %v", r.Error)
 	}
 
-	bodies, err := NetworkTask{}.ExportGlobal()
+	bodies, err := NetworkTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestIntegrationExportNetwork(t *testing.T) {
 	// the recipe loader defaults to present; set it here since we plan the body
 	// directly without going through the loader.
 	found.State = StatePresent
-	if plan := found.Plan(); plan.Error != nil {
+	if plan := found.Plan(testCtx()); plan.Error != nil {
 		t.Fatalf("re-plan of exported task failed: %v", plan.Error)
 	} else if !plan.InSync {
 		t.Errorf("exported task should be in sync after export, got %+v", plan)

--- a/tasks/network_task_test.go
+++ b/tasks/network_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNetworkTaskInvalidState(t *testing.T) {
 	task := NetworkTask{Name: "test-network", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -69,7 +69,7 @@ func TestNetworkExportGlobalOnlyDokkuManaged(t *testing.T) {
 		"--quiet network:list --format json": networkListFixture,
 	}))()
 
-	bodies, err := NetworkTask{}.ExportGlobal()
+	bodies, err := NetworkTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestExportNetworksBecomeTasks(t *testing.T) {
 		"--quiet network:list --format json": networkListFixture,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // NginxPropertyTask manages the nginx configuration for a given dokku application
 type NginxPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t NginxPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the nginx property
-func (t NginxPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t NginxPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // nginxPropertyTable maps nginx property names to the JSON keys emitted by
@@ -121,15 +123,15 @@ func (t NginxPropertyTask) PropertyTable() PropertyTable {
 }
 
 // ExportApp reconstructs the app's explicitly-set nginx properties.
-func (t NginxPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t NginxPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return NginxPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t NginxPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t NginxPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return NginxPropertyTask{Global: true, Property: property, Value: value}
 	})
 }
@@ -140,8 +142,8 @@ func (t NginxPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the NginxPropertyTask would produce.
-func (t NginxPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t NginxPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // init registers the NginxPropertyTask with the task registry

--- a/tasks/nginx_property_task_integration_test.go
+++ b/tasks/nginx_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationNginxPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-nginx"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -63,7 +63,7 @@ func TestIntegrationNginxPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := NginxPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "nginx global " + tc.property,
 					setTask:   NginxPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/nginx_property_task_test.go
+++ b/tasks/nginx_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNginxPropertyTaskInvalidState(t *testing.T) {
 	task := NginxPropertyTask{App: "test-app", Property: "proxy-read-timeout", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestNginxPropertyTaskInvalidState(t *testing.T) {
 
 func TestNginxPropertyTaskMissingApp(t *testing.T) {
 	task := NginxPropertyTask{Property: "proxy-read-timeout", Value: "120s", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestNginxPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "120s",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestNginxPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestNginxPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "120s",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // OpenrestyPropertyTask manages the openresty configuration for a given dokku application
 type OpenrestyPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t OpenrestyPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the openresty property
-func (t OpenrestyPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t OpenrestyPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // openrestyPropertyTable maps openresty property names to the JSON keys
@@ -129,20 +131,20 @@ func (t OpenrestyPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the OpenrestyPropertyTask would produce.
-func (t OpenrestyPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t OpenrestyPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t OpenrestyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t OpenrestyPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return OpenrestyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t OpenrestyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t OpenrestyPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return OpenrestyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/openresty_property_task_integration_test.go
+++ b/tasks/openresty_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationOpenrestyPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-openresty"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -64,7 +64,7 @@ func TestIntegrationOpenrestyPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := OpenrestyPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "openresty global " + tc.property,
 					setTask:   OpenrestyPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/openresty_property_task_test.go
+++ b/tasks/openresty_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestOpenrestyPropertyTaskInvalidState(t *testing.T) {
 	task := OpenrestyPropertyTask{App: "test-app", Property: "proxy-read-timeout", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestOpenrestyPropertyTaskInvalidState(t *testing.T) {
 
 func TestOpenrestyPropertyTaskMissingApp(t *testing.T) {
 	task := OpenrestyPropertyTask{Property: "proxy-read-timeout", Value: "120s", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestOpenrestyPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "0.0.0.0",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestOpenrestyPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestOpenrestyPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "120s",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/ordered_map_test.go
+++ b/tasks/ordered_map_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -12,8 +13,12 @@ type mockTask struct {
 
 func (m mockTask) Doc() string              { return "" }
 func (m mockTask) Examples() ([]Doc, error) { return nil, nil }
-func (m mockTask) Plan() PlanResult         { return PlanResult{InSync: true, Status: PlanStatusOK} }
-func (m mockTask) Execute() TaskOutputState { return TaskOutputState{State: m.state} }
+func (m mockTask) Plan(ctx context.Context) PlanResult {
+	return PlanResult{InSync: true, Status: PlanStatusOK}
+}
+func (m mockTask) Execute(ctx context.Context) TaskOutputState {
+	return TaskOutputState{State: m.state}
+}
 
 func envelopeOf(name string, state State) *TaskEnvelope {
 	return &TaskEnvelope{Name: name, Task: mockTask{name: name, state: state}}
@@ -27,8 +32,8 @@ func TestOrderedStringEnvelopeMapSetAndGet(t *testing.T) {
 	if got == nil {
 		t.Fatal("Get returned nil for existing key")
 	}
-	if got.Execute().State != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", got.Execute().State)
+	if got.Execute(testCtx()).State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", got.Execute(testCtx()).State)
 	}
 	if env := m.GetEnvelope("key1"); env == nil {
 		t.Fatal("GetEnvelope returned nil for existing key")
@@ -88,8 +93,8 @@ func TestOrderedStringEnvelopeMapOverwriteValue(t *testing.T) {
 	if got == nil {
 		t.Fatal("Get returned nil for overwritten key")
 	}
-	if got.Execute().State != StateAbsent {
-		t.Errorf("expected overwritten state 'absent', got '%s'", got.Execute().State)
+	if got.Execute(testCtx()).State != StateAbsent {
+		t.Errorf("expected overwritten state 'absent', got '%s'", got.Execute(testCtx()).State)
 	}
 	if keys := m.Keys(); len(keys) != 1 {
 		t.Fatalf("expected 1 key (deduped), got %d", len(keys))

--- a/tasks/pairs.go
+++ b/tasks/pairs.go
@@ -1,14 +1,18 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
 )
 
 // pairsCurrentFunc returns the pairs currently stored at the task's scope.
-// A non-nil error short-circuits the plan with PlanStatusError.
-type pairsCurrentFunc func() (map[string]string, error)
+// A non-nil error short-circuits the plan with PlanStatusError. It takes the
+// context rather than capturing one, for the same reason PlanResult.apply
+// does: the probe runs under the caller's context, not one baked in wherever
+// the closure happened to be built.
+type pairsCurrentFunc func(ctx context.Context) (map[string]string, error)
 
 // pairsCommandFunc builds one dokku subprocess invocation that sets or
 // clears a single key. Pass an empty value to clear (dokku interprets a
@@ -19,8 +23,8 @@ type pairsCommandFunc func(key, value string) subprocess.ExecCommandInput
 // PlanResult whose apply runs one command per drifted key. kind is the
 // singular noun the helper substitutes into the user-facing reason
 // ("label", "annotation", "chart value").
-func planPairsSet(kind string, desired map[string]string, currentFn pairsCurrentFunc, commandFn pairsCommandFunc) PlanResult {
-	current, err := currentFn()
+func planPairsSet(ctx context.Context, kind string, desired map[string]string, currentFn pairsCurrentFunc, commandFn pairsCommandFunc) PlanResult {
+	current, err := currentFn(ctx)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -45,9 +49,9 @@ func planPairsSet(kind string, desired map[string]string, currentFn pairsCurrent
 		Status:    status,
 		Reason:    fmt.Sprintf("%d %s(s) to set", len(drifted), kind),
 		Mutations: formatSetMutations(drifted, desired, current),
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
@@ -55,8 +59,8 @@ func planPairsSet(kind string, desired map[string]string, currentFn pairsCurrent
 // planPairsUnset probes current pairs and returns a PlanResult whose apply
 // clears each desired key that exists in current. Keys absent from the
 // server are skipped silently (no-op).
-func planPairsUnset(kind string, desired map[string]string, currentFn pairsCurrentFunc, commandFn pairsCommandFunc) PlanResult {
-	current, err := currentFn()
+func planPairsUnset(ctx context.Context, kind string, desired map[string]string, currentFn pairsCurrentFunc, commandFn pairsCommandFunc) PlanResult {
+	current, err := currentFn(ctx)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -76,9 +80,9 @@ func planPairsUnset(kind string, desired map[string]string, currentFn pairsCurre
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d %s(s) to unset", len(toClear), kind),
 		Mutations: formatClearMutations(toClear, current),
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }

--- a/tasks/pairs_test.go
+++ b/tasks/pairs_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -16,13 +17,13 @@ func chartCommandStub(key, value string) subprocess.ExecCommandInput {
 }
 
 func staticCurrent(pairs map[string]string) pairsCurrentFunc {
-	return func() (map[string]string, error) { return pairs, nil }
+	return func(ctx context.Context) (map[string]string, error) { return pairs, nil }
 }
 
 func TestPlanPairsSetInSync(t *testing.T) {
 	desired := map[string]string{"foo": "1", "bar": "2"}
 	current := map[string]string{"foo": "1", "bar": "2", "extra": "z"}
-	plan := planPairsSet("chart value", desired, staticCurrent(current), chartCommandStub)
+	plan := planPairsSet(testCtx(), "chart value", desired, staticCurrent(current), chartCommandStub)
 	if !plan.InSync {
 		t.Fatalf("expected InSync, got %#v", plan)
 	}
@@ -33,7 +34,7 @@ func TestPlanPairsSetInSync(t *testing.T) {
 
 func TestPlanPairsSetAllNewYieldsCreate(t *testing.T) {
 	desired := map[string]string{"foo": "1", "bar": "2"}
-	plan := planPairsSet("chart value", desired, staticCurrent(map[string]string{}), chartCommandStub)
+	plan := planPairsSet(testCtx(), "chart value", desired, staticCurrent(map[string]string{}), chartCommandStub)
 	if plan.InSync {
 		t.Fatal("expected drift")
 	}
@@ -54,7 +55,7 @@ func TestPlanPairsSetAllNewYieldsCreate(t *testing.T) {
 func TestPlanPairsSetPartialDriftYieldsModify(t *testing.T) {
 	desired := map[string]string{"foo": "1", "bar": "2"}
 	current := map[string]string{"foo": "old"}
-	plan := planPairsSet("chart value", desired, staticCurrent(current), chartCommandStub)
+	plan := planPairsSet(testCtx(), "chart value", desired, staticCurrent(current), chartCommandStub)
 	if plan.Status != PlanStatusModify {
 		t.Errorf("expected PlanStatusModify, got %v", plan.Status)
 	}
@@ -65,8 +66,8 @@ func TestPlanPairsSetPartialDriftYieldsModify(t *testing.T) {
 
 func TestPlanPairsSetProbeError(t *testing.T) {
 	probeErr := errors.New("boom")
-	fn := func() (map[string]string, error) { return nil, probeErr }
-	plan := planPairsSet("chart value", map[string]string{"k": "v"}, fn, chartCommandStub)
+	fn := func(ctx context.Context) (map[string]string, error) { return nil, probeErr }
+	plan := planPairsSet(testCtx(), "chart value", map[string]string{"k": "v"}, fn, chartCommandStub)
 	if plan.Error != probeErr {
 		t.Fatalf("expected probe error to propagate, got %v", plan.Error)
 	}
@@ -78,7 +79,7 @@ func TestPlanPairsSetProbeError(t *testing.T) {
 func TestPlanPairsUnsetSkipsMissingKeys(t *testing.T) {
 	desired := map[string]string{"foo": "", "missing": ""}
 	current := map[string]string{"foo": "1", "other": "2"}
-	plan := planPairsUnset("chart value", desired, staticCurrent(current), chartCommandStub)
+	plan := planPairsUnset(testCtx(), "chart value", desired, staticCurrent(current), chartCommandStub)
 	if plan.InSync {
 		t.Fatal("expected drift (one key still exists)")
 	}
@@ -96,7 +97,7 @@ func TestPlanPairsUnsetSkipsMissingKeys(t *testing.T) {
 func TestPlanPairsUnsetInSyncWhenNothingMatches(t *testing.T) {
 	desired := map[string]string{"foo": ""}
 	current := map[string]string{"bar": "1"}
-	plan := planPairsUnset("chart value", desired, staticCurrent(current), chartCommandStub)
+	plan := planPairsUnset(testCtx(), "chart value", desired, staticCurrent(current), chartCommandStub)
 	if !plan.InSync {
 		t.Fatalf("expected InSync when no desired keys exist on the server, got %#v", plan)
 	}

--- a/tasks/plan_integration_test.go
+++ b/tasks/plan_integration_test.go
@@ -11,12 +11,12 @@ func TestIntegrationPlanDetectsMissingApp(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-plan-detect"
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	task := AppTask{App: appName, State: StatePresent}
 
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("Plan() errored: %v", plan.Error)
 	}
@@ -35,15 +35,15 @@ func TestIntegrationPlanInSyncAfterApply(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-plan-roundtrip"
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	task := AppTask{App: appName, State: StatePresent}
-	if state := task.Execute(); state.Error != nil {
+	if state := task.Execute(testCtx()); state.Error != nil {
 		t.Fatalf("apply errored: %v", state.Error)
 	}
 
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("plan errored after apply: %v", plan.Error)
 	}
@@ -58,13 +58,13 @@ func TestIntegrationPlanDoesNotMutate(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-plan-no-mutate"
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	task := AppTask{App: appName, State: StatePresent}
-	_ = task.Plan()
+	_ = task.Plan(testCtx())
 
-	exists, _ := appExists(appName)
+	exists, _ := appExists(testCtx(), appName)
 	if exists {
 		t.Errorf("Plan() unexpectedly created %s", appName)
 	}
@@ -76,10 +76,10 @@ func TestIntegrationPlanConfigItemizes(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-plan-config"
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
-	if state := (AppTask{App: appName, State: StatePresent}).Execute(); state.Error != nil {
+	if state := (AppTask{App: appName, State: StatePresent}).Execute(testCtx()); state.Error != nil {
 		t.Fatalf("setup apps:create failed: %v", state.Error)
 	}
 
@@ -90,7 +90,7 @@ func TestIntegrationPlanConfigItemizes(t *testing.T) {
 		State:   StatePresent,
 	}
 
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("plan errored: %v", plan.Error)
 	}
@@ -113,10 +113,10 @@ func TestIntegrationPlanCommandsPopulatedOnDrift(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-plan-commands"
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
-	plan := (AppTask{App: appName, State: StatePresent}).Plan()
+	plan := (AppTask{App: appName, State: StatePresent}).Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("plan errored: %v", plan.Error)
 	}
@@ -139,12 +139,12 @@ func TestIntegrationExecuteIdempotent(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-plan-idempotent"
-	destroyApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	task := AppTask{App: appName, State: StatePresent}
 
-	first := task.Execute()
+	first := task.Execute(testCtx())
 	if first.Error != nil {
 		t.Fatalf("first apply errored: %v", first.Error)
 	}
@@ -152,7 +152,7 @@ func TestIntegrationExecuteIdempotent(t *testing.T) {
 		t.Error("first apply should report Changed=true (app was missing)")
 	}
 
-	second := task.Execute()
+	second := task.Execute(testCtx())
 	if second.Error != nil {
 		t.Fatalf("second apply errored: %v", second.Error)
 	}

--- a/tasks/plan_test.go
+++ b/tasks/plan_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -54,11 +55,11 @@ func TestDispatchPlanSetsDesiredState(t *testing.T) {
 // invariant that makes apply idempotent for the post-#198 design.
 func TestExecutePlanInSyncSkipsApply(t *testing.T) {
 	called := false
-	result := ExecutePlan(PlanResult{
+	result := ExecutePlan(testCtx(), PlanResult{
 		InSync:       true,
 		Status:       PlanStatusOK,
 		DesiredState: StatePresent,
-		apply: func() TaskOutputState {
+		apply: func(ctx context.Context) TaskOutputState {
 			called = true
 			return TaskOutputState{}
 		},
@@ -82,11 +83,11 @@ func TestExecutePlanInSyncSkipsApply(t *testing.T) {
 func TestExecutePlanErrorSkipsApply(t *testing.T) {
 	called := false
 	probeErr := errors.New("probe failed")
-	result := ExecutePlan(PlanResult{
+	result := ExecutePlan(testCtx(), PlanResult{
 		Status:       PlanStatusError,
 		Error:        probeErr,
 		DesiredState: StatePresent,
-		apply: func() TaskOutputState {
+		apply: func(ctx context.Context) TaskOutputState {
 			called = true
 			return TaskOutputState{}
 		},
@@ -103,11 +104,11 @@ func TestExecutePlanErrorSkipsApply(t *testing.T) {
 // the apply closure when the plan reports drift (the canonical path).
 func TestExecutePlanInvokesApplyOnDrift(t *testing.T) {
 	called := false
-	result := ExecutePlan(PlanResult{
+	result := ExecutePlan(testCtx(), PlanResult{
 		InSync:       false,
 		Status:       PlanStatusModify,
 		DesiredState: StatePresent,
-		apply: func() TaskOutputState {
+		apply: func(ctx context.Context) TaskOutputState {
 			called = true
 			return TaskOutputState{Changed: true, State: StatePresent}
 		},
@@ -127,7 +128,7 @@ func TestExecutePlanInvokesApplyOnDrift(t *testing.T) {
 // without an apply closure surfaces a clear error rather than silently
 // no-opping. Catches refactor mistakes where Plan() forgets to set apply.
 func TestExecutePlanMissingApplyIsError(t *testing.T) {
-	result := ExecutePlan(PlanResult{
+	result := ExecutePlan(testCtx(), PlanResult{
 		InSync:       false,
 		Status:       PlanStatusModify,
 		DesiredState: StatePresent,

--- a/tasks/plugin_task.go
+++ b/tasks/plugin_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -92,8 +93,8 @@ func (t PluginTask) Examples() ([]Doc, error) {
 }
 
 // Execute installs or uninstalls the plugin
-func (t PluginTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t PluginTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the PluginTask's inputs without contacting the server.
@@ -108,13 +109,13 @@ func (t PluginTask) Validate() error {
 }
 
 // Plan reports the drift the PluginTask would produce.
-func (t PluginTask) Plan() PlanResult {
+func (t PluginTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			installed, err := pluginInstalled(t.Name)
+			installed, err := pluginInstalled(ctx, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -132,14 +133,14 @@ func (t PluginTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "plugin not installed",
 				Mutations: []string{fmt.Sprintf("install plugin %s", t.Name)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			installed, err := pluginInstalled(t.Name)
+			installed, err := pluginInstalled(ctx, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -155,9 +156,9 @@ func (t PluginTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "plugin installed",
 				Mutations: []string{fmt.Sprintf("uninstall plugin %s", t.Name)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -180,8 +181,8 @@ type pluginListEntry struct {
 // followed branch, and checked-out commit. Core plugins ship with dokku (and
 // plugin:uninstall rejects them), and plugins without a git source (a tarball or
 // local path) cannot be reinstalled declaratively, so both are skipped.
-func (t PluginTask) ExportGlobal() ([]interface{}, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func (t PluginTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "plugin:list", "--format", "json"},
 	})
@@ -224,8 +225,8 @@ func (t PluginTask) ExportGlobal() ([]interface{}, error) {
 // pluginInstalled reports whether a plugin is installed by parsing
 // `dokku plugin:list`, whose first whitespace-delimited field per line is the
 // plugin name (mirrors dokku's own plugin:installed check).
-func pluginInstalled(name string) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func pluginInstalled(ctx context.Context, name string) (bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "plugin:list"},
 	})

--- a/tasks/plugin_task_integration_test.go
+++ b/tasks/plugin_task_integration_test.go
@@ -17,7 +17,7 @@ func TestIntegrationPlugin(t *testing.T) {
 	pluginCommittish := "v0.9.0"
 
 	uninstallPlugin := func() {
-		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "dokku",
 			Args:    []string{"--quiet", "plugin:uninstall", pluginName},
 		})
@@ -28,7 +28,7 @@ func TestIntegrationPlugin(t *testing.T) {
 
 	assertInstalled := func(t *testing.T, label string, want bool) {
 		t.Helper()
-		got, err := pluginInstalled(pluginName)
+		got, err := pluginInstalled(testCtx(), pluginName)
 		if err != nil {
 			t.Fatalf("%s: pluginInstalled failed: %v", label, err)
 		}
@@ -41,7 +41,7 @@ func TestIntegrationPlugin(t *testing.T) {
 
 	// install the plugin
 	installTask := PluginTask{Name: pluginName, URL: pluginURL, Committish: pluginCommittish, State: StatePresent}
-	result := installTask.Execute()
+	result := installTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to install plugin: %v", result.Error)
 	}
@@ -54,7 +54,7 @@ func TestIntegrationPlugin(t *testing.T) {
 	assertInstalled(t, "after install", true)
 
 	// install again - idempotent
-	result = installTask.Execute()
+	result = installTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second install: %v", result.Error)
 	}
@@ -64,7 +64,7 @@ func TestIntegrationPlugin(t *testing.T) {
 
 	// uninstall the plugin
 	uninstallTask := PluginTask{Name: pluginName, State: StateAbsent}
-	result = uninstallTask.Execute()
+	result = uninstallTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to uninstall plugin: %v", result.Error)
 	}
@@ -77,7 +77,7 @@ func TestIntegrationPlugin(t *testing.T) {
 	assertInstalled(t, "after uninstall", false)
 
 	// uninstall again - idempotent
-	result = uninstallTask.Execute()
+	result = uninstallTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second uninstall: %v", result.Error)
 	}
@@ -92,7 +92,7 @@ func TestIntegrationExportPlugin(t *testing.T) {
 	// A dokku predating plugin:list --format json ignores the flag and prints
 	// stdout text with a zero exit, so skip unless the output parses as a JSON
 	// array rather than guarding on a non-zero exit.
-	probe, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	probe, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "plugin:list", "--format", "json"},
 	})
@@ -109,7 +109,7 @@ func TestIntegrationExportPlugin(t *testing.T) {
 	pluginCommittish := "v0.9.0"
 
 	uninstallPlugin := func() {
-		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "dokku",
 			Args:    []string{"--quiet", "plugin:uninstall", pluginName},
 		})
@@ -119,11 +119,11 @@ func TestIntegrationExportPlugin(t *testing.T) {
 	defer uninstallPlugin()
 
 	installTask := PluginTask{Name: pluginName, URL: pluginURL, Committish: pluginCommittish, State: StatePresent}
-	if result := installTask.Execute(); result.Error != nil {
+	if result := installTask.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to install plugin: %v", result.Error)
 	}
 
-	bodies, err := PluginTask{}.ExportGlobal()
+	bodies, err := PluginTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestIntegrationExportPlugin(t *testing.T) {
 
 	// The exported task round-trips: re-planning it against the same server is a
 	// no-op because the plugin is already installed.
-	plan := found.Plan()
+	plan := found.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("re-plan of exported task failed: %v", plan.Error)
 	}

--- a/tasks/plugin_task_test.go
+++ b/tasks/plugin_task_test.go
@@ -6,21 +6,21 @@ import (
 
 func TestPluginTaskInvalidState(t *testing.T) {
 	task := PluginTask{Name: "redis", URL: "https://github.com/dokku/dokku-redis.git", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
 }
 
 func TestPluginTaskRequiresName(t *testing.T) {
-	result := PluginTask{URL: "https://github.com/dokku/dokku-redis.git", State: StatePresent}.Plan()
+	result := PluginTask{URL: "https://github.com/dokku/dokku-redis.git", State: StatePresent}.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan without 'name' should return an error")
 	}
 }
 
 func TestPluginTaskRequiresURLWhenPresent(t *testing.T) {
-	result := PluginTask{Name: "redis", State: StatePresent}.Plan()
+	result := PluginTask{Name: "redis", State: StatePresent}.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with state 'present' and no 'url' should return an error")
 	}

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/dokku/docket/subprocess"
@@ -127,8 +128,8 @@ func (t PortsTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the app's port mappings
-func (t PortsTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t PortsTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the PortsTask's inputs without contacting the server.
@@ -181,21 +182,21 @@ func (t PortsTask) Validate() error {
 }
 
 // Plan reports the drift the PortsTask would produce.
-func (t PortsTask) Plan() PlanResult {
+func (t PortsTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planPortsPresent(t) },
-		StateAbsent:  func() PlanResult { return planPortsAbsent(t) },
-		StateSet:     func() PlanResult { return planPortsSet(t) },
-		StateClear:   func() PlanResult { return planPortsClear(t) },
+		StatePresent: func() PlanResult { return planPortsPresent(ctx, t) },
+		StateAbsent:  func() PlanResult { return planPortsAbsent(ctx, t) },
+		StateSet:     func() PlanResult { return planPortsSet(ctx, t) },
+		StateClear:   func() PlanResult { return planPortsClear(ctx, t) },
 	})
 }
 
 // planPortsPresent reports drift for the present-state mapping add.
-func planPortsPresent(t PortsTask) PlanResult {
-	currentPorts, err := getPorts(t.App)
+func planPortsPresent(ctx context.Context, t PortsTask) PlanResult {
+	currentPorts, err := getPorts(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -233,14 +234,14 @@ func planPortsPresent(t PortsTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("%d port mapping(s) to add", len(toAdd)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs("ports:add", t.App, toAdd, StatePresent, StateAbsent),
 	}
 }
 
 // planPortsAbsent reports drift for the absent-state mapping remove.
-func planPortsAbsent(t PortsTask) PlanResult {
-	currentPorts, err := getPorts(t.App)
+func planPortsAbsent(ctx context.Context, t PortsTask) PlanResult {
+	currentPorts, err := getPorts(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -261,7 +262,7 @@ func planPortsAbsent(t PortsTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(toRemove)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs("ports:remove", t.App, toRemove, StateAbsent, StatePresent),
 	}
 }
@@ -269,8 +270,8 @@ func planPortsAbsent(t PortsTask) PlanResult {
 // planPortsSet reports drift for the set-state full replacement. The itemized
 // mutations are the adds and removes the replacement works out to; the command
 // itself always carries the complete desired list.
-func planPortsSet(t PortsTask) PlanResult {
-	currentPorts, err := getPorts(t.App)
+func planPortsSet(ctx context.Context, t PortsTask) PlanResult {
+	currentPorts, err := getPorts(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -303,14 +304,14 @@ func planPortsSet(t PortsTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("%d port mapping change(s)", len(mutations)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs("ports:set", t.App, args, StateSet, StateAbsent),
 	}
 }
 
 // planPortsClear reports drift for the clear-state operation.
-func planPortsClear(t PortsTask) PlanResult {
-	currentPorts, err := getPorts(t.App)
+func planPortsClear(ctx context.Context, t PortsTask) PlanResult {
+	currentPorts, err := getPorts(ctx, t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -328,7 +329,7 @@ func planPortsClear(t PortsTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("clear %d port mapping(s)", len(currentPorts)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyDokkuArgs("ports:clear", t.App, nil, StateClear, StatePresent),
 	}
 }
@@ -357,8 +358,8 @@ func sortedPortMappings(mappings map[string]PortMapping) []string {
 // ExportApp reads the app's port mappings and returns a dokku_ports task, or
 // nil when none are configured. Mappings are sorted for deterministic output.
 // state:set replaces the whole mapping list for an exact match.
-func (t PortsTask) ExportApp(app string) ([]interface{}, error) {
-	mappings, err := getPorts(app)
+func (t PortsTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	mappings, err := getPorts(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -375,10 +376,10 @@ func (t PortsTask) ExportApp(app string) ([]interface{}, error) {
 // getPorts gets the ports for a given app. A transport-level failure
 // (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit
 // (e.g. app does not exist) is treated as "no ports configured."
-func getPorts(appName string) (map[string]PortMapping, error) {
+func getPorts(ctx context.Context, appName string) (map[string]PortMapping, error) {
 	// dokku master has a --ports-map-json that would replace this text parse,
 	// but it is not in a release yet; see #431.
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",

--- a/tasks/ports_task_integration_test.go
+++ b/tasks/ports_task_integration_test.go
@@ -11,7 +11,7 @@ import (
 // getReportedPorts queries dokku ports:report to get the current mappings for
 // an app, so assertions do not lean on the task's own probe.
 func getReportedPorts(appName string) []string {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "ports:report", appName, "--ports-map"},
 	})
@@ -29,9 +29,9 @@ func TestIntegrationPortsAddAndRemove(t *testing.T) {
 
 	appName := "docket-test-ports"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	portMappings := []PortMapping{
 		{Scheme: "http", Host: 8080, Container: 5000},
@@ -39,7 +39,7 @@ func TestIntegrationPortsAddAndRemove(t *testing.T) {
 
 	// add port
 	addTask := PortsTask{App: appName, PortMappings: portMappings, State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add port: %v", result.Error)
 	}
@@ -51,7 +51,7 @@ func TestIntegrationPortsAddAndRemove(t *testing.T) {
 	}
 
 	// add same port again (idempotent)
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent add failed: %v", result.Error)
 	}
@@ -61,7 +61,7 @@ func TestIntegrationPortsAddAndRemove(t *testing.T) {
 
 	// remove port
 	removeTask := PortsTask{App: appName, PortMappings: portMappings, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove port: %v", result.Error)
 	}
@@ -73,7 +73,7 @@ func TestIntegrationPortsAddAndRemove(t *testing.T) {
 	}
 
 	// remove again (idempotent)
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent remove failed: %v", result.Error)
 	}
@@ -90,16 +90,16 @@ func TestIntegrationPortsPresentRejectsSchemeHostCollision(t *testing.T) {
 
 	appName := "docket-test-ports-collision"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	seedTask := PortsTask{
 		App:          appName,
 		PortMappings: []PortMapping{{Scheme: "http", Host: 8080, Container: 5000}},
 		State:        StatePresent,
 	}
-	if result := seedTask.Execute(); result.Error != nil {
+	if result := seedTask.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to seed ports: %v", result.Error)
 	}
 
@@ -108,7 +108,7 @@ func TestIntegrationPortsPresentRejectsSchemeHostCollision(t *testing.T) {
 		PortMappings: []PortMapping{{Scheme: "http", Host: 8080, Container: 6000}},
 		State:        StatePresent,
 	}
-	result := collidingTask.Execute()
+	result := collidingTask.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected an error when adding a mapping on an already-bound scheme:host pair")
 	}
@@ -130,9 +130,9 @@ func TestIntegrationPortsSetAndClear(t *testing.T) {
 
 	appName := "docket-test-ports-set-clear"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// seed two mappings so set has something to replace
 	seedTask := PortsTask{
@@ -143,7 +143,7 @@ func TestIntegrationPortsSetAndClear(t *testing.T) {
 		},
 		State: StatePresent,
 	}
-	if result := seedTask.Execute(); result.Error != nil {
+	if result := seedTask.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to seed ports: %v", result.Error)
 	}
 
@@ -153,7 +153,7 @@ func TestIntegrationPortsSetAndClear(t *testing.T) {
 		PortMappings: []PortMapping{{Scheme: "http", Host: 8082, Container: 5000}},
 		State:        StateSet,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set ports: %v", result.Error)
 	}
@@ -170,7 +170,7 @@ func TestIntegrationPortsSetAndClear(t *testing.T) {
 	}
 
 	// set again (idempotent)
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent set failed: %v", result.Error)
 	}
@@ -180,7 +180,7 @@ func TestIntegrationPortsSetAndClear(t *testing.T) {
 
 	// clear drops every mapping in one call
 	clearTask := PortsTask{App: appName, State: StateClear}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear ports: %v", result.Error)
 	}
@@ -196,7 +196,7 @@ func TestIntegrationPortsSetAndClear(t *testing.T) {
 	}
 
 	// clear again (idempotent)
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent clear failed: %v", result.Error)
 	}

--- a/tasks/ports_task_test.go
+++ b/tasks/ports_task_test.go
@@ -15,7 +15,7 @@ func TestPortsTaskInvalidState(t *testing.T) {
 		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}},
 		State:        "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -23,7 +23,7 @@ func TestPortsTaskInvalidState(t *testing.T) {
 
 func TestPortsTaskEmptyPortMappings(t *testing.T) {
 	task := PortsTask{App: "test-app", PortMappings: []PortMapping{}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty port mappings should return an error")
 	}
@@ -157,7 +157,7 @@ func TestPortsSetPlansFullReplacement(t *testing.T) {
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "http", Host: 8080, Container: 5000}},
 		State:        StateSet,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -189,7 +189,7 @@ func TestPortsSetOnAppWithNoMappingsIsACreate(t *testing.T) {
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}},
 		State:        StateSet,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -210,7 +210,7 @@ func TestPortsSetConvergesWhenReportMatches(t *testing.T) {
 			{Scheme: "https", Host: 443, Container: 5000},
 		},
 		State: StateSet,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -227,7 +227,7 @@ func TestPortsClearPlansEveryMapping(t *testing.T) {
 		portsReportKey: "http:80:5000 https:443:5000",
 	}))()
 
-	plan := PortsTask{App: "web", State: StateClear}.Plan()
+	plan := PortsTask{App: "web", State: StateClear}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -255,7 +255,7 @@ func TestPortsClearIsInSyncWithoutMappings(t *testing.T) {
 		portsReportKey: "",
 	}))()
 
-	plan := PortsTask{App: "web", State: StateClear}.Plan()
+	plan := PortsTask{App: "web", State: StateClear}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -279,7 +279,7 @@ func TestPortsPresentPlansOnlyTheMissingMappings(t *testing.T) {
 			{Scheme: "https", Host: 443, Container: 5000},
 		},
 		State: StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -307,7 +307,7 @@ func TestPortsPresentRejectsCollisionWithAnExistingMapping(t *testing.T) {
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 6000}},
 		State:        StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error == nil {
 		t.Fatal("expected an error when the scheme:host pair is already bound to another container port")
 	}
@@ -328,7 +328,7 @@ func TestPortsPresentAllowsTheSameHostPortUnderAnotherScheme(t *testing.T) {
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "https", Host: 80, Container: 5000}},
 		State:        StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -352,7 +352,7 @@ func TestPortsAbsentPlansOnlyThePresentMappings(t *testing.T) {
 			{Scheme: "https", Host: 443, Container: 5000},
 		},
 		State: StateAbsent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}

--- a/tasks/probe_coverage_test.go
+++ b/tasks/probe_coverage_test.go
@@ -200,7 +200,7 @@ func TestPlanResultInSyncImpliesStatusOK(t *testing.T) {
 // planFuncKey identifies a node the static analysis can reach: a package-level
 // func ("planProperty"), a method ("GitAuthTask.Plan"), or one branch of a
 // DispatchPlan map ("GitAuthTask.Plan[present]"). Methods must be keyed by
-// receiver type - every task's Execute() is `return ExecutePlan(t.Plan())`, so
+// receiver type - every task's Execute() is `return ExecutePlan(testCtx(), t.Plan(testCtx()))`, so
 // a bare "Plan" key would merge all 73 method bodies into one node and the
 // invariant would hold vacuously. Branch keys use a spelling no Go identifier
 // can collide with.
@@ -785,7 +785,7 @@ func TestPlanGraphBranchConvergence(t *testing.T) {
 		{
 			name: "every branch converges",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return ` + inSync + ` },
 		StateAbsent:  func() PlanResult { return ` + inSync + ` },
@@ -797,7 +797,7 @@ func (t FooTask) Plan() PlanResult {
 		{
 			name: "one branch never converges",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return ` + inSync + ` },
 		StateAbsent:  func() PlanResult { return ` + drift + ` },
@@ -810,7 +810,7 @@ func (t FooTask) Plan() PlanResult {
 		{
 			name: "no branch converges",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return ` + drift + ` },
 		StateAbsent:  func() PlanResult { return ` + drift + ` },
@@ -825,7 +825,7 @@ func (t FooTask) Plan() PlanResult {
 			// no dispatch map of their own and inherit the helper's branches.
 			name: "branches inherited from a shared helper",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return planShared(t.State)
 }
 
@@ -843,7 +843,7 @@ func planShared(state State) PlanResult {
 			// A branch that delegates converges through the call edge.
 			name: "branch converges through a called plan func",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return planFooPresent(t) },
 	})
@@ -861,7 +861,7 @@ func planFooPresent(t FooTask) PlanResult {
 			// edge and blame the branch.
 			name: "branch converges through a multi-result pointer helper",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			_, res := readFooState(t)
@@ -882,7 +882,7 @@ func readFooState(t FooTask) (bool, *PlanResult) {
 		{
 			name: "dispatch map held in a local",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	handlers := map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return ` + inSync + ` },
 		StateAbsent:  func() PlanResult { return ` + drift + ` },
@@ -896,7 +896,7 @@ func (t FooTask) Plan() PlanResult {
 		{
 			name: "dispatch map declared with var",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	var handlers = map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return ` + inSync + ` },
 		StateAbsent:  func() PlanResult { return ` + drift + ` },
@@ -911,7 +911,7 @@ func (t FooTask) Plan() PlanResult {
 			// An unmapped key still names something a reader can act on.
 			name: "keys that are not State constants fall back to their spelling",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		"deployed":   func() PlanResult { return ` + inSync + ` },
 		StateUnknown: func() PlanResult { return ` + drift + ` },
@@ -956,7 +956,7 @@ func TestPlanGraphReachesFunc(t *testing.T) {
 		{
 			name: "calls the helper directly",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return planToggle(t.State, t.App)
 }
 
@@ -968,7 +968,7 @@ func planToggle(state State, app string) PlanResult {
 		{
 			name: "reaches the helper one hop away",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return planFooToggle(t)
 }
 
@@ -984,7 +984,7 @@ func planToggle(state State, app string) PlanResult {
 		{
 			name: "delegates elsewhere",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return planProperty(t.State)
 }
 
@@ -1027,7 +1027,7 @@ func TestPlanGraphReportsUnwalkableShapes(t *testing.T) {
 		{
 			name: "map assembled after its literal",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	handlers := map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return ` + inSync + ` },
 	}
@@ -1039,7 +1039,7 @@ func (t FooTask) Plan() PlanResult {
 		{
 			name: "map reassigned",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	handlers := map[State]func() PlanResult{}
 	handlers = map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return ` + inSync + ` },
@@ -1059,7 +1059,7 @@ func planShared(state State, handlers map[State]func() PlanResult) PlanResult {
 		{
 			name: "branch is not a func literal",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: presentBranch,
 	})
@@ -1069,7 +1069,7 @@ func (t FooTask) Plan() PlanResult {
 		{
 			name: "branch key is computed",
 			src: `
-func (t FooTask) Plan() PlanResult {
+func (t FooTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		State("present"): func() PlanResult { return ` + inSync + ` },
 	})

--- a/tasks/probe_support_test.go
+++ b/tasks/probe_support_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"testing"
 )
 
@@ -10,10 +11,10 @@ import (
 // generator omit the section and the coverage test name the offender.
 type probelessTask struct{}
 
-func (t probelessTask) Doc() string              { return "" }
-func (t probelessTask) Examples() ([]Doc, error) { return nil, nil }
-func (t probelessTask) Plan() PlanResult         { return PlanResult{} }
-func (t probelessTask) Execute() TaskOutputState { return TaskOutputState{} }
+func (t probelessTask) Doc() string                                 { return "" }
+func (t probelessTask) Examples() ([]Doc, error)                    { return nil, nil }
+func (t probelessTask) Plan(ctx context.Context) PlanResult         { return PlanResult{} }
+func (t probelessTask) Execute(ctx context.Context) TaskOutputState { return TaskOutputState{} }
 
 func TestTaskProbeSupportUndeclared(t *testing.T) {
 	support, ok := TaskProbeSupport(probelessTask{})

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -224,11 +225,11 @@ func (e *errUnknownProperty) Error() string {
 //   - (value, nil) when the looked-up key exists in the JSON payload
 //   - ("", *errUnknownProperty) when the JSON parsed but the key was absent
 //   - ("", err) when the exec or JSON parse failed
-func getProperty(subcommand, app string, global bool, property string, keys map[string]PropertyKeys) (string, error) {
+func getProperty(ctx context.Context, subcommand, app string, global bool, property string, keys map[string]PropertyKeys) (string, error) {
 	plugin := pluginFromSubcommand(subcommand)
 	args := getPropertyArgs(plugin, app, global)
 
-	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	response, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    args,
 	})
@@ -284,11 +285,11 @@ func getProperty(subcommand, app string, global bool, property string, keys map[
 // A probeable dynamic family cannot be enumerated in keys, so the properties the
 // payload happens to carry are synthesized into it first; without that a set
 // letsencrypt `dns-provider-<KEY>` credential is dropped from the export (#449).
-func exportProperties(task PropertyTableDocer, app string, factory func(app, property, value string) interface{}) ([]interface{}, error) {
+func exportProperties(ctx context.Context, task PropertyTableDocer, app string, factory func(app, property, value string) interface{}) ([]interface{}, error) {
 	table := task.PropertyTable()
 	keys := table.Keys
 	plugin := table.Plugin()
-	payload, err := readPropertyReport(plugin, app, false)
+	payload, err := readPropertyReport(ctx, plugin, app, false)
 	if err != nil {
 		return nil, err
 	}
@@ -326,11 +327,11 @@ func exportProperties(task PropertyTableDocer, app string, factory func(app, pro
 // globally-scoped state (for example scheduler-k3s bootstrap keys) is captured
 // instead of silently dropped (#327). Probeable dynamic properties are
 // synthesized into keys the same way exportProperties does it.
-func exportGlobalProperties(task PropertyTableDocer, factory func(property, value string) interface{}) ([]interface{}, error) {
+func exportGlobalProperties(ctx context.Context, task PropertyTableDocer, factory func(property, value string) interface{}) ([]interface{}, error) {
 	table := task.PropertyTable()
 	keys := table.Keys
 	plugin := table.Plugin()
-	payload, err := readPropertyReport(plugin, "", true)
+	payload, err := readPropertyReport(ctx, plugin, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -369,8 +370,8 @@ func exportGlobalProperties(task PropertyTableDocer, factory func(property, valu
 // error. A JSON parse failure is always an error, since the exec succeeded so the
 // plugin responded with something unparseable (for example a deprecation line
 // printed before the JSON payload) rather than being absent (#329).
-func readPropertyReport(plugin, app string, global bool) (map[string]string, error) {
-	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func readPropertyReport(ctx context.Context, plugin, app string, global bool) (map[string]string, error) {
+	response, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    getPropertyArgs(plugin, app, global),
 	})
@@ -379,7 +380,7 @@ func readPropertyReport(plugin, app string, global bool) (map[string]string, err
 		if errors.As(err, &sshErr) {
 			return nil, err
 		}
-		if installed, ierr := pluginInstalled(plugin); ierr != nil || !installed {
+		if installed, ierr := pluginInstalled(ctx, plugin); ierr != nil || !installed {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("dokku %s:report failed: %w", plugin, err)
@@ -703,7 +704,7 @@ func validatePropertyInput(task PropertyTableDocer, state State, app string, glo
 	return nil
 }
 
-func planProperty(task PropertyTableDocer, state State, app string, global bool, property, value string) PlanResult {
+func planProperty(ctx context.Context, task PropertyTableDocer, state State, app string, global bool, property, value string) PlanResult {
 	if err := validatePropertyInput(task, state, app, global, property, value); err != nil {
 		return planErr(err)
 	}
@@ -741,13 +742,13 @@ func planProperty(task PropertyTableDocer, state State, app string, global bool,
 			// Dynamic property families have no probe key; treat as drift
 			// and run the mutation unconditionally.
 			if _, mapped := keys[property]; !mapped && isDynamicProperty(plugin, property) {
-				return runUnprobedSet(subcommand, target, property, value)
+				return runUnprobedSet(ctx, subcommand, target, property, value)
 			}
 
 			// Probe; treat dokku-level failure as "drift, must mutate"
 			// (matches pre-probe behavior for unsupported plugins) but
 			// surface SSH transport failures so the user sees `! ssh:`.
-			current, probeErr := getProperty(subcommand, app, global, property, keys)
+			current, probeErr := getProperty(ctx, subcommand, app, global, property, keys)
 			if sensitive {
 				subprocess.AddGlobalSensitive(current)
 			}
@@ -782,17 +783,17 @@ func planProperty(task PropertyTableDocer, state State, app string, global bool,
 				Status:    status,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
-				Commands:  resolveCommands(inputs),
+				Commands:  resolveCommands(ctx, inputs),
 				Warnings:  warnings,
 				apply:     applyPropertySet(subcommand, target, property, value),
 			}
 		},
 		StateAbsent: func() PlanResult {
 			if _, mapped := keys[property]; !mapped && isDynamicProperty(plugin, property) {
-				return runUnprobedUnset(subcommand, target, property)
+				return runUnprobedUnset(ctx, subcommand, target, property)
 			}
 
-			current, probeErr := getProperty(subcommand, app, global, property, keys)
+			current, probeErr := getProperty(ctx, subcommand, app, global, property, keys)
 			if sensitive {
 				subprocess.AddGlobalSensitive(current)
 			}
@@ -823,7 +824,7 @@ func planProperty(task PropertyTableDocer, state State, app string, global bool,
 				Status:    PlanStatusDestroy,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("unset %s", property)},
-				Commands:  resolveCommands(inputs),
+				Commands:  resolveCommands(ctx, inputs),
 				Warnings:  warnings,
 				apply:     applyPropertyUnset(subcommand, target, property),
 			}
@@ -858,28 +859,28 @@ func validateProperty(plugin, property string, global bool, keys map[string]Prop
 
 // runUnprobedSet returns a PlanResult that runs `:set` unconditionally for
 // dynamic properties that have no probe key (e.g. traefik dns-provider-*).
-func runUnprobedSet(subcommand, target, property, value string) PlanResult {
+func runUnprobedSet(ctx context.Context, subcommand, target, property, value string) PlanResult {
 	inputs := propertySetInputs(subcommand, target, property, value)
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("would set %s on %s (no probe key)", property, target),
 		Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyPropertySet(subcommand, target, property, value),
 	}
 }
 
 // runUnprobedUnset returns a PlanResult that runs `:set` (no value, the unset
 // form) unconditionally for dynamic properties with no probe key.
-func runUnprobedUnset(subcommand, target, property string) PlanResult {
+func runUnprobedUnset(ctx context.Context, subcommand, target, property string) PlanResult {
 	inputs := propertyUnsetInputs(subcommand, target, property)
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("would unset %s on %s (no probe key)", property, target),
 		Mutations: []string{fmt.Sprintf("unset %s", property)},
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyPropertyUnset(subcommand, target, property),
 	}
 }
@@ -900,19 +901,19 @@ func propertyUnsetInputs(subcommand, target, property string) []subprocess.ExecC
 
 // applyPropertySet returns a closure that runs `dokku <subcommand> <target>
 // <property> <value>` and converts the result into a TaskOutputState.
-func applyPropertySet(subcommand, target, property, value string) func() TaskOutputState {
+func applyPropertySet(subcommand, target, property, value string) func(ctx context.Context) TaskOutputState {
 	inputs := propertySetInputs(subcommand, target, property, value)
-	return func() TaskOutputState {
-		return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+	return func(ctx context.Context) TaskOutputState {
+		return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 	}
 }
 
 // applyPropertyUnset returns a closure that runs `dokku <subcommand> <target>
 // <property>` (no value, which dokku interprets as unset) and converts the
 // result into a TaskOutputState.
-func applyPropertyUnset(subcommand, target, property string) func() TaskOutputState {
+func applyPropertyUnset(subcommand, target, property string) func(ctx context.Context) TaskOutputState {
 	inputs := propertyUnsetInputs(subcommand, target, property)
-	return func() TaskOutputState {
-		return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+	return func(ctx context.Context) TaskOutputState {
+		return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 	}
 }

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -51,7 +51,7 @@ func TestPlanPropertyMasksSensitiveDriftValue(t *testing.T) {
 		"--quiet myplugin:report --global --format json": `{"global-secret-prop":"oldsecret"}`,
 	}))()
 
-	res := planProperty(fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "secret-prop", "newsecret")
+	res := planProperty(testCtx(), fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "secret-prop", "newsecret")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -87,7 +87,7 @@ func TestPlanPropertyAbsentMasksSensitiveOldValue(t *testing.T) {
 
 	// The absent path leaks the current server secret even without a sensitive
 	// recipe value (the value must be empty for absent).
-	res := planProperty(fakePropertyTask("myplugin:set", keys), StateAbsent, "", true, "secret-prop", "")
+	res := planProperty(testCtx(), fakePropertyTask("myplugin:set", keys), StateAbsent, "", true, "secret-prop", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -107,7 +107,7 @@ func TestPlanPropertyDoesNotMaskBenignDriftValue(t *testing.T) {
 		"--quiet myplugin:report --global --format json": `{"global-timeout":"60s"}`,
 	}))()
 
-	res := planProperty(fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "timeout", "90s")
+	res := planProperty(testCtx(), fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "timeout", "90s")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -136,7 +136,7 @@ func TestReadPropertyReportUnparseableReportErrors(t *testing.T) {
 		"--quiet nginx:report web --format json": "Deprecated: use something else\n{\"x\":\"y\"}",
 	}))()
 
-	if _, err := readPropertyReport("nginx", "web", false); err == nil {
+	if _, err := readPropertyReport(testCtx(), "nginx", "web", false); err == nil {
 		t.Error("expected an error for an installed-but-unreadable report")
 	}
 }
@@ -154,7 +154,7 @@ func TestReadPropertyReportNotInstalledIsQuietSkip(t *testing.T) {
 		return subprocess.ExecCommandResponse{}, nil
 	})()
 
-	payload, err := readPropertyReport("caddy", "web", false)
+	payload, err := readPropertyReport(testCtx(), "caddy", "web", false)
 	if err != nil {
 		t.Errorf("a not-installed plugin should be a quiet skip, got error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestReadPropertyReportInstalledExecFailureErrors(t *testing.T) {
 		return subprocess.ExecCommandResponse{}, nil
 	})()
 
-	if _, err := readPropertyReport("nginx", "web", false); err == nil {
+	if _, err := readPropertyReport(testCtx(), "nginx", "web", false); err == nil {
 		t.Error("expected an error when an installed plugin's report fails")
 	}
 }
@@ -294,7 +294,7 @@ func TestPlanPropertyAttachesUnknownKeyWarning(t *testing.T) {
 		"--quiet nginx:report myapp --format json": `{"proxy-read-timeout":"60s"}`,
 	}))()
 
-	res := planProperty(fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
+	res := planProperty(testCtx(), fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -321,7 +321,7 @@ func TestPlanPropertyAttachesRejectedProbeWarning(t *testing.T) {
 		return resp, &subprocess.ExecError{Response: resp, Err: errors.New("exit status 1"), Ran: true}
 	})()
 
-	res := planProperty(fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
+	res := planProperty(testCtx(), fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -435,7 +435,7 @@ func TestPlanPropertyDynamicLetsencryptInSync(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"token123"}`,
 	}))()
 
-	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
+	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -452,7 +452,7 @@ func TestPlanPropertyDynamicLetsencryptGlobalInSync(t *testing.T) {
 		"--quiet letsencrypt:report --global --format json": `{"global-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
 	}))()
 
-	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "", true, "dns-provider-NAMECHEAP_API_USER", "deploy-bot")
+	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "", true, "dns-provider-NAMECHEAP_API_USER", "deploy-bot")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -472,7 +472,7 @@ func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"oldtoken"}`,
 	}))()
 
-	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "newtoken")
+	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "newtoken")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -500,7 +500,7 @@ func TestPlanPropertyDynamicLetsencryptMissingRowPlansCreate(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
 	}))()
 
-	res := planProperty(LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
+	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -520,7 +520,7 @@ func TestPlanPropertyDynamicLetsencryptAbsentMissingRowIsInSync(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
 	}))()
 
-	res := planProperty(LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
+	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -537,7 +537,7 @@ func TestPlanPropertyDynamicLetsencryptAbsentPlansDestroy(t *testing.T) {
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"livetoken"}`,
 	}))()
 
-	res := planProperty(LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
+	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -559,7 +559,7 @@ func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
 		return subprocess.ExecCommandResponse{}, nil
 	})()
 
-	res := planProperty(TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
+	res := planProperty(testCtx(), TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -585,7 +585,7 @@ func TestPlanPropertyDynamicTraefikMasksCredential(t *testing.T) {
 		return subprocess.ExecCommandResponse{}, nil
 	})()
 
-	res := planProperty(TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "traefiktoken")
+	res := planProperty(testCtx(), TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "traefiktoken")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}

--- a/tasks/property_coverage_test.go
+++ b/tasks/property_coverage_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -409,12 +410,14 @@ func TestRejectedPropertyFamiliesReportIdenticallyFromPlanAndValidate(t *testing
 				continue
 			}
 
-			planner, ok := instance.(interface{ Plan() PlanResult })
+			planner, ok := instance.(interface {
+				Plan(ctx context.Context) PlanResult
+			})
 			if !ok {
 				t.Errorf("task %q has no Plan() to compare against", name)
 				continue
 			}
-			plan := planner.Plan()
+			plan := planner.Plan(testCtx())
 			if plan.Status != PlanStatusError || plan.Error == nil {
 				t.Errorf("task %q plans %q instead of rejecting it: status %q", name, property, plan.Status)
 				continue

--- a/tasks/property_idempotency_helper_test.go
+++ b/tasks/property_idempotency_helper_test.go
@@ -1,12 +1,13 @@
 package tasks
 
 import (
+	"context"
 	"testing"
 )
 
 // propertyTask is the minimal Task interface used by the idempotency helper.
 type propertyTask interface {
-	Execute() TaskOutputState
+	Execute(ctx context.Context) TaskOutputState
 }
 
 // propertyIdempotencyCase describes the inputs to runPropertyIdempotencyTest.
@@ -21,7 +22,7 @@ type propertyIdempotencyCase struct {
 func runPropertyIdempotencyTest(t *testing.T, c propertyIdempotencyCase) {
 	t.Helper()
 
-	result := c.setTask.Execute()
+	result := c.setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("%s: failed to set: %v", c.label, result.Error)
 	}
@@ -29,7 +30,7 @@ func runPropertyIdempotencyTest(t *testing.T, c propertyIdempotencyCase) {
 		t.Errorf("%s: expected state 'present', got '%s'", c.label, result.State)
 	}
 
-	result = c.setTask.Execute()
+	result = c.setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("%s: failed to re-apply set: %v", c.label, result.Error)
 	}
@@ -37,7 +38,7 @@ func runPropertyIdempotencyTest(t *testing.T, c propertyIdempotencyCase) {
 		t.Errorf("%s: expected re-apply to report Changed=false", c.label)
 	}
 
-	result = c.unsetTask.Execute()
+	result = c.unsetTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("%s: failed to unset: %v", c.label, result.Error)
 	}
@@ -45,7 +46,7 @@ func runPropertyIdempotencyTest(t *testing.T, c propertyIdempotencyCase) {
 		t.Errorf("%s: expected state 'absent', got '%s'", c.label, result.State)
 	}
 
-	result = c.unsetTask.Execute()
+	result = c.unsetTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("%s: failed to re-apply unset: %v", c.label, result.Error)
 	}

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // ProxyPropertyTask manages the proxy configuration for a given dokku application
 type ProxyPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t ProxyPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the proxy property
-func (t ProxyPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ProxyPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // proxyPropertyTable maps proxy property names to the JSON keys emitted by
@@ -98,20 +100,20 @@ func (t ProxyPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the ProxyPropertyTask would produce.
-func (t ProxyPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t ProxyPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t ProxyPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t ProxyPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return ProxyPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t ProxyPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t ProxyPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return ProxyPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/proxy_property_task_integration_test.go
+++ b/tasks/proxy_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationProxyPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-proxy-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -35,7 +35,7 @@ func TestIntegrationProxyPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := ProxyPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "proxy global " + tc.property,
 					setTask:   ProxyPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/proxy_property_task_test.go
+++ b/tasks/proxy_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestProxyPropertyTaskInvalidState(t *testing.T) {
 	task := ProxyPropertyTask{App: "test-app", Property: "type", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestProxyPropertyTaskInvalidState(t *testing.T) {
 
 func TestProxyPropertyTaskMissingApp(t *testing.T) {
 	task := ProxyPropertyTask{Property: "type", Value: "nginx", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestProxyPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "nginx",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestProxyPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestProxyPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "nginx",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -8,10 +9,10 @@ import (
 
 // proxyEnabled probes whether the proxy is enabled for an app via
 // `dokku --quiet proxy:report <app> --proxy-enabled`. Output is "true"/"false".
-func proxyEnabled(ctx ToggleContext) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func proxyEnabled(ctx context.Context, tc ToggleContext) (bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    []string{"--quiet", "proxy:report", ctx.App, "--proxy-enabled"},
+		Args:    []string{"--quiet", "proxy:report", tc.App, "--proxy-enabled"},
 	})
 	if err != nil {
 		return false, err
@@ -21,8 +22,8 @@ func proxyEnabled(ctx ToggleContext) (bool, error) {
 
 // ExportApp emits a dokku_proxy_toggle task only when the proxy is disabled
 // (it is enabled by default).
-func (t ProxyToggleTask) ExportApp(app string) ([]interface{}, error) {
-	enabled, err := proxyEnabled(ToggleContext{App: app})
+func (t ProxyToggleTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	enabled, err := proxyEnabled(ctx, ToggleContext{App: app})
 	if err != nil {
 		return nil, err
 	}
@@ -84,13 +85,13 @@ func (t ProxyToggleTask) Examples() ([]Doc, error) {
 }
 
 // Execute enables or disables the proxy
-func (t ProxyToggleTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ProxyToggleTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the ProxyToggleTask would produce.
-func (t ProxyToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, "proxy:enable", "proxy:disable", proxyEnabled)
+func (t ProxyToggleTask) Plan(ctx context.Context) PlanResult {
+	return planToggle(ctx, t.State, t.App, "proxy:enable", "proxy:disable", proxyEnabled)
 }
 
 // init registers the ProxyToggleTask with the task registry

--- a/tasks/proxy_toggle_task_integration_test.go
+++ b/tasks/proxy_toggle_task_integration_test.go
@@ -9,13 +9,13 @@ func TestIntegrationProxyToggle(t *testing.T) {
 
 	appName := "docket-test-proxy"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// enable proxy
 	enableTask := ProxyToggleTask{App: appName, State: StatePresent}
-	result := enableTask.Execute()
+	result := enableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to enable proxy: %v", result.Error)
 	}
@@ -25,7 +25,7 @@ func TestIntegrationProxyToggle(t *testing.T) {
 
 	// disable proxy
 	disableTask := ProxyToggleTask{App: appName, State: StateAbsent}
-	result = disableTask.Execute()
+	result = disableTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to disable proxy: %v", result.Error)
 	}

--- a/tasks/proxy_toggle_task_test.go
+++ b/tasks/proxy_toggle_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestProxyToggleTaskInvalidState(t *testing.T) {
 	task := ProxyToggleTask{App: "test-app", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -27,7 +27,7 @@ func TestProxyToggleTaskPlanSurfacesSSHError(t *testing.T) {
 		}
 	})()
 
-	plan := ProxyToggleTask{App: "web", State: StateAbsent}.Plan()
+	plan := ProxyToggleTask{App: "web", State: StateAbsent}.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // PsPropertyTask manages the ps configuration for a given dokku application
 type PsPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t PsPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the ps property
-func (t PsPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t PsPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // psPropertyTable maps ps property names to the JSON keys emitted by
@@ -94,20 +96,20 @@ func (t PsPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the PsPropertyTask would produce.
-func (t PsPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t PsPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t PsPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t PsPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return PsPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t PsPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t PsPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return PsPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/ps_property_task_integration_test.go
+++ b/tasks/ps_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationPsPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-ps-prop"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -38,7 +38,7 @@ func TestIntegrationPsPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := PsPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "ps global " + tc.property,
 					setTask:   PsPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/ps_property_task_test.go
+++ b/tasks/ps_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestPsPropertyTaskInvalidState(t *testing.T) {
 	task := PsPropertyTask{App: "test-app", Property: "restart-policy", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestPsPropertyTaskInvalidState(t *testing.T) {
 
 func TestPsPropertyTaskMissingApp(t *testing.T) {
 	task := PsPropertyTask{Property: "restart-policy", Value: "on-failure:5", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestPsPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "on-failure:5",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestPsPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestPsPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "on-failure:5",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -82,8 +83,8 @@ func (t PsScaleTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets the process scale for a given dokku application
-func (t PsScaleTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t PsScaleTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the PsScaleTask's inputs without contacting the server.
@@ -95,13 +96,13 @@ func (t PsScaleTask) Validate() error {
 }
 
 // Plan reports the drift the PsScaleTask would produce.
-func (t PsScaleTask) Plan() PlanResult {
+func (t PsScaleTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			existing, err := getPsScale(t.App)
+			existing, err := getPsScale(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -141,9 +142,9 @@ func (t PsScaleTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("%d process scale change(s)", len(mutations)),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -152,8 +153,8 @@ func (t PsScaleTask) Plan() PlanResult {
 
 // ExportApp reads the app's process scale and returns a dokku_ps_scale task
 // when any process is scaled above zero (an undeployed app has nothing to set).
-func (t PsScaleTask) ExportApp(app string) ([]interface{}, error) {
-	scale, err := getPsScale(app)
+func (t PsScaleTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	scale, err := getPsScale(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +172,8 @@ func (t PsScaleTask) ExportApp(app string) ([]interface{}, error) {
 }
 
 // getPsScale retrieves the current process scale for a given dokku application
-func getPsScale(app string) (map[string]int, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getPsScale(ctx context.Context, app string) (map[string]int, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "ps:scale", app},
 	})

--- a/tasks/ps_scale_task_integration_test.go
+++ b/tasks/ps_scale_task_integration_test.go
@@ -12,9 +12,9 @@ func TestIntegrationPsScale(t *testing.T) {
 	appName := "docket-test-psscale"
 
 	// ensure clean state
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// deploy the smoke test app so we have running containers to scale
 	deployTask := GitFromImageTask{
@@ -22,7 +22,7 @@ func TestIntegrationPsScale(t *testing.T) {
 		Image: "dokku/smoke-test-app:dockerfile",
 		State: StateDeployed,
 	}
-	deployResult := deployTask.Execute()
+	deployResult := deployTask.Execute(testCtx())
 	if deployResult.Error != nil {
 		t.Fatalf("failed to deploy app: %v", deployResult.Error)
 	}
@@ -37,7 +37,7 @@ func TestIntegrationPsScale(t *testing.T) {
 	}
 
 	// verify the initial container is running via docker inspect
-	inspectResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	inspectResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"inspect", "--format", "{{.State.Running}}", initialContainers[0]},
 	})
@@ -54,7 +54,7 @@ func TestIntegrationPsScale(t *testing.T) {
 		Scale: map[string]int{"web": 2},
 		State: StatePresent,
 	}
-	result := scaleTask.Execute()
+	result := scaleTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to scale app: %v", result.Error)
 	}
@@ -76,7 +76,7 @@ func TestIntegrationPsScale(t *testing.T) {
 
 	// verify each container is running via docker inspect
 	for _, containerID := range scaledContainers {
-		inspectResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		inspectResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "docker",
 			Args:    []string{"inspect", "--format", "{{.State.Running}}", containerID},
 		})
@@ -89,7 +89,7 @@ func TestIntegrationPsScale(t *testing.T) {
 	}
 
 	// scaling again should be idempotent
-	result = scaleTask.Execute()
+	result = scaleTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent scale failed: %v", result.Error)
 	}
@@ -103,7 +103,7 @@ func TestIntegrationPsScale(t *testing.T) {
 		Scale: map[string]int{"web": 1},
 		State: StatePresent,
 	}
-	result = scaleDownTask.Execute()
+	result = scaleDownTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to scale down: %v", result.Error)
 	}
@@ -121,7 +121,7 @@ func TestIntegrationPsScale(t *testing.T) {
 	}
 
 	// verify the final container is running via docker inspect
-	inspectResult, err = subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	inspectResult, err = subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"inspect", "--format", "{{.State.Running}}", finalContainers[0]},
 	})
@@ -138,9 +138,9 @@ func TestIntegrationPsScaleSkipDeploy(t *testing.T) {
 
 	appName := "docket-test-psscale-sd"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// scale with skip_deploy on an undeployed app
 	scaleTask := PsScaleTask{
@@ -149,7 +149,7 @@ func TestIntegrationPsScaleSkipDeploy(t *testing.T) {
 		SkipDeploy: boolPtr(true),
 		State:      StatePresent,
 	}
-	result := scaleTask.Execute()
+	result := scaleTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to scale with skip_deploy: %v", result.Error)
 	}
@@ -158,7 +158,7 @@ func TestIntegrationPsScaleSkipDeploy(t *testing.T) {
 	}
 
 	// verify the scale was set correctly
-	scale, err := getPsScale(appName)
+	scale, err := getPsScale(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("failed to get ps scale: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestIntegrationPsScaleSkipDeploy(t *testing.T) {
 	}
 
 	// idempotent
-	result = scaleTask.Execute()
+	result = scaleTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent scale failed: %v", result.Error)
 	}

--- a/tasks/ps_scale_task_test.go
+++ b/tasks/ps_scale_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPsScaleTaskInvalidState(t *testing.T) {
 	task := PsScaleTask{App: "test-app", Scale: map[string]int{"web": 1}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -18,7 +18,7 @@ func TestPsScaleTaskInvalidState(t *testing.T) {
 
 func TestPsScaleTaskEmptyScale(t *testing.T) {
 	task := PsScaleTask{App: "test-app", Scale: map[string]int{}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty scale and state=present should return an error")
 	}
@@ -26,7 +26,7 @@ func TestPsScaleTaskEmptyScale(t *testing.T) {
 
 func TestPsScaleTaskNilScale(t *testing.T) {
 	task := PsScaleTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with nil scale and state=present should return an error")
 	}
@@ -52,7 +52,7 @@ func TestPsScaleCommandDeterministicOrder(t *testing.T) {
 	// Repeat so a reintroduced map-order bug is caught reliably rather than
 	// passing by chance on a lucky iteration.
 	for i := 0; i < 20; i++ {
-		plan := task.Plan()
+		plan := task.Plan(testCtx())
 		if plan.Error != nil {
 			t.Fatalf("iteration %d: unexpected plan error: %v", i, plan.Error)
 		}

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -99,8 +100,8 @@ func (t RegistryAuthTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the registry authentication
-func (t RegistryAuthTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t RegistryAuthTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the RegistryAuthTask's inputs without contacting the server.
@@ -117,7 +118,7 @@ func (t RegistryAuthTask) Validate() error {
 // Plan reports the drift the RegistryAuthTask would produce. dokku registry
 // plugins do not expose a probe for current login state, so the plan
 // reports drift unconditionally.
-func (t RegistryAuthTask) Plan() PlanResult {
+func (t RegistryAuthTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
@@ -144,9 +145,9 @@ func (t RegistryAuthTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "registry login state not probed",
 				Mutations: []string{fmt.Sprintf("registry:login %s %s as %s", target, t.Server, t.Username)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -164,9 +165,9 @@ func (t RegistryAuthTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "registry login state not probed",
 				Mutations: []string{fmt.Sprintf("registry:logout %s %s", target, t.Server)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/registry_auth_task_integration_test.go
+++ b/tasks/registry_auth_task_integration_test.go
@@ -16,7 +16,7 @@ func startTestRegistry(t *testing.T) string {
 	containerName := "docket-test-registry"
 
 	// best-effort cleanup of any previous run
-	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"rm", "-f", containerName},
 	})
@@ -24,7 +24,7 @@ func startTestRegistry(t *testing.T) string {
 	port := "5555"
 	server := "localhost:" + port
 
-	_, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	_, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args: []string{
 			"run", "-d", "--rm",
@@ -37,7 +37,7 @@ func startTestRegistry(t *testing.T) string {
 		t.Skipf("skipping integration test: failed to start registry:2 container: %v", err)
 	}
 	t.Cleanup(func() {
-		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "docker",
 			Args:    []string{"rm", "-f", containerName},
 		})
@@ -46,7 +46,7 @@ func startTestRegistry(t *testing.T) string {
 	// wait until the registry is reachable
 	deadline := time.Now().Add(20 * time.Second)
 	for {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "curl",
 			Args:    []string{"-sf", "http://" + server + "/v2/"},
 		})
@@ -67,12 +67,12 @@ func TestIntegrationRegistryAuthApp(t *testing.T) {
 	server := startTestRegistry(t)
 
 	appName := "docket-test-registry-auth"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// best-effort cleanup of any leftover credential
-	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute()
+	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute(testCtx())
 
 	// log in
 	loginTask := RegistryAuthTask{
@@ -82,7 +82,7 @@ func TestIntegrationRegistryAuthApp(t *testing.T) {
 		Password: "testpassword",
 		State:    StatePresent,
 	}
-	result := loginTask.Execute()
+	result := loginTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to log in: %v", result.Error)
 	}
@@ -95,7 +95,7 @@ func TestIntegrationRegistryAuthApp(t *testing.T) {
 
 	// log out
 	logoutTask := RegistryAuthTask{App: appName, Server: server, State: StateAbsent}
-	result = logoutTask.Execute()
+	result = logoutTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to log out: %v", result.Error)
 	}
@@ -112,9 +112,9 @@ func TestIntegrationRegistryAuthGlobal(t *testing.T) {
 	server := startTestRegistry(t)
 
 	// best-effort cleanup of any leftover global credential
-	(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute()
+	(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute(testCtx())
 	t.Cleanup(func() {
-		(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute()
+		(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute(testCtx())
 	})
 
 	loginTask := RegistryAuthTask{
@@ -124,7 +124,7 @@ func TestIntegrationRegistryAuthGlobal(t *testing.T) {
 		Password: "testpassword",
 		State:    StatePresent,
 	}
-	result := loginTask.Execute()
+	result := loginTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to log in globally: %v", result.Error)
 	}
@@ -133,7 +133,7 @@ func TestIntegrationRegistryAuthGlobal(t *testing.T) {
 	}
 
 	logoutTask := RegistryAuthTask{Global: true, Server: server, State: StateAbsent}
-	result = logoutTask.Execute()
+	result = logoutTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to log out globally: %v", result.Error)
 	}
@@ -155,9 +155,9 @@ func TestIntegrationRegistryAuthPasswordNotInArgs(t *testing.T) {
 	// being naively quoted into argv).
 	server := startTestRegistry(t)
 	appName := "docket-test-registry-auth-stdin"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	pw := "p@ss with spaces and 'quotes\""
 	loginTask := RegistryAuthTask{
@@ -167,7 +167,7 @@ func TestIntegrationRegistryAuthPasswordNotInArgs(t *testing.T) {
 		Password: pw,
 		State:    StatePresent,
 	}
-	result := loginTask.Execute()
+	result := loginTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("login with whitespace password failed: %v", result.Error)
 	}
@@ -175,5 +175,5 @@ func TestIntegrationRegistryAuthPasswordNotInArgs(t *testing.T) {
 		t.Errorf("password should not appear in task message")
 	}
 
-	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute()
+	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute(testCtx())
 }

--- a/tasks/registry_auth_task_test.go
+++ b/tasks/registry_auth_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRegistryAuthTaskInvalidState(t *testing.T) {
 	task := RegistryAuthTask{App: "test-app", Server: "docker.io", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestRegistryAuthTaskInvalidState(t *testing.T) {
 
 func TestRegistryAuthTaskMissingApp(t *testing.T) {
 	task := RegistryAuthTask{Server: "docker.io", Username: "u", Password: "p", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -26,7 +26,7 @@ func TestRegistryAuthTaskMissingApp(t *testing.T) {
 
 func TestRegistryAuthTaskGlobalWithApp(t *testing.T) {
 	task := RegistryAuthTask{App: "test-app", Global: true, Server: "docker.io", Username: "u", Password: "p", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -38,7 +38,7 @@ func TestRegistryAuthTaskGlobalWithApp(t *testing.T) {
 func TestRegistryAuthTaskMissingServer(t *testing.T) {
 	for _, st := range []State{StatePresent, StateAbsent} {
 		task := RegistryAuthTask{App: "test-app", Username: "u", Password: "p", State: st}
-		result := task.Execute()
+		result := task.Execute(testCtx())
 		if result.Error == nil {
 			t.Fatalf("expected error with empty server (state=%s)", st)
 		}
@@ -50,7 +50,7 @@ func TestRegistryAuthTaskMissingServer(t *testing.T) {
 
 func TestRegistryAuthTaskPresentMissingUsername(t *testing.T) {
 	task := RegistryAuthTask{App: "test-app", Server: "docker.io", Password: "p", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without username should return an error")
 	}
@@ -61,7 +61,7 @@ func TestRegistryAuthTaskPresentMissingUsername(t *testing.T) {
 
 func TestRegistryAuthTaskPresentMissingPassword(t *testing.T) {
 	task := RegistryAuthTask{App: "test-app", Server: "docker.io", Username: "u", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without password should return an error")
 	}

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // RegistryPropertyTask manages the registry configuration for a given dokku application
 type RegistryPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t RegistryPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the registry property
-func (t RegistryPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t RegistryPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // registryPropertyTable maps registry property names to the JSON keys
@@ -100,20 +102,20 @@ func (t RegistryPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the RegistryPropertyTask would produce.
-func (t RegistryPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t RegistryPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t RegistryPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t RegistryPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return RegistryPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t RegistryPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t RegistryPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return RegistryPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/registry_property_task_integration_test.go
+++ b/tasks/registry_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationRegistryPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-registry"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -37,7 +37,7 @@ func TestIntegrationRegistryPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := RegistryPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "registry global " + tc.property,
 					setTask:   RegistryPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/registry_property_task_test.go
+++ b/tasks/registry_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRegistryPropertyTaskInvalidState(t *testing.T) {
 	task := RegistryPropertyTask{App: "test-app", Property: "image-repo", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestRegistryPropertyTaskInvalidState(t *testing.T) {
 
 func TestRegistryPropertyTaskMissingApp(t *testing.T) {
 	task := RegistryPropertyTask{Property: "image-repo", Value: "registry.example.com/app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestRegistryPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "registry.example.com",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestRegistryPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestRegistryPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "registry.example.com/app",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // ResourceLimitTask manages the resource limits for a given dokku application
 type ResourceLimitTask struct {
 	// App is the name of the app
@@ -82,13 +84,13 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or clears the resource limits for a given dokku application
-func (t ResourceLimitTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ResourceLimitTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // ExportApp reconstructs the app's resource limits, one task per process type.
-func (t ResourceLimitTask) ExportApp(app string) ([]interface{}, error) {
-	return exportResourceTasks(app, "limit", func(app, processType string, resources map[string]string) interface{} {
+func (t ResourceLimitTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportResourceTasks(ctx, app, "limit", func(app, processType string, resources map[string]string) interface{} {
 		return ResourceLimitTask{App: app, ProcessType: processType, Resources: resources}
 	})
 }
@@ -99,8 +101,8 @@ func (t ResourceLimitTask) Validate() error {
 }
 
 // Plan reports the drift the ResourceLimitTask would produce.
-func (t ResourceLimitTask) Plan() PlanResult {
-	return planResource(t.State, t.App, t.ProcessType, t.Resources, boolValue(t.ClearBefore, false), "resource:limit")
+func (t ResourceLimitTask) Plan(ctx context.Context) PlanResult {
+	return planResource(ctx, t.State, t.App, t.ProcessType, t.Resources, boolValue(t.ClearBefore, false), "resource:limit")
 }
 
 // init registers the ResourceLimitTask with the task registry

--- a/tasks/resource_limit_task_integration_test.go
+++ b/tasks/resource_limit_task_integration_test.go
@@ -9,9 +9,9 @@ func TestIntegrationResourceLimit(t *testing.T) {
 
 	appName := "docket-test-reslimit"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// set resource limits
 	setTask := ResourceLimitTask{
@@ -19,7 +19,7 @@ func TestIntegrationResourceLimit(t *testing.T) {
 		Resources: map[string]string{"cpu": "100", "memory": "256"},
 		State:     StatePresent,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set resource limits: %v", result.Error)
 	}
@@ -31,7 +31,7 @@ func TestIntegrationResourceLimit(t *testing.T) {
 	}
 
 	// setting same limits again should be idempotent
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent set failed: %v", result.Error)
 	}
@@ -44,7 +44,7 @@ func TestIntegrationResourceLimit(t *testing.T) {
 		App:   appName,
 		State: StateAbsent,
 	}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear resource limits: %v", result.Error)
 	}
@@ -56,7 +56,7 @@ func TestIntegrationResourceLimit(t *testing.T) {
 	}
 
 	// clear again should be idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent clear failed: %v", result.Error)
 	}
@@ -70,9 +70,9 @@ func TestIntegrationResourceLimitProcessType(t *testing.T) {
 
 	appName := "docket-test-reslimit-pt"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// set resource limits for a specific process type
 	setTask := ResourceLimitTask{
@@ -81,7 +81,7 @@ func TestIntegrationResourceLimitProcessType(t *testing.T) {
 		Resources:   map[string]string{"memory": "512"},
 		State:       StatePresent,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set resource limits: %v", result.Error)
 	}
@@ -90,7 +90,7 @@ func TestIntegrationResourceLimitProcessType(t *testing.T) {
 	}
 
 	// idempotent
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent set failed: %v", result.Error)
 	}
@@ -106,7 +106,7 @@ func TestIntegrationResourceLimitProcessType(t *testing.T) {
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
 	}
-	result = clearBeforeTask.Execute()
+	result = clearBeforeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear_before and set: %v", result.Error)
 	}
@@ -120,7 +120,7 @@ func TestIntegrationResourceLimitProcessType(t *testing.T) {
 		ProcessType: "web",
 		State:       StateAbsent,
 	}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear: %v", result.Error)
 	}

--- a/tasks/resource_limit_task_test.go
+++ b/tasks/resource_limit_task_test.go
@@ -15,7 +15,7 @@ func TestResourceLimitTaskInvalidState(t *testing.T) {
 		Resources: map[string]string{"cpu": "100"},
 		State:     "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -23,7 +23,7 @@ func TestResourceLimitTaskInvalidState(t *testing.T) {
 
 func TestResourceLimitTaskEmptyResources(t *testing.T) {
 	task := ResourceLimitTask{App: "test-app", Resources: map[string]string{}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty resources and state=present should return an error")
 	}
@@ -31,7 +31,7 @@ func TestResourceLimitTaskEmptyResources(t *testing.T) {
 
 func TestResourceLimitTaskNilResources(t *testing.T) {
 	task := ResourceLimitTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with nil resources and state=present should return an error")
 	}
@@ -47,7 +47,7 @@ func TestResourceLimitClearBeforeConvergesWhenMatched(t *testing.T) {
 		Resources:   map[string]string{"cpu": "100"},
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -67,7 +67,7 @@ func TestResourceLimitClearBeforeIgnoresEmptyExtraResource(t *testing.T) {
 		Resources:   map[string]string{"cpu": "100"},
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -87,7 +87,7 @@ func TestResourceLimitClearBeforeClearsNonDesiredResource(t *testing.T) {
 		Resources:   map[string]string{"cpu": "100"},
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
-	}.Plan()
+	}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -134,7 +134,7 @@ func TestResourceLimitSetCommandDeterministicOrder(t *testing.T) {
 	// Repeat so a reintroduced map-order bug is caught reliably rather than
 	// passing by chance on a lucky iteration.
 	for i := 0; i < 20; i++ {
-		plan := task.Plan()
+		plan := task.Plan(testCtx())
 		if plan.Error != nil {
 			t.Fatalf("iteration %d: unexpected plan error: %v", i, plan.Error)
 		}

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // ResourceReserveTask manages the resource reservations for a given dokku application
 type ResourceReserveTask struct {
 	// App is the name of the app
@@ -82,13 +84,13 @@ func (t ResourceReserveTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or clears the resource reservations for a given dokku application
-func (t ResourceReserveTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ResourceReserveTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // ExportApp reconstructs the app's resource reservations, one task per process type.
-func (t ResourceReserveTask) ExportApp(app string) ([]interface{}, error) {
-	return exportResourceTasks(app, "reserve", func(app, processType string, resources map[string]string) interface{} {
+func (t ResourceReserveTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportResourceTasks(ctx, app, "reserve", func(app, processType string, resources map[string]string) interface{} {
 		return ResourceReserveTask{App: app, ProcessType: processType, Resources: resources}
 	})
 }
@@ -99,8 +101,8 @@ func (t ResourceReserveTask) Validate() error {
 }
 
 // Plan reports the drift the ResourceReserveTask would produce.
-func (t ResourceReserveTask) Plan() PlanResult {
-	return planResource(t.State, t.App, t.ProcessType, t.Resources, boolValue(t.ClearBefore, false), "resource:reserve")
+func (t ResourceReserveTask) Plan(ctx context.Context) PlanResult {
+	return planResource(ctx, t.State, t.App, t.ProcessType, t.Resources, boolValue(t.ClearBefore, false), "resource:reserve")
 }
 
 // init registers the ResourceReserveTask with the task registry

--- a/tasks/resource_reserve_task_integration_test.go
+++ b/tasks/resource_reserve_task_integration_test.go
@@ -9,9 +9,9 @@ func TestIntegrationResourceReserve(t *testing.T) {
 
 	appName := "docket-test-resreserve"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// set resource reservations
 	setTask := ResourceReserveTask{
@@ -19,7 +19,7 @@ func TestIntegrationResourceReserve(t *testing.T) {
 		Resources: map[string]string{"cpu": "100", "memory": "256"},
 		State:     StatePresent,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set resource reservations: %v", result.Error)
 	}
@@ -31,7 +31,7 @@ func TestIntegrationResourceReserve(t *testing.T) {
 	}
 
 	// setting same reservations again should be idempotent
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent set failed: %v", result.Error)
 	}
@@ -44,7 +44,7 @@ func TestIntegrationResourceReserve(t *testing.T) {
 		App:   appName,
 		State: StateAbsent,
 	}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear resource reservations: %v", result.Error)
 	}
@@ -56,7 +56,7 @@ func TestIntegrationResourceReserve(t *testing.T) {
 	}
 
 	// clear again should be idempotent
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent clear failed: %v", result.Error)
 	}
@@ -70,9 +70,9 @@ func TestIntegrationResourceReserveProcessType(t *testing.T) {
 
 	appName := "docket-test-resreserve-pt"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// set resource reservations for a specific process type
 	setTask := ResourceReserveTask{
@@ -81,7 +81,7 @@ func TestIntegrationResourceReserveProcessType(t *testing.T) {
 		Resources:   map[string]string{"memory": "512"},
 		State:       StatePresent,
 	}
-	result := setTask.Execute()
+	result := setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to set resource reservations: %v", result.Error)
 	}
@@ -90,7 +90,7 @@ func TestIntegrationResourceReserveProcessType(t *testing.T) {
 	}
 
 	// idempotent
-	result = setTask.Execute()
+	result = setTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent set failed: %v", result.Error)
 	}
@@ -106,7 +106,7 @@ func TestIntegrationResourceReserveProcessType(t *testing.T) {
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
 	}
-	result = clearBeforeTask.Execute()
+	result = clearBeforeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear_before and set: %v", result.Error)
 	}
@@ -120,7 +120,7 @@ func TestIntegrationResourceReserveProcessType(t *testing.T) {
 		ProcessType: "web",
 		State:       StateAbsent,
 	}
-	result = clearTask.Execute()
+	result = clearTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to clear: %v", result.Error)
 	}

--- a/tasks/resource_reserve_task_test.go
+++ b/tasks/resource_reserve_task_test.go
@@ -14,7 +14,7 @@ func TestResourceReserveTaskInvalidState(t *testing.T) {
 		Resources: map[string]string{"cpu": "100"},
 		State:     "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -22,7 +22,7 @@ func TestResourceReserveTaskInvalidState(t *testing.T) {
 
 func TestResourceReserveTaskEmptyResources(t *testing.T) {
 	task := ResourceReserveTask{App: "test-app", Resources: map[string]string{}, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with empty resources and state=present should return an error")
 	}
@@ -30,7 +30,7 @@ func TestResourceReserveTaskEmptyResources(t *testing.T) {
 
 func TestResourceReserveTaskNilResources(t *testing.T) {
 	task := ResourceReserveTask{App: "test-app", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with nil resources and state=present should return an error")
 	}
@@ -56,7 +56,7 @@ func TestResourceReserveSetCommandDeterministicOrder(t *testing.T) {
 	// Repeat so a reintroduced map-order bug is caught reliably rather than
 	// passing by chance on a lucky iteration.
 	for i := 0; i < 20; i++ {
-		plan := task.Plan()
+		plan := task.Plan(testCtx())
 		if plan.Error != nil {
 			t.Fatalf("iteration %d: unexpected plan error: %v", i, plan.Error)
 		}

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,7 +27,7 @@ type ResourceContext struct {
 }
 
 // getResources retrieves the current resources for a given dokku application
-func getResources(subcommand string, rctx ResourceContext) (map[string]string, error) {
+func getResources(ctx context.Context, subcommand string, rctx ResourceContext) (map[string]string, error) {
 	args := []string{
 		"--quiet",
 		subcommand,
@@ -38,7 +39,7 @@ func getResources(subcommand string, rctx ResourceContext) (map[string]string, e
 
 	args = append(args, rctx.App)
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    args,
 	})
@@ -68,8 +69,8 @@ func getResources(subcommand string, rctx ResourceContext) (map[string]string, e
 // "reserve") from resource:report, one task per process type (in sorted order),
 // carrying only the explicitly-set (non-empty) resources. factory builds the
 // concrete task body for a (process type, resources) pair.
-func exportResourceTasks(app, kind string, factory func(app, processType string, resources map[string]string) interface{}) ([]interface{}, error) {
-	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func exportResourceTasks(ctx context.Context, app, kind string, factory func(app, processType string, resources map[string]string) interface{}) ([]interface{}, error) {
+	response, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "resource:report", app, "--format", "json"},
 	})
@@ -134,7 +135,7 @@ func validateResourceInput(state State, resources map[string]string) error {
 	return nil
 }
 
-func planResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
+func planResource(ctx context.Context, state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
 	if err := validateResourceInput(state, resources); err != nil {
 		return planErr(err)
 	}
@@ -147,14 +148,14 @@ func planResource(state State, app, processType string, resources map[string]str
 	}
 
 	return DispatchPlan(state, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planSetResource(subcommand, rctx) },
-		StateAbsent:  func() PlanResult { return planClearResource(subcommand, rctx) },
+		StatePresent: func() PlanResult { return planSetResource(ctx, subcommand, rctx) },
+		StateAbsent:  func() PlanResult { return planClearResource(ctx, subcommand, rctx) },
 	})
 }
 
 // planSetResource reports drift for a present-state resource set.
-func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
-	currentResources, err := getResources(subcommand, rctx)
+func planSetResource(ctx context.Context, subcommand string, rctx ResourceContext) PlanResult {
+	currentResources, err := getResources(ctx, subcommand, rctx)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -196,7 +197,7 @@ func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d resource(s) to set", len(mutations)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyResourceSet(subcommand, effective),
 	}
 }
@@ -223,8 +224,8 @@ func clearBeforeChanges(current, desired map[string]string) bool {
 }
 
 // planClearResource reports drift for an absent-state resource clear.
-func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
-	currentResources, err := getResources(subcommand, rctx)
+func planClearResource(ctx context.Context, subcommand string, rctx ResourceContext) PlanResult {
+	currentResources, err := getResources(ctx, subcommand, rctx)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -246,7 +247,7 @@ func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    "would clear all resources",
 		Mutations: []string{fmt.Sprintf("clear resources via %s-clear", subcommand)},
-		Commands:  resolveCommands(inputs),
+		Commands:  resolveCommands(ctx, inputs),
 		apply:     applyResourceClear(subcommand, rctx),
 	}
 }
@@ -283,19 +284,19 @@ func resourceSetInputs(subcommand string, rctx ResourceContext) []subprocess.Exe
 
 // applyResourceSet returns a closure that runs the underlying resource
 // set command. ClearBefore is honored by clearing before setting.
-func applyResourceSet(subcommand string, rctx ResourceContext) func() TaskOutputState {
+func applyResourceSet(subcommand string, rctx ResourceContext) func(ctx context.Context) TaskOutputState {
 	inputs := resourceSetInputs(subcommand, rctx)
-	return func() TaskOutputState {
-		return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+	return func(ctx context.Context) TaskOutputState {
+		return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 	}
 }
 
 // applyResourceClear returns a closure that runs the underlying resource
 // clear command (subcommand + "-clear").
-func applyResourceClear(subcommand string, rctx ResourceContext) func() TaskOutputState {
+func applyResourceClear(subcommand string, rctx ResourceContext) func(ctx context.Context) TaskOutputState {
 	inputs := []subprocess.ExecCommandInput{resourceClearInput(subcommand, rctx)}
-	return func() TaskOutputState {
-		return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+	return func(ctx context.Context) TaskOutputState {
+		return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 	}
 }
 

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // SchedulerDockerLocalPropertyTask manages the scheduler-docker-local configuration for a given dokku application
 type SchedulerDockerLocalPropertyTask struct {
 	// App is the name of the app
@@ -75,8 +77,8 @@ func (t SchedulerDockerLocalPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the scheduler-docker-local property
-func (t SchedulerDockerLocalPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerDockerLocalPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // schedulerDockerLocalPropertyTable maps scheduler-docker-local property
@@ -102,13 +104,13 @@ func (t SchedulerDockerLocalPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerDockerLocalPropertyTask would produce.
-func (t SchedulerDockerLocalPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, false, t.Property, t.Value)
+func (t SchedulerDockerLocalPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, false, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t SchedulerDockerLocalPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t SchedulerDockerLocalPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return SchedulerDockerLocalPropertyTask{App: app, Property: property, Value: value}
 	})
 }

--- a/tasks/scheduler_docker_local_property_task_integration_test.go
+++ b/tasks/scheduler_docker_local_property_task_integration_test.go
@@ -10,9 +10,9 @@ func TestIntegrationSchedulerDockerLocalPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-scheduler-docker-local"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string

--- a/tasks/scheduler_docker_local_property_task_test.go
+++ b/tasks/scheduler_docker_local_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSchedulerDockerLocalPropertyTaskInvalidState(t *testing.T) {
 	task := SchedulerDockerLocalPropertyTask{App: "test-app", Property: "init-process", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestSchedulerDockerLocalPropertyTaskInvalidState(t *testing.T) {
 
 func TestSchedulerDockerLocalPropertyTaskMissingApp(t *testing.T) {
 	task := SchedulerDockerLocalPropertyTask{Property: "init-process", Value: "true", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app should return an error")
 	}
@@ -31,7 +31,7 @@ func TestSchedulerDockerLocalPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -47,7 +47,7 @@ func TestSchedulerDockerLocalPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "true",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/scheduler_k3s_annotations_task.go
+++ b/tasks/scheduler_k3s_annotations_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // SchedulerK3sAnnotationsTask manages a group of scheduler-k3s annotations
 // scoped to a (process_type, resource_type) pair on a dokku application or
 // globally.
@@ -107,8 +109,8 @@ func (t SchedulerK3sAnnotationsTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or clears the scheduler-k3s annotations for the configured scope
-func (t SchedulerK3sAnnotationsTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerK3sAnnotationsTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the SchedulerK3sAnnotationsTask's inputs without contacting the server.
@@ -117,14 +119,14 @@ func (t SchedulerK3sAnnotationsTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerK3sAnnotationsTask would produce.
-func (t SchedulerK3sAnnotationsTask) Plan() PlanResult {
+func (t SchedulerK3sAnnotationsTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	spec := t.spec()
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(spec) },
-		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(spec) },
+		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(ctx, spec) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(ctx, spec) },
 	})
 }
 
@@ -143,8 +145,8 @@ func (t SchedulerK3sAnnotationsTask) spec() schedulerK3sScopedPairsSpec {
 
 // ExportApp reconstructs the app's annotations, one task per
 // (process_type, resource_type) scope, from scheduler-k3s:annotations:report.
-func (t SchedulerK3sAnnotationsTask) ExportApp(app string) ([]interface{}, error) {
-	return exportSchedulerK3sScopedPairs("annotations", app, false, func(processType, resourceType string, pairs map[string]string) interface{} {
+func (t SchedulerK3sAnnotationsTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs(ctx, "annotations", app, false, func(processType, resourceType string, pairs map[string]string) interface{} {
 		return SchedulerK3sAnnotationsTask{
 			App:          app,
 			ProcessType:  processType,
@@ -156,8 +158,8 @@ func (t SchedulerK3sAnnotationsTask) ExportApp(app string) ([]interface{}, error
 
 // ExportGlobal reconstructs the global-scope annotations, one task per
 // (process_type, resource_type) scope, from scheduler-k3s:annotations:report.
-func (t SchedulerK3sAnnotationsTask) ExportGlobal() ([]interface{}, error) {
-	return exportSchedulerK3sScopedPairs("annotations", "", true, func(processType, resourceType string, pairs map[string]string) interface{} {
+func (t SchedulerK3sAnnotationsTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs(ctx, "annotations", "", true, func(processType, resourceType string, pairs map[string]string) interface{} {
 		return SchedulerK3sAnnotationsTask{
 			Global:       true,
 			ProcessType:  processType,

--- a/tasks/scheduler_k3s_annotations_task_integration_test.go
+++ b/tasks/scheduler_k3s_annotations_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationSchedulerK3sAnnotationsAll(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	appName := "docket-test-scheduler-k3s-annotations"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		name         string
@@ -90,7 +90,7 @@ func TestIntegrationSchedulerK3sAnnotationsAll(t *testing.T) {
 				Annotations:  tc.annotations,
 				State:        StateAbsent,
 			}
-			defer unsetTask.Execute()
+			defer unsetTask.Execute(testCtx())
 			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 				label:     "scheduler-k3s annotations " + tc.name,
 				setTask:   setTask,

--- a/tasks/scheduler_k3s_annotations_task_test.go
+++ b/tasks/scheduler_k3s_annotations_task_test.go
@@ -12,7 +12,7 @@ func TestSchedulerK3sAnnotationsTaskInvalidState(t *testing.T) {
 		Annotations:  map[string]string{"prometheus.io/scrape": "true"},
 		State:        "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -24,7 +24,7 @@ func TestSchedulerK3sAnnotationsTaskMissingApp(t *testing.T) {
 		Annotations:  map[string]string{"prometheus.io/scrape": "true"},
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -41,7 +41,7 @@ func TestSchedulerK3sAnnotationsTaskGlobalWithAppSet(t *testing.T) {
 		Annotations:  map[string]string{"prometheus.io/scrape": "true"},
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -56,7 +56,7 @@ func TestSchedulerK3sAnnotationsTaskMissingResourceType(t *testing.T) {
 		Annotations: map[string]string{"prometheus.io/scrape": "true"},
 		State:       StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when resource_type is empty")
 	}
@@ -71,7 +71,7 @@ func TestSchedulerK3sAnnotationsTaskPresentWithoutAnnotations(t *testing.T) {
 		ResourceType: "deployment",
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no annotations")
 	}
@@ -86,7 +86,7 @@ func TestSchedulerK3sAnnotationsTaskAbsentWithoutAnnotations(t *testing.T) {
 		ResourceType: "deployment",
 		State:        StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has no annotations")
 	}
@@ -102,7 +102,7 @@ func TestSchedulerK3sAnnotationsTaskEmptyAnnotationKey(t *testing.T) {
 		Annotations:  map[string]string{"": "true"},
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when an annotation key is empty")
 	}

--- a/tasks/scheduler_k3s_autoscaling_auth.go
+++ b/tasks/scheduler_k3s_autoscaling_auth.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -55,8 +56,8 @@ func validateSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec, s
 // computes the drifted keys, and emits one bulk `:set` call carrying a
 // `--metadata k=v` flag per drifted key. Dokku's `:set` is an additive merge,
 // so extra keys not in the spec are left alone.
-func planSchedulerK3sAutoscalingAuthSet(spec schedulerK3sAutoscalingAuthSpec) PlanResult {
-	current, err := getSchedulerK3sAutoscalingAuth(spec)
+func planSchedulerK3sAutoscalingAuthSet(ctx context.Context, spec schedulerK3sAutoscalingAuthSpec) PlanResult {
+	current, err := getSchedulerK3sAutoscalingAuth(ctx, spec)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -80,9 +81,9 @@ func planSchedulerK3sAutoscalingAuthSet(spec schedulerK3sAutoscalingAuthSpec) Pl
 		Status:    status,
 		Reason:    fmt.Sprintf("%d metadata key(s) to set", len(drifted)),
 		Mutations: formatSetMutations(drifted, spec.Metadata, current),
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
@@ -93,8 +94,8 @@ func planSchedulerK3sAutoscalingAuthSet(spec schedulerK3sAutoscalingAuthSpec) Pl
 // the only public-CLI route to clearing specific keys is to wipe the whole
 // trigger and re-set the keys the task does NOT name. Any key not in the
 // current map is skipped (already absent).
-func planSchedulerK3sAutoscalingAuthUnset(spec schedulerK3sAutoscalingAuthSpec) PlanResult {
-	current, err := getSchedulerK3sAutoscalingAuth(spec)
+func planSchedulerK3sAutoscalingAuthUnset(ctx context.Context, spec schedulerK3sAutoscalingAuthSpec) PlanResult {
+	current, err := getSchedulerK3sAutoscalingAuth(ctx, spec)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -137,9 +138,9 @@ func planSchedulerK3sAutoscalingAuthUnset(spec schedulerK3sAutoscalingAuthSpec) 
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d metadata key(s) to unset", len(toClear)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }
@@ -187,7 +188,7 @@ func schedulerK3sAutoscalingAuthClearCommand(spec schedulerK3sAutoscalingAuthSpe
 // metadata values (dokku only masks stdout and single-flag output, never the
 // JSON payload). We keep the entries under our trigger and strip the
 // `<trigger>.` prefix to recover the original metadata keys.
-func getSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec) (map[string]string, error) {
+func getSchedulerK3sAutoscalingAuth(ctx context.Context, spec schedulerK3sAutoscalingAuthSpec) (map[string]string, error) {
 	args := []string{"--quiet", "scheduler-k3s:autoscaling-auth:report"}
 	if spec.Global {
 		args = append(args, "--global")
@@ -196,7 +197,7 @@ func getSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec) (map[s
 	}
 	args = append(args, "--format", "json")
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    args,
 	})
@@ -238,13 +239,13 @@ func parseSchedulerK3sAutoscalingAuthReport(raw []byte, trigger string) (map[str
 // body. Non-SSH errors and unparseable output are swallowed (return nil) so a
 // host without scheduler-k3s state does not fail the whole export, mirroring
 // the profile and chart exporters.
-func exportSchedulerK3sAutoscalingAuth(app string, global bool, build func(trigger string, metadata map[string]string) interface{}) ([]interface{}, error) {
+func exportSchedulerK3sAutoscalingAuth(ctx context.Context, app string, global bool, build func(trigger string, metadata map[string]string) interface{}) ([]interface{}, error) {
 	target := app
 	if global {
 		target = "--global"
 	}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "scheduler-k3s:autoscaling-auth:report", target, "--format", "json"},
 	})

--- a/tasks/scheduler_k3s_autoscaling_auth_task.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // SchedulerK3sAutoscalingAuthTask manages the KEDA TriggerAuthentication
 // metadata stored under a single trigger for a dokku application or globally.
 type SchedulerK3sAutoscalingAuthTask struct {
@@ -111,8 +113,8 @@ func (t SchedulerK3sAutoscalingAuthTask) SensitiveValues() []string {
 }
 
 // Execute sets or clears the scheduler-k3s autoscaling trigger authentication metadata
-func (t SchedulerK3sAutoscalingAuthTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerK3sAutoscalingAuthTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the SchedulerK3sAutoscalingAuthTask's inputs without contacting the server.
@@ -121,14 +123,14 @@ func (t SchedulerK3sAutoscalingAuthTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerK3sAutoscalingAuthTask would produce.
-func (t SchedulerK3sAutoscalingAuthTask) Plan() PlanResult {
+func (t SchedulerK3sAutoscalingAuthTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	spec := t.spec()
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planSchedulerK3sAutoscalingAuthSet(spec) },
-		StateAbsent:  func() PlanResult { return planSchedulerK3sAutoscalingAuthUnset(spec) },
+		StatePresent: func() PlanResult { return planSchedulerK3sAutoscalingAuthSet(ctx, spec) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sAutoscalingAuthUnset(ctx, spec) },
 	})
 }
 
@@ -145,8 +147,8 @@ func (t SchedulerK3sAutoscalingAuthTask) spec() schedulerK3sAutoscalingAuthSpec 
 // ExportApp reconstructs the app's trigger authentication metadata, one task
 // per trigger, from scheduler-k3s:autoscaling-auth:report. The metadata values
 // are secrets; the export engine lifts them into the companion vars-file.
-func (t SchedulerK3sAutoscalingAuthTask) ExportApp(app string) ([]interface{}, error) {
-	return exportSchedulerK3sAutoscalingAuth(app, false, func(trigger string, metadata map[string]string) interface{} {
+func (t SchedulerK3sAutoscalingAuthTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportSchedulerK3sAutoscalingAuth(ctx, app, false, func(trigger string, metadata map[string]string) interface{} {
 		return SchedulerK3sAutoscalingAuthTask{
 			App:      app,
 			Trigger:  trigger,
@@ -157,8 +159,8 @@ func (t SchedulerK3sAutoscalingAuthTask) ExportApp(app string) ([]interface{}, e
 
 // ExportGlobal reconstructs the global-scope trigger authentication metadata,
 // one task per trigger, from scheduler-k3s:autoscaling-auth:report.
-func (t SchedulerK3sAutoscalingAuthTask) ExportGlobal() ([]interface{}, error) {
-	return exportSchedulerK3sAutoscalingAuth("", true, func(trigger string, metadata map[string]string) interface{} {
+func (t SchedulerK3sAutoscalingAuthTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportSchedulerK3sAutoscalingAuth(ctx, "", true, func(trigger string, metadata map[string]string) interface{} {
 		return SchedulerK3sAutoscalingAuthTask{
 			Global:   true,
 			Trigger:  trigger,

--- a/tasks/scheduler_k3s_autoscaling_auth_task_integration_test.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationSchedulerK3sAutoscalingAuthAll(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	appName := "docket-test-scheduler-k3s-autoscaling-auth"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		name     string
@@ -63,7 +63,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthAll(t *testing.T) {
 				Metadata: tc.metadata,
 				State:    StateAbsent,
 			}
-			defer unsetTask.Execute()
+			defer unsetTask.Execute(testCtx())
 			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 				label:     "scheduler-k3s autoscaling-auth " + tc.name,
 				setTask:   setTask,
@@ -79,9 +79,9 @@ func TestIntegrationSchedulerK3sAutoscalingAuthPartialClear(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	appName := "docket-test-scheduler-k3s-autoscaling-auth-partial"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	trigger := "aws-secret-manager"
 
@@ -96,7 +96,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthPartialClear(t *testing.T) {
 		},
 		State: StatePresent,
 	}
-	if result := seed.Execute(); result.Error != nil {
+	if result := seed.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("seed set failed: %v", result.Error)
 	}
 
@@ -110,17 +110,17 @@ func TestIntegrationSchedulerK3sAutoscalingAuthPartialClear(t *testing.T) {
 		},
 		State: StateAbsent,
 	}
-	if result := clear.Execute(); result.Error != nil {
+	if result := clear.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("partial clear failed: %v", result.Error)
 	}
-	if result := clear.Execute(); result.Error != nil {
+	if result := clear.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("re-apply partial clear failed: %v", result.Error)
 	} else if result.Changed {
 		t.Errorf("re-apply partial clear should be a no-op, got Changed=true")
 	}
 
 	// Verify roleArn still exists and the other two are gone.
-	current, err := getSchedulerK3sAutoscalingAuth(schedulerK3sAutoscalingAuthSpec{
+	current, err := getSchedulerK3sAutoscalingAuth(testCtx(), schedulerK3sAutoscalingAuthSpec{
 		App:      appName,
 		Trigger:  trigger,
 		Metadata: map[string]string{},
@@ -147,7 +147,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthPartialClear(t *testing.T) {
 		},
 		State: StateAbsent,
 	}
-	finalClear.Execute()
+	finalClear.Execute(testCtx())
 }
 
 // TestIntegrationSchedulerK3sAutoscalingAuthAdditivePresent verifies that
@@ -156,9 +156,9 @@ func TestIntegrationSchedulerK3sAutoscalingAuthAdditivePresent(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	appName := "docket-test-scheduler-k3s-autoscaling-auth-additive"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	trigger := "aws-secret-manager"
 
@@ -172,7 +172,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthAdditivePresent(t *testing.T) {
 		},
 		State: StatePresent,
 	}
-	if result := seed.Execute(); result.Error != nil {
+	if result := seed.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("seed set failed: %v", result.Error)
 	}
 	defer SchedulerK3sAutoscalingAuthTask{
@@ -184,7 +184,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthAdditivePresent(t *testing.T) {
 			"extraKey":   "",
 		},
 		State: StateAbsent,
-	}.Execute()
+	}.Execute(testCtx())
 
 	// Apply present with only the two original keys; extraKey should be left alone.
 	apply := SchedulerK3sAutoscalingAuthTask{
@@ -196,7 +196,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthAdditivePresent(t *testing.T) {
 		},
 		State: StatePresent,
 	}
-	result := apply.Execute()
+	result := apply.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("present re-apply failed: %v", result.Error)
 	}
@@ -204,7 +204,7 @@ func TestIntegrationSchedulerK3sAutoscalingAuthAdditivePresent(t *testing.T) {
 		t.Errorf("present re-apply with no drift should be a no-op, got Changed=true")
 	}
 
-	current, err := getSchedulerK3sAutoscalingAuth(schedulerK3sAutoscalingAuthSpec{
+	current, err := getSchedulerK3sAutoscalingAuth(testCtx(), schedulerK3sAutoscalingAuthSpec{
 		App:      appName,
 		Trigger:  trigger,
 		Metadata: map[string]string{},

--- a/tasks/scheduler_k3s_autoscaling_auth_task_test.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task_test.go
@@ -54,7 +54,7 @@ func TestSchedulerK3sAutoscalingAuthUnsetMasksProbedSecrets(t *testing.T) {
 		Metadata: map[string]string{"secretName": ""},
 		State:    StateAbsent,
 	}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error != nil {
 		t.Fatalf("Plan returned error: %v", result.Error)
 	}
@@ -90,7 +90,7 @@ func TestSchedulerK3sAutoscalingAuthTaskInvalidState(t *testing.T) {
 		Metadata: map[string]string{"awsRegion": "us-east-1"},
 		State:    "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -102,7 +102,7 @@ func TestSchedulerK3sAutoscalingAuthTaskMissingApp(t *testing.T) {
 		Metadata: map[string]string{"awsRegion": "us-east-1"},
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -119,7 +119,7 @@ func TestSchedulerK3sAutoscalingAuthTaskGlobalWithAppSet(t *testing.T) {
 		Metadata: map[string]string{"awsRegion": "us-east-1"},
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -134,7 +134,7 @@ func TestSchedulerK3sAutoscalingAuthTaskMissingTrigger(t *testing.T) {
 		Metadata: map[string]string{"awsRegion": "us-east-1"},
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when trigger is empty")
 	}
@@ -149,7 +149,7 @@ func TestSchedulerK3sAutoscalingAuthTaskPresentWithoutMetadata(t *testing.T) {
 		Trigger: "aws-secret-manager",
 		State:   StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no metadata")
 	}
@@ -164,7 +164,7 @@ func TestSchedulerK3sAutoscalingAuthTaskAbsentWithoutMetadata(t *testing.T) {
 		Trigger: "aws-secret-manager",
 		State:   StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has no metadata")
 	}
@@ -180,7 +180,7 @@ func TestSchedulerK3sAutoscalingAuthTaskEmptyMetadataKey(t *testing.T) {
 		Metadata: map[string]string{"": "value"},
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when a metadata key is empty")
 	}

--- a/tasks/scheduler_k3s_chart_task.go
+++ b/tasks/scheduler_k3s_chart_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -118,8 +119,8 @@ func (t SchedulerK3sChartTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or clears the configured chart values
-func (t SchedulerK3sChartTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerK3sChartTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the SchedulerK3sChartTask's inputs without contacting the server.
@@ -151,7 +152,7 @@ func (t SchedulerK3sChartTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerK3sChartTask would produce.
-func (t SchedulerK3sChartTask) Plan() PlanResult {
+func (t SchedulerK3sChartTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
@@ -161,8 +162,8 @@ func (t SchedulerK3sChartTask) Plan() PlanResult {
 	// guaranteed nil.
 	desired, _ := flattenChartValues(t.Values)
 
-	currentFn := func() (map[string]string, error) {
-		return getSchedulerK3sChartValues(t.Chart)
+	currentFn := func(ctx context.Context) (map[string]string, error) {
+		return getSchedulerK3sChartValues(ctx, t.Chart)
 	}
 	commandFn := func(key, value string) subprocess.ExecCommandInput {
 		return subprocess.ExecCommandInput{
@@ -177,8 +178,8 @@ func (t SchedulerK3sChartTask) Plan() PlanResult {
 	}
 
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planPairsSet("chart value", desired, currentFn, commandFn) },
-		StateAbsent:  func() PlanResult { return planPairsUnset("chart value", desired, currentFn, commandFn) },
+		StatePresent: func() PlanResult { return planPairsSet(ctx, "chart value", desired, currentFn, commandFn) },
+		StateAbsent:  func() PlanResult { return planPairsUnset(ctx, "chart value", desired, currentFn, commandFn) },
 	})
 }
 
@@ -187,8 +188,8 @@ func (t SchedulerK3sChartTask) Plan() PlanResult {
 // keyed `<chart>.<override-key>`; this strips the `<chart>.` prefix to
 // return a map keyed by the override key alone (matching the form
 // callers hand back when setting).
-func getSchedulerK3sChartValues(chart string) (map[string]string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getSchedulerK3sChartValues(ctx context.Context, chart string) (map[string]string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -343,8 +344,8 @@ func escapeChartSegment(segment string) string {
 // ExportGlobal reconstructs helm chart value overrides from charts:report,
 // which returns every override keyed "<chart>.<key>". Values are grouped into
 // one task per chart, keyed by the dotted override path.
-func (t SchedulerK3sChartTask) ExportGlobal() ([]interface{}, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func (t SchedulerK3sChartTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "scheduler-k3s:charts:report", "--format", "json"},
 	})

--- a/tasks/scheduler_k3s_chart_task_integration_test.go
+++ b/tasks/scheduler_k3s_chart_task_integration_test.go
@@ -61,7 +61,7 @@ func TestIntegrationSchedulerK3sChartAll(t *testing.T) {
 				Values: tc.values,
 				State:  StateAbsent,
 			}
-			defer unsetTask.Execute()
+			defer unsetTask.Execute(testCtx())
 			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 				label:     "scheduler-k3s chart " + tc.name,
 				setTask:   setTask,

--- a/tasks/scheduler_k3s_chart_task_test.go
+++ b/tasks/scheduler_k3s_chart_task_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,7 +15,7 @@ func TestSchedulerK3sChartTaskInvalidState(t *testing.T) {
 		Values: map[string]any{"replicaCount": "3"},
 		State:  "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -25,7 +26,7 @@ func TestSchedulerK3sChartTaskMissingChart(t *testing.T) {
 		Values: map[string]any{"replicaCount": "3"},
 		State:  StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when chart is empty")
 	}
@@ -39,7 +40,7 @@ func TestSchedulerK3sChartTaskPresentWithoutValues(t *testing.T) {
 		Chart: "ingress-nginx",
 		State: StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no values")
 	}
@@ -53,7 +54,7 @@ func TestSchedulerK3sChartTaskAbsentWithoutValues(t *testing.T) {
 		Chart: "ingress-nginx",
 		State: StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has no values")
 	}
@@ -94,7 +95,7 @@ func TestSchedulerK3sChartTaskRejectsListValue(t *testing.T) {
 		Values: map[string]any{"hosts": []any{"a", "b"}},
 		State:  StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when value is a list")
 	}
@@ -304,8 +305,8 @@ func TestSchedulerK3sChartTaskCommandShapeSet(t *testing.T) {
 	desired := map[string]string{"replicaCount": "3"}
 	chart := "ingress-nginx"
 	commandFn := schedulerK3sChartsCommandFor(t, chart)
-	plan := planPairsSet("chart value", desired,
-		func() (map[string]string, error) { return current, nil },
+	plan := planPairsSet(testCtx(), "chart value", desired,
+		func(ctx context.Context) (map[string]string, error) { return current, nil },
 		commandFn,
 	)
 	if len(plan.Commands) != 1 {
@@ -322,8 +323,8 @@ func TestSchedulerK3sChartTaskCommandShapeClear(t *testing.T) {
 	desired := map[string]string{"replicaCount": "ignored"}
 	chart := "ingress-nginx"
 	commandFn := schedulerK3sChartsCommandFor(t, chart)
-	plan := planPairsUnset("chart value", desired,
-		func() (map[string]string, error) { return current, nil },
+	plan := planPairsUnset(testCtx(), "chart value", desired,
+		func(ctx context.Context) (map[string]string, error) { return current, nil },
 		commandFn,
 	)
 	if len(plan.Commands) != 1 {

--- a/tasks/scheduler_k3s_export_test.go
+++ b/tasks/scheduler_k3s_export_test.go
@@ -84,7 +84,7 @@ func TestSchedulerK3sAnnotationsExportApp(t *testing.T) {
 		}`,
 	}))()
 
-	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp("myapp")
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(testCtx(), "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestSchedulerK3sAnnotationsExportGlobal(t *testing.T) {
 		"--quiet scheduler-k3s:annotations:report --global --format json": `{"global.deployment.managed-by":"docket"}`,
 	}))()
 
-	bodies, err := SchedulerK3sAnnotationsTask{}.ExportGlobal()
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestSchedulerK3sLabelsExportApp(t *testing.T) {
 		"--quiet scheduler-k3s:labels:report myapp --format json": `{"web.deployment.tier":"edge","web.deployment.app.kubernetes.io/component":"api"}`,
 	}))()
 
-	bodies, err := SchedulerK3sLabelsTask{}.ExportApp("myapp")
+	bodies, err := SchedulerK3sLabelsTask{}.ExportApp(testCtx(), "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestSchedulerK3sAutoscalingAuthExportApp(t *testing.T) {
 		}`,
 	}))()
 
-	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp("myapp")
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp(testCtx(), "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestSchedulerK3sAutoscalingAuthExportGlobal(t *testing.T) {
 		"--quiet scheduler-k3s:autoscaling-auth:report --global --format json": `{"datadog.apiKey":"global-secret"}`,
 	}))()
 
-	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportGlobal()
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestSchedulerK3sScopedPairsExportEmpty(t *testing.T) {
 		"--quiet scheduler-k3s:annotations:report myapp --format json": `{}`,
 	}))()
 
-	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp("myapp")
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(testCtx(), "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestExportSchedulerK3sScopedAndAuthRecipe(t *testing.T) {
 		"--quiet scheduler-k3s:autoscaling-auth:report web --format json": `{"datadog.apiKey":"s3cr3t-key"}`,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestSchedulerK3sProfileExportReportLeavesOutUnappliableProfiles(t *testing.
 	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
 
 	var warnings []string
-	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(func(msg string) {
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(testCtx(), func(msg string) {
 		warnings = append(warnings, msg)
 	})
 	if err != nil {
@@ -362,7 +362,7 @@ func TestSchedulerK3sProfileExportReportLeavesOutUnappliableProfiles(t *testing.
 func TestSchedulerK3sProfileExportGlobalDropsWithoutDiagnostics(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
 
-	bodies, err := SchedulerK3sProfileTask{}.ExportGlobal()
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestSchedulerK3sProfileExportGlobalDropsWithoutDiagnostics(t *testing.T) {
 func TestExportSchedulerK3sProfileRecipeOmitsUnappliableProfiles(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestExportSchedulerK3sProfileResourceAddressReportsAMissingProfile(t *testi
 	if err != nil {
 		t.Fatalf("ParseResourceSelectors: %v", err)
 	}
-	res, err := ExportRecipe(ExportOptions{Resources: selectors})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Resources: selectors})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/scheduler_k3s_labels_task.go
+++ b/tasks/scheduler_k3s_labels_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // SchedulerK3sLabelsTask manages a group of scheduler-k3s labels scoped to a
 // (process_type, resource_type) pair on a dokku application or globally.
 type SchedulerK3sLabelsTask struct {
@@ -105,8 +107,8 @@ func (t SchedulerK3sLabelsTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or clears the scheduler-k3s labels for the configured scope
-func (t SchedulerK3sLabelsTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerK3sLabelsTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the SchedulerK3sLabelsTask's inputs without contacting the server.
@@ -115,14 +117,14 @@ func (t SchedulerK3sLabelsTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerK3sLabelsTask would produce.
-func (t SchedulerK3sLabelsTask) Plan() PlanResult {
+func (t SchedulerK3sLabelsTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	spec := t.spec()
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(spec) },
-		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(spec) },
+		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(ctx, spec) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(ctx, spec) },
 	})
 }
 
@@ -141,8 +143,8 @@ func (t SchedulerK3sLabelsTask) spec() schedulerK3sScopedPairsSpec {
 
 // ExportApp reconstructs the app's labels, one task per
 // (process_type, resource_type) scope, from scheduler-k3s:labels:report.
-func (t SchedulerK3sLabelsTask) ExportApp(app string) ([]interface{}, error) {
-	return exportSchedulerK3sScopedPairs("labels", app, false, func(processType, resourceType string, pairs map[string]string) interface{} {
+func (t SchedulerK3sLabelsTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs(ctx, "labels", app, false, func(processType, resourceType string, pairs map[string]string) interface{} {
 		return SchedulerK3sLabelsTask{
 			App:          app,
 			ProcessType:  processType,
@@ -154,8 +156,8 @@ func (t SchedulerK3sLabelsTask) ExportApp(app string) ([]interface{}, error) {
 
 // ExportGlobal reconstructs the global-scope labels, one task per
 // (process_type, resource_type) scope, from scheduler-k3s:labels:report.
-func (t SchedulerK3sLabelsTask) ExportGlobal() ([]interface{}, error) {
-	return exportSchedulerK3sScopedPairs("labels", "", true, func(processType, resourceType string, pairs map[string]string) interface{} {
+func (t SchedulerK3sLabelsTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs(ctx, "labels", "", true, func(processType, resourceType string, pairs map[string]string) interface{} {
 		return SchedulerK3sLabelsTask{
 			Global:       true,
 			ProcessType:  processType,

--- a/tasks/scheduler_k3s_labels_task_integration_test.go
+++ b/tasks/scheduler_k3s_labels_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationSchedulerK3sLabelsAll(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	appName := "docket-test-scheduler-k3s-labels"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		name         string
@@ -83,7 +83,7 @@ func TestIntegrationSchedulerK3sLabelsAll(t *testing.T) {
 				Labels:       tc.labels,
 				State:        StateAbsent,
 			}
-			defer unsetTask.Execute()
+			defer unsetTask.Execute(testCtx())
 			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 				label:     "scheduler-k3s labels " + tc.name,
 				setTask:   setTask,

--- a/tasks/scheduler_k3s_labels_task_test.go
+++ b/tasks/scheduler_k3s_labels_task_test.go
@@ -12,7 +12,7 @@ func TestSchedulerK3sLabelsTaskInvalidState(t *testing.T) {
 		Labels:       map[string]string{"tier": "edge"},
 		State:        "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -24,7 +24,7 @@ func TestSchedulerK3sLabelsTaskMissingApp(t *testing.T) {
 		Labels:       map[string]string{"tier": "edge"},
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -41,7 +41,7 @@ func TestSchedulerK3sLabelsTaskGlobalWithAppSet(t *testing.T) {
 		Labels:       map[string]string{"tier": "edge"},
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -56,7 +56,7 @@ func TestSchedulerK3sLabelsTaskMissingResourceType(t *testing.T) {
 		Labels: map[string]string{"tier": "edge"},
 		State:  StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when resource_type is empty")
 	}
@@ -71,7 +71,7 @@ func TestSchedulerK3sLabelsTaskPresentWithoutLabels(t *testing.T) {
 		ResourceType: "deployment",
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no labels")
 	}
@@ -86,7 +86,7 @@ func TestSchedulerK3sLabelsTaskAbsentWithoutLabels(t *testing.T) {
 		ResourceType: "deployment",
 		State:        StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has no labels")
 	}
@@ -102,7 +102,7 @@ func TestSchedulerK3sLabelsTaskEmptyLabelKey(t *testing.T) {
 		Labels:       map[string]string{"": "edge"},
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when a label key is empty")
 	}

--- a/tasks/scheduler_k3s_profile_task.go
+++ b/tasks/scheduler_k3s_profile_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -108,8 +109,8 @@ func (t SchedulerK3sProfileTask) Examples() ([]Doc, error) {
 }
 
 // Execute drives the profile to the configured state.
-func (t SchedulerK3sProfileTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerK3sProfileTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the SchedulerK3sProfileTask's inputs without contacting the server.
@@ -121,14 +122,14 @@ func (t SchedulerK3sProfileTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerK3sProfileTask would produce.
-func (t SchedulerK3sProfileTask) Plan() PlanResult {
+func (t SchedulerK3sProfileTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planSchedulerK3sProfileSet(t) },
-		StateAbsent:  func() PlanResult { return planSchedulerK3sProfileUnset(t) },
+		StatePresent: func() PlanResult { return planSchedulerK3sProfileSet(ctx, t) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sProfileUnset(ctx, t) },
 	})
 }
 
@@ -246,8 +247,8 @@ func validateSchedulerK3sProfile(t SchedulerK3sProfileTask) error {
 // boolean flags appear only when true; kubelet args are emitted in
 // user-declared order so the stored slice tracks the YAML for any apply that
 // actually runs.
-func planSchedulerK3sProfileSet(t SchedulerK3sProfileTask) PlanResult {
-	current, found, err := getSchedulerK3sProfile(t.Name)
+func planSchedulerK3sProfileSet(ctx context.Context, t SchedulerK3sProfileTask) PlanResult {
+	current, found, err := getSchedulerK3sProfile(ctx, t.Name)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -266,9 +267,9 @@ func planSchedulerK3sProfileSet(t SchedulerK3sProfileTask) PlanResult {
 		Status:    status,
 		Reason:    fmt.Sprintf("profile %s drift", t.Name),
 		Mutations: []string{formatProfileSetMutation(t, current, found)},
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
@@ -276,8 +277,8 @@ func planSchedulerK3sProfileSet(t SchedulerK3sProfileTask) PlanResult {
 // planSchedulerK3sProfileUnset probes for the named profile and removes it
 // only when present. dokku's `profiles:remove` silently succeeds when the
 // profile is missing, but skipping the call keeps Changed=false honest.
-func planSchedulerK3sProfileUnset(t SchedulerK3sProfileTask) PlanResult {
-	_, found, err := getSchedulerK3sProfile(t.Name)
+func planSchedulerK3sProfileUnset(ctx context.Context, t SchedulerK3sProfileTask) PlanResult {
+	_, found, err := getSchedulerK3sProfile(ctx, t.Name)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -294,9 +295,9 @@ func planSchedulerK3sProfileUnset(t SchedulerK3sProfileTask) PlanResult {
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("profile %s present", t.Name),
 		Mutations: []string{"remove profile " + t.Name},
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }
@@ -333,8 +334,8 @@ type schedulerK3sProfileEntry struct {
 // `scheduler-k3s:profiles:list --format json`. There is no `profiles:report`
 // subcommand, so the list call (returning every profile) is the only public
 // route to a single profile.
-func getSchedulerK3sProfile(name string) (schedulerK3sProfileEntry, bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func getSchedulerK3sProfile(ctx context.Context, name string) (schedulerK3sProfileEntry, bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -426,16 +427,16 @@ func formatProfileSetMutation(t SchedulerK3sProfileTask, current schedulerK3sPro
 // no-op warn callback. The export engine prefers ExportGlobalReport when
 // present, so the left-out-profile diagnostic reaches ExportReport.Warnings
 // rather than being discarded here.
-func (t SchedulerK3sProfileTask) ExportGlobal() ([]interface{}, error) {
-	return t.exportGlobal(func(string) {})
+func (t SchedulerK3sProfileTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return t.exportGlobal(ctx, func(string) {})
 }
 
 // ExportGlobalReport is the diagnostics-aware form of ExportGlobal (the
 // globalExportReporter interface): it routes the "profile left out" warning
 // through the engine's warn callback (wired to ExportReport.Warnings) instead
 // of dropping the profile silently.
-func (t SchedulerK3sProfileTask) ExportGlobalReport(warn func(msg string)) ([]interface{}, error) {
-	return t.exportGlobal(warn)
+func (t SchedulerK3sProfileTask) ExportGlobalReport(ctx context.Context, warn func(msg string)) ([]interface{}, error) {
+	return t.exportGlobal(ctx, warn)
 }
 
 // exportGlobal reconstructs every scheduler-k3s node profile from
@@ -453,8 +454,8 @@ func (t SchedulerK3sProfileTask) ExportGlobalReport(warn func(msg string)) ([]in
 // recipe that does come back applies. The warning names the profile and the
 // remedy, since a left-out profile is also one docket can no longer be asked to
 // remove.
-func (t SchedulerK3sProfileTask) exportGlobal(warn func(msg string)) ([]interface{}, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func (t SchedulerK3sProfileTask) exportGlobal(ctx context.Context, warn func(msg string)) ([]interface{}, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "scheduler-k3s:profiles:list", "--format", "json"},
 	})

--- a/tasks/scheduler_k3s_profile_task_integration_test.go
+++ b/tasks/scheduler_k3s_profile_task_integration_test.go
@@ -72,7 +72,7 @@ func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
 			setTask.State = StatePresent
 			unsetTask := tc.task
 			unsetTask.State = StateAbsent
-			defer unsetTask.Execute()
+			defer unsetTask.Execute(testCtx())
 			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 				label:     "scheduler-k3s profile " + tc.name,
 				setTask:   setTask,
@@ -99,9 +99,9 @@ func TestIntegrationSchedulerK3sProfileFieldDrift(t *testing.T) {
 		AllowUnknownHosts: true,
 		State:             StatePresent,
 	}
-	defer SchedulerK3sProfileTask{Name: profileName, Role: "worker", State: StateAbsent}.Execute()
+	defer SchedulerK3sProfileTask{Name: profileName, Role: "worker", State: StateAbsent}.Execute(testCtx())
 
-	if result := seed.Execute(); result.Error != nil {
+	if result := seed.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("seed failed: %v", result.Error)
 	}
 
@@ -162,7 +162,7 @@ func TestIntegrationSchedulerK3sProfileFieldDrift(t *testing.T) {
 	for _, step := range steps {
 		t.Run(step.name, func(t *testing.T) {
 			next := step.mutate(current)
-			result := next.Execute()
+			result := next.Execute(testCtx())
 			if result.Error != nil {
 				t.Fatalf("apply failed: %v", result.Error)
 			}
@@ -170,7 +170,7 @@ func TestIntegrationSchedulerK3sProfileFieldDrift(t *testing.T) {
 				t.Errorf("expected Changed=true on drift apply, got false")
 			}
 
-			reapply := next.Execute()
+			reapply := next.Execute(testCtx())
 			if reapply.Error != nil {
 				t.Fatalf("re-apply failed: %v", reapply.Error)
 			}
@@ -178,7 +178,7 @@ func TestIntegrationSchedulerK3sProfileFieldDrift(t *testing.T) {
 				t.Errorf("expected Changed=false on immediate re-apply, got true")
 			}
 
-			entry, found, err := getSchedulerK3sProfile(profileName)
+			entry, found, err := getSchedulerK3sProfile(testCtx(), profileName)
 			if err != nil {
 				t.Fatalf("probe failed: %v", err)
 			}

--- a/tasks/scheduler_k3s_profile_task_test.go
+++ b/tasks/scheduler_k3s_profile_task_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSchedulerK3sProfileTaskMissingName(t *testing.T) {
 	task := SchedulerK3sProfileTask{Role: "worker", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when name is empty")
 	}
@@ -19,7 +19,7 @@ func TestSchedulerK3sProfileTaskMissingName(t *testing.T) {
 
 func TestSchedulerK3sProfileTaskMissingRole(t *testing.T) {
 	task := SchedulerK3sProfileTask{Name: "edge-pool", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when role is empty")
 	}
@@ -30,7 +30,7 @@ func TestSchedulerK3sProfileTaskMissingRole(t *testing.T) {
 
 func TestSchedulerK3sProfileTaskInvalidRole(t *testing.T) {
 	task := SchedulerK3sProfileTask{Name: "edge-pool", Role: "controlplane", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when role is invalid")
 	}
@@ -56,7 +56,7 @@ func TestSchedulerK3sProfileTaskInvalidKubeletArg(t *testing.T) {
 				KubeletArgs: tc.args,
 				State:       StatePresent,
 			}
-			result := task.Execute()
+			result := task.Execute(testCtx())
 			if result.Error == nil {
 				t.Fatalf("expected error for kubelet_args=%v", tc.args)
 			}
@@ -180,7 +180,7 @@ func TestSchedulerK3sProfileNameHelmLimitDerivation(t *testing.T) {
 
 func TestSchedulerK3sProfileTaskInvalidState(t *testing.T) {
 	task := SchedulerK3sProfileTask{Name: "edge-pool", Role: "worker", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when state is invalid")
 	}

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // SchedulerK3sPropertyTask manages the scheduler-k3s configuration for a given dokku application
 type SchedulerK3sPropertyTask PropertyFields
 
@@ -71,8 +73,8 @@ func (t SchedulerK3sPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the scheduler-k3s property
-func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerK3sPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // schedulerK3sPropertyTable maps scheduler-k3s property names to the JSON
@@ -120,20 +122,20 @@ func (t SchedulerK3sPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerK3sPropertyTask would produce.
-func (t SchedulerK3sPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t SchedulerK3sPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t SchedulerK3sPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t SchedulerK3sPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return SchedulerK3sPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t SchedulerK3sPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t SchedulerK3sPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return SchedulerK3sPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/scheduler_k3s_property_task_integration_test.go
+++ b/tasks/scheduler_k3s_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationSchedulerK3sPropertyAll(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	appName := "docket-test-scheduler-k3s"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -46,7 +46,7 @@ func TestIntegrationSchedulerK3sPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := SchedulerK3sPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "scheduler-k3s global " + tc.property,
 					setTask:   SchedulerK3sPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/scheduler_k3s_property_task_test.go
+++ b/tasks/scheduler_k3s_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSchedulerK3sPropertyTaskInvalidState(t *testing.T) {
 	task := SchedulerK3sPropertyTask{App: "test-app", Property: "deploy-timeout", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestSchedulerK3sPropertyTaskInvalidState(t *testing.T) {
 
 func TestSchedulerK3sPropertyTaskMissingApp(t *testing.T) {
 	task := SchedulerK3sPropertyTask{Property: "deploy-timeout", Value: "300s", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestSchedulerK3sPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "admin@example.com",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestSchedulerK3sPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestSchedulerK3sPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "300s",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}
@@ -77,7 +77,7 @@ func TestSchedulerK3sPropertyTaskRejectsChartProperty(t *testing.T) {
 		Value:    "3",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected chart.* property to be rejected")
 	}
@@ -108,7 +108,7 @@ func TestSchedulerK3sPropertyTaskChartRejectionIsIdenticalOffline(t *testing.T) 
 		t.Fatal("Validate should reject a chart.* property")
 	}
 
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusError || plan.Error == nil {
 		t.Fatalf("Plan should reject a chart.* property, got status %q error %v", plan.Status, plan.Error)
 	}

--- a/tasks/scheduler_k3s_scoped_pairs.go
+++ b/tasks/scheduler_k3s_scoped_pairs.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -59,11 +60,11 @@ func validateSchedulerK3sScopedPairs(spec schedulerK3sScopedPairsSpec, state Sta
 
 // planSchedulerK3sScopedPairsSet delegates to planPairsSet with a current-state
 // reader and a per-key command builder bound to the spec's scope.
-func planSchedulerK3sScopedPairsSet(spec schedulerK3sScopedPairsSpec) PlanResult {
-	return planPairsSet(
+func planSchedulerK3sScopedPairsSet(ctx context.Context, spec schedulerK3sScopedPairsSpec) PlanResult {
+	return planPairsSet(ctx,
 		singularizeSchedulerK3sKind(spec.Kind),
 		spec.Pairs,
-		func() (map[string]string, error) { return getSchedulerK3sScopedPairs(spec) },
+		func(ctx context.Context) (map[string]string, error) { return getSchedulerK3sScopedPairs(ctx, spec) },
 		func(key, value string) subprocess.ExecCommandInput {
 			return schedulerK3sScopedPairsCommand(spec, key, value)
 		},
@@ -73,11 +74,11 @@ func planSchedulerK3sScopedPairsSet(spec schedulerK3sScopedPairsSpec) PlanResult
 // planSchedulerK3sScopedPairsUnset delegates to planPairsUnset; the command
 // builder passes an empty value, which dokku's `:labels:set` / `:annotations:set`
 // interpret as "clear this key".
-func planSchedulerK3sScopedPairsUnset(spec schedulerK3sScopedPairsSpec) PlanResult {
-	return planPairsUnset(
+func planSchedulerK3sScopedPairsUnset(ctx context.Context, spec schedulerK3sScopedPairsSpec) PlanResult {
+	return planPairsUnset(ctx,
 		singularizeSchedulerK3sKind(spec.Kind),
 		spec.Pairs,
-		func() (map[string]string, error) { return getSchedulerK3sScopedPairs(spec) },
+		func(ctx context.Context) (map[string]string, error) { return getSchedulerK3sScopedPairs(ctx, spec) },
 		func(key, value string) subprocess.ExecCommandInput {
 			return schedulerK3sScopedPairsCommand(spec, key, value)
 		},
@@ -105,7 +106,7 @@ func schedulerK3sScopedPairsCommand(spec schedulerK3sScopedPairsSpec, key, value
 // `dokku scheduler-k3s:<kind>:report ... --format json`, which returns a flat
 // map keyed by `<rendered_process_type>.<resource_type>.<key>`, and strips the
 // prefix to recover the original keys.
-func getSchedulerK3sScopedPairs(spec schedulerK3sScopedPairsSpec) (map[string]string, error) {
+func getSchedulerK3sScopedPairs(ctx context.Context, spec schedulerK3sScopedPairsSpec) (map[string]string, error) {
 	args := []string{"--quiet", "scheduler-k3s:" + spec.Kind + ":report"}
 	if spec.Global {
 		args = append(args, "--global")
@@ -121,7 +122,7 @@ func getSchedulerK3sScopedPairs(spec schedulerK3sScopedPairsSpec) (map[string]st
 	args = append(args, "--process-type", effectiveProcessType)
 	args = append(args, "--format", "json")
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    args,
 	})
@@ -185,13 +186,13 @@ func schedulerK3sReportProcessTypeToTask(rendered string) string {
 // the task struct. Non-SSH errors and unparseable output are swallowed (return
 // nil) so a host without scheduler-k3s state does not fail the whole export,
 // mirroring the profile and chart exporters.
-func exportSchedulerK3sScopedPairs(kind, app string, global bool, build func(processType, resourceType string, pairs map[string]string) interface{}) ([]interface{}, error) {
+func exportSchedulerK3sScopedPairs(ctx context.Context, kind, app string, global bool, build func(processType, resourceType string, pairs map[string]string) interface{}) ([]interface{}, error) {
 	target := app
 	if global {
 		target = "--global"
 	}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "scheduler-k3s:" + kind + ":report", target, "--format", "json"},
 	})

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // SchedulerPropertyTask manages the scheduler configuration for a given dokku application
 type SchedulerPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t SchedulerPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the scheduler property
-func (t SchedulerPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SchedulerPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // schedulerPropertyTable maps scheduler property names to the JSON keys
@@ -88,20 +90,20 @@ func (t SchedulerPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the SchedulerPropertyTask would produce.
-func (t SchedulerPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t SchedulerPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t SchedulerPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t SchedulerPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return SchedulerPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t SchedulerPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t SchedulerPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return SchedulerPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/scheduler_property_task_integration_test.go
+++ b/tasks/scheduler_property_task_integration_test.go
@@ -8,9 +8,9 @@ func TestIntegrationSchedulerPropertyAll(t *testing.T) {
 	skipIfNoDokkuT(t)
 
 	appName := "docket-test-scheduler"
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	cases := []struct {
 		property string
@@ -34,7 +34,7 @@ func TestIntegrationSchedulerPropertyAll(t *testing.T) {
 		if tc.global {
 			t.Run(tc.property+"/global", func(t *testing.T) {
 				unsetTask := SchedulerPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-				defer unsetTask.Execute()
+				defer unsetTask.Execute(testCtx())
 				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 					label:     "scheduler global " + tc.property,
 					setTask:   SchedulerPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},

--- a/tasks/scheduler_property_task_test.go
+++ b/tasks/scheduler_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSchedulerPropertyTaskInvalidState(t *testing.T) {
 	task := SchedulerPropertyTask{App: "test-app", Property: "selected", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestSchedulerPropertyTaskInvalidState(t *testing.T) {
 
 func TestSchedulerPropertyTaskMissingApp(t *testing.T) {
 	task := SchedulerPropertyTask{Property: "selected", Value: "docker-local", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestSchedulerPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "docker-local",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestSchedulerPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestSchedulerPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "docker-local",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tasks/sensitive_test.go
+++ b/tasks/sensitive_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"sort"
 	"testing"
 )
@@ -16,8 +17,8 @@ type fakeTask struct {
 
 func (f *fakeTask) Doc() string                  { return "" }
 func (f *fakeTask) Examples() ([]Doc, error)     { return nil, nil }
-func (f *fakeTask) Plan() PlanResult             { return PlanResult{} }
-func (f *fakeTask) Execute() TaskOutputState     { return TaskOutputState{} }
+func (f *fakeTask) Plan(ctx context.Context) PlanResult             { return PlanResult{} }
+func (f *fakeTask) Execute(ctx context.Context) TaskOutputState     { return TaskOutputState{} }
 
 type taggedSliceTask struct {
 	Tokens []string `sensitive:"true"`
@@ -25,8 +26,8 @@ type taggedSliceTask struct {
 
 func (t *taggedSliceTask) Doc() string              { return "" }
 func (t *taggedSliceTask) Examples() ([]Doc, error) { return nil, nil }
-func (t *taggedSliceTask) Plan() PlanResult         { return PlanResult{} }
-func (t *taggedSliceTask) Execute() TaskOutputState { return TaskOutputState{} }
+func (t *taggedSliceTask) Plan(ctx context.Context) PlanResult         { return PlanResult{} }
+func (t *taggedSliceTask) Execute(ctx context.Context) TaskOutputState { return TaskOutputState{} }
 
 type taggedMapTask struct {
 	Headers map[string]string `sensitive:"true"`
@@ -34,8 +35,8 @@ type taggedMapTask struct {
 
 func (t *taggedMapTask) Doc() string              { return "" }
 func (t *taggedMapTask) Examples() ([]Doc, error) { return nil, nil }
-func (t *taggedMapTask) Plan() PlanResult         { return PlanResult{} }
-func (t *taggedMapTask) Execute() TaskOutputState { return TaskOutputState{} }
+func (t *taggedMapTask) Plan(ctx context.Context) PlanResult         { return PlanResult{} }
+func (t *taggedMapTask) Execute(ctx context.Context) TaskOutputState { return TaskOutputState{} }
 
 type nestedTask struct {
 	Outer struct {
@@ -45,8 +46,8 @@ type nestedTask struct {
 
 func (n *nestedTask) Doc() string              { return "" }
 func (n *nestedTask) Examples() ([]Doc, error) { return nil, nil }
-func (n *nestedTask) Plan() PlanResult         { return PlanResult{} }
-func (n *nestedTask) Execute() TaskOutputState { return TaskOutputState{} }
+func (n *nestedTask) Plan(ctx context.Context) PlanResult         { return PlanResult{} }
+func (n *nestedTask) Execute(ctx context.Context) TaskOutputState { return TaskOutputState{} }
 
 type overrideTask struct {
 	Field string `sensitive:"true"`
@@ -55,8 +56,8 @@ type overrideTask struct {
 
 func (o *overrideTask) Doc() string                { return "" }
 func (o *overrideTask) Examples() ([]Doc, error)   { return nil, nil }
-func (o *overrideTask) Plan() PlanResult           { return PlanResult{} }
-func (o *overrideTask) Execute() TaskOutputState   { return TaskOutputState{} }
+func (o *overrideTask) Plan(ctx context.Context) PlanResult           { return PlanResult{} }
+func (o *overrideTask) Execute(ctx context.Context) TaskOutputState   { return TaskOutputState{} }
 func (o *overrideTask) SensitiveValues() []string {
 	out := make([]string, 0, len(o.Map))
 	for _, v := range o.Map {

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -90,14 +91,14 @@ func (t ServiceBackupTask) ProbeSupport() ProbeSupport {
 // credentials and encryption passphrase have no read command, so they are
 // omitted (a partial export) and must be re-supplied before the recipe backs
 // up. Services without a schedule are skipped.
-func (t ServiceBackupTask) ExportGlobal() ([]interface{}, error) {
-	services, err := listServices()
+func (t ServiceBackupTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	services, err := listServices(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var out []interface{}
 	for _, s := range services {
-		content, scheduled, err := serviceBackupScheduled(s.Type, s.Name)
+		content, scheduled, err := serviceBackupScheduled(ctx, s.Type, s.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -197,8 +198,8 @@ func (t ServiceBackupTask) Examples() ([]Doc, error) {
 }
 
 // Execute manages the backup configuration for a dokku service
-func (t ServiceBackupTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ServiceBackupTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // hasAuth reports whether any AWS credential field was provided.
@@ -241,13 +242,13 @@ func (t ServiceBackupTask) Validate() error {
 }
 
 // Plan reports the drift the ServiceBackupTask would produce.
-func (t ServiceBackupTask) Plan() PlanResult {
+func (t ServiceBackupTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -282,7 +283,7 @@ func (t ServiceBackupTask) Plan() PlanResult {
 			}
 
 			if t.Schedule != "" {
-				content, scheduled, err := serviceBackupScheduled(t.Service, t.Name)
+				content, scheduled, err := serviceBackupScheduled(ctx, t.Service, t.Name)
 				if err != nil {
 					return PlanResult{Status: PlanStatusError, Error: err}
 				}
@@ -307,14 +308,14 @@ func (t ServiceBackupTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "backup configuration not in sync",
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -325,7 +326,7 @@ func (t ServiceBackupTask) Plan() PlanResult {
 			inputs := []subprocess.ExecCommandInput{}
 			mutations := []string{}
 
-			_, scheduled, err := serviceBackupScheduled(t.Service, t.Name)
+			_, scheduled, err := serviceBackupScheduled(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -359,9 +360,9 @@ func (t ServiceBackupTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "backup configuration present",
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -373,8 +374,8 @@ func (t ServiceBackupTask) Plan() PlanResult {
 // transport-level failure (`*subprocess.SSHError`) is propagated; a
 // dokku-level non-zero exit (no schedule configured) is treated as
 // "not scheduled."
-func serviceBackupScheduled(service, name string) (string, bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func serviceBackupScheduled(ctx context.Context, service, name string) (string, bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",

--- a/tasks/service_backup_task_test.go
+++ b/tasks/service_backup_task_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestServiceBackupTaskInvalidState(t *testing.T) {
 	task := ServiceBackupTask{Service: "postgres", Name: "my-db", Schedule: "0 3 * * *", Bucket: "b", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -17,7 +17,7 @@ func TestServiceBackupTaskInvalidState(t *testing.T) {
 
 func TestServiceBackupTaskScheduleRequiresBucket(t *testing.T) {
 	task := ServiceBackupTask{Service: "postgres", Name: "my-db", Schedule: "0 3 * * *"}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with schedule and no bucket should return an error")
 	}
@@ -25,7 +25,7 @@ func TestServiceBackupTaskScheduleRequiresBucket(t *testing.T) {
 
 func TestServiceBackupTaskBucketRequiresSchedule(t *testing.T) {
 	task := ServiceBackupTask{Service: "postgres", Name: "my-db", Bucket: "my-bucket"}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with bucket and no schedule should return an error")
 	}
@@ -33,7 +33,7 @@ func TestServiceBackupTaskBucketRequiresSchedule(t *testing.T) {
 
 func TestServiceBackupTaskPartialAuthRejected(t *testing.T) {
 	task := ServiceBackupTask{Service: "postgres", Name: "my-db", AwsAccessKeyID: "AKIA"}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with only an access key id should return an error")
 	}
@@ -91,7 +91,7 @@ func TestServiceBackupTaskValidateAuthChain(t *testing.T) {
 
 func TestServiceBackupTaskPresentRequiresSomething(t *testing.T) {
 	task := ServiceBackupTask{Service: "postgres", Name: "my-db"}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with nothing to configure should return an error")
 	}

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"sort"
@@ -131,14 +132,14 @@ func (t ServiceCreateTask) ProbeSupport() ProbeSupport {
 // separately - but the image it runs is exported, so a service recreated on
 // another server comes up on the same version rather than whatever that
 // server's plugin defaults to, which is what its `:import` counterpart needs.
-func (t ServiceCreateTask) ExportGlobal() ([]interface{}, error) {
-	services, err := listServices()
+func (t ServiceCreateTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	services, err := listServices(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var out []interface{}
 	for _, s := range services {
-		image, version, err := serviceImage(s.Type, s.Name)
+		image, version, err := serviceImage(ctx, s.Type, s.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -206,8 +207,8 @@ func (t ServiceCreateTask) Examples() ([]Doc, error) {
 }
 
 // Execute creates or destroys a dokku service
-func (t ServiceCreateTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ServiceCreateTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // setCreateOptions returns the recipe keys of every create-time option the
@@ -487,18 +488,18 @@ func (t ServiceCreateTask) Validate() error {
 }
 
 // Plan reports the drift the ServiceCreateTask would produce.
-func (t ServiceCreateTask) Plan() PlanResult {
+func (t ServiceCreateTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if exists {
-				if drift := planServiceImageDrift(t); drift != nil {
+				if drift := planServiceImageDrift(ctx, t); drift != nil {
 					return *drift
 				}
 				return PlanResult{InSync: true, Status: PlanStatusOK}
@@ -513,14 +514,14 @@ func (t ServiceCreateTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("%s service %s missing", t.Service, t.Name),
 				Mutations: []string{fmt.Sprintf("%s:create %s%s", t.Service, t.Name, t.imageSuffix())},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -536,9 +537,9 @@ func (t ServiceCreateTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%s service %s present", t.Service, t.Name),
 				Mutations: []string{fmt.Sprintf("%s:destroy %s", t.Service, t.Name)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -554,13 +555,13 @@ func (t ServiceCreateTask) Plan() PlanResult {
 // It is a package-level func rather than a method because
 // TestProbeSupportMatchesPlanWiring walks the tasks package for plan-returning
 // methods and allows exactly one per task, Plan itself.
-func planServiceImageDrift(t ServiceCreateTask) *PlanResult {
+func planServiceImageDrift(ctx context.Context, t ServiceCreateTask) *PlanResult {
 	mode := t.imageDriftMode()
 	if mode == imageDriftIgnore || !t.pinsImage() {
 		return nil
 	}
 
-	ref, err := serviceImageRef(t.Service, t.Name)
+	ref, err := serviceImageRef(ctx, t.Service, t.Name)
 	if err != nil {
 		return &PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -595,7 +596,7 @@ func planServiceImageDrift(t ServiceCreateTask) *PlanResult {
 				t.Service, t.Name, running, t.pinnedDescription(image)),
 		}
 	case imageDriftUpgrade:
-		return planServiceImageUpgrade(t, running, image)
+		return planServiceImageUpgrade(ctx, t, running, image)
 	}
 
 	return &PlanResult{
@@ -615,7 +616,7 @@ func planServiceImageDrift(t ServiceCreateTask) *PlanResult {
 // so the only half that may need filling is the name.
 //
 // Package-level for the same reason as planServiceImageDrift.
-func planServiceImageUpgrade(t ServiceCreateTask, running, image string) *PlanResult {
+func planServiceImageUpgrade(ctx context.Context, t ServiceCreateTask, running, image string) *PlanResult {
 	if t.Image != "" {
 		image = t.Image
 	} else if image == "" || strings.Contains(running, "@") {
@@ -633,7 +634,7 @@ func planServiceImageUpgrade(t ServiceCreateTask, running, image string) *PlanRe
 
 	restartApps := false
 	if t.RestartApps {
-		apps, err := serviceLinkedApps(t.Service, t.Name)
+		apps, err := serviceLinkedApps(ctx, t.Service, t.Name)
 		if err != nil {
 			return &PlanResult{Status: PlanStatusError, Error: err}
 		}
@@ -662,9 +663,9 @@ func planServiceImageUpgrade(t ServiceCreateTask, running, image string) *PlanRe
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("image drift: %s -> %s", running, target),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StatePresent, inputs)
 		},
 	}
 }
@@ -673,8 +674,8 @@ func planServiceImageUpgrade(t ServiceCreateTask, running, image string) *PlanRe
 // when the probe could not run - a transport failure, a missing dokku
 // binary, or a cancellation, (false, nil) when dokku reports the service
 // absent, (true, nil) when present.
-func serviceExists(service, name string) (bool, error) {
-	return subprocess.Probe(subprocess.ExecCommandInput{
+func serviceExists(ctx context.Context, service, name string) (bool, error) {
+	return subprocess.Probe(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -685,18 +686,18 @@ func serviceExists(service, name string) (bool, error) {
 }
 
 // destroyService destroys a dokku service
-func destroyService(service, name string) TaskOutputState {
+func destroyService(ctx context.Context, service, name string) TaskOutputState {
 	state := TaskOutputState{
 		Changed: false,
 		State:   "present",
 	}
-	exists, _ := serviceExists(service, name)
+	exists, _ := serviceExists(ctx, service, name)
 	if !exists {
 		state.State = "absent"
 		return state
 	}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",

--- a/tasks/service_create_task_integration_test.go
+++ b/tasks/service_create_task_integration_test.go
@@ -13,11 +13,11 @@ func TestIntegrationServiceCreateAndDestroy(t *testing.T) {
 	serviceType := "redis"
 
 	// ensure clean state
-	destroyService(serviceType, serviceName)
+	destroyService(testCtx(), serviceType, serviceName)
 
 	// create the service
 	task := ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create service: %v", result.Error)
 	}
@@ -29,7 +29,7 @@ func TestIntegrationServiceCreateAndDestroy(t *testing.T) {
 	}
 
 	// creating again should be idempotent
-	result = task.Execute()
+	result = task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent create failed: %v", result.Error)
 	}
@@ -42,7 +42,7 @@ func TestIntegrationServiceCreateAndDestroy(t *testing.T) {
 
 	// destroy the service
 	destroyTask := ServiceCreateTask{Service: serviceType, Name: serviceName, State: StateAbsent}
-	result = destroyTask.Execute()
+	result = destroyTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to destroy service: %v", result.Error)
 	}
@@ -54,7 +54,7 @@ func TestIntegrationServiceCreateAndDestroy(t *testing.T) {
 	}
 
 	// destroying again should be idempotent
-	result = destroyTask.Execute()
+	result = destroyTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent destroy failed: %v", result.Error)
 	}
@@ -80,8 +80,8 @@ func TestIntegrationServiceCreatePinnedImage(t *testing.T) {
 	image := "redis"
 	imageVersion := "7.2.5"
 
-	destroyService(serviceType, serviceName)
-	t.Cleanup(func() { destroyService(serviceType, serviceName) })
+	destroyService(testCtx(), serviceType, serviceName)
+	t.Cleanup(func() { destroyService(testCtx(), serviceType, serviceName) })
 
 	task := ServiceCreateTask{
 		Service:      serviceType,
@@ -90,7 +90,7 @@ func TestIntegrationServiceCreatePinnedImage(t *testing.T) {
 		ImageVersion: imageVersion,
 		State:        StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create pinned service: %v\n  commands: %v\n  stderr: %s", result.Error, result.Commands, result.Stderr)
 	}
@@ -98,7 +98,7 @@ func TestIntegrationServiceCreatePinnedImage(t *testing.T) {
 		t.Fatalf("expected a changed, present service, got changed=%v state=%q", result.Changed, result.State)
 	}
 
-	gotImage, gotVersion, err := serviceImage(serviceType, serviceName)
+	gotImage, gotVersion, err := serviceImage(testCtx(), serviceType, serviceName)
 	if err != nil {
 		t.Fatalf("serviceImage: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestIntegrationServiceCreatePinnedImage(t *testing.T) {
 		t.Errorf("service is running %q:%q, want %q:%q", gotImage, gotVersion, image, imageVersion)
 	}
 
-	if plan := task.Plan(); !plan.InSync {
+	if plan := task.Plan(testCtx()); !plan.InSync {
 		t.Errorf("expected the pinned service to be in sync on re-plan, got %+v", plan)
 	}
 }
@@ -126,8 +126,8 @@ const (
 // of them fighting over one service.
 func createDriftService(t *testing.T, name, tag string) {
 	t.Helper()
-	destroyService(driftService, name)
-	t.Cleanup(func() { destroyService(driftService, name) })
+	destroyService(testCtx(), driftService, name)
+	t.Cleanup(func() { destroyService(testCtx(), driftService, name) })
 
 	task := ServiceCreateTask{
 		Service:      driftService,
@@ -136,7 +136,7 @@ func createDriftService(t *testing.T, name, tag string) {
 		ImageVersion: tag,
 		State:        StatePresent,
 	}
-	if result := task.Execute(); result.Error != nil {
+	if result := task.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to create %s:%s: %v\n  commands: %v\n  stderr: %s", driftImage, tag, result.Error, result.Commands, result.Stderr)
 	}
 }
@@ -157,7 +157,7 @@ func TestIntegrationServiceCreateImageDriftWarns(t *testing.T) {
 		ImageVersion: driftOldTag,
 		State:        StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -167,7 +167,7 @@ func TestIntegrationServiceCreateImageDriftWarns(t *testing.T) {
 	if len(plan.Warnings) != 1 || plan.Warnings[0].Reason != WarnReasonServiceImageDrift {
 		t.Fatalf("expected one %s warning, got %v", WarnReasonServiceImageDrift, plan.Warnings)
 	}
-	if result := task.Execute(); result.Error != nil || result.Changed {
+	if result := task.Execute(testCtx()); result.Error != nil || result.Changed {
 		t.Errorf("warn mode must not change the server, got changed=%v err=%v", result.Changed, result.Error)
 	}
 }
@@ -188,7 +188,7 @@ func TestIntegrationServiceCreateImageDriftErrors(t *testing.T) {
 		ImageDrift:   imageDriftError,
 		State:        StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error == nil || plan.Status != PlanStatusError {
 		t.Fatalf("expected a plan error, got status=%q err=%v", plan.Status, plan.Error)
 	}
@@ -217,7 +217,7 @@ func TestIntegrationServiceCreateImageDriftUpgrades(t *testing.T) {
 		State:        StatePresent,
 	}
 
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -225,7 +225,7 @@ func TestIntegrationServiceCreateImageDriftUpgrades(t *testing.T) {
 		t.Fatalf("expected drift, got InSync=%v status=%q", plan.InSync, plan.Status)
 	}
 
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to upgrade: %v\n  commands: %v\n  stderr: %s", result.Error, result.Commands, result.Stderr)
 	}
@@ -233,7 +233,7 @@ func TestIntegrationServiceCreateImageDriftUpgrades(t *testing.T) {
 		t.Fatalf("expected a changed, present service, got changed=%v state=%q", result.Changed, result.State)
 	}
 
-	image, version, err := serviceImage(driftService, serviceName)
+	image, version, err := serviceImage(testCtx(), driftService, serviceName)
 	if err != nil {
 		t.Fatalf("serviceImage: %v", err)
 	}
@@ -241,10 +241,10 @@ func TestIntegrationServiceCreateImageDriftUpgrades(t *testing.T) {
 		t.Errorf("service is running %q:%q, want %q:%q", image, version, driftImage, driftNewTag)
 	}
 
-	if plan := task.Plan(); !plan.InSync || len(plan.Warnings) != 0 {
+	if plan := task.Plan(testCtx()); !plan.InSync || len(plan.Warnings) != 0 {
 		t.Errorf("the upgraded service must re-plan in sync and silent, got %+v", plan)
 	}
-	if second := task.Execute(); second.Error != nil || second.Changed {
+	if second := task.Execute(testCtx()); second.Error != nil || second.Changed {
 		t.Errorf("a second apply must be a no-op, got changed=%v err=%v", second.Changed, second.Error)
 	}
 }

--- a/tasks/service_create_task_test.go
+++ b/tasks/service_create_task_test.go
@@ -27,7 +27,7 @@ func serviceMissing() func(context.Context, subprocess.ExecCommandInput) (subpro
 // task's service, failing the test if the plan did not reach a create.
 func planCreateCommand(t *testing.T, task ServiceCreateTask) string {
 	t.Helper()
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -39,7 +39,7 @@ func planCreateCommand(t *testing.T, task ServiceCreateTask) string {
 
 func TestServiceCreateTaskInvalidState(t *testing.T) {
 	task := ServiceCreateTask{Service: "redis", Name: "test-service", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -219,7 +219,7 @@ func TestServiceCreateTaskMutationNamesPinnedImage(t *testing.T) {
 			defer subprocess.SetExecRunner(serviceMissing())()
 			task := tc.task
 			task.State = StatePresent
-			plan := task.Plan()
+			plan := task.Plan(testCtx())
 			if plan.Error != nil {
 				t.Fatalf("unexpected plan error: %v", plan.Error)
 			}
@@ -344,7 +344,7 @@ func TestServiceCreateTaskValidate(t *testing.T) {
 			}
 			// Plan() must report the same message, so plan, apply, and
 			// validate all read alike.
-			if plan := tc.task.Plan(); plan.Error == nil || plan.Error.Error() != tc.wantErr {
+			if plan := tc.task.Plan(testCtx()); plan.Error == nil || plan.Error.Error() != tc.wantErr {
 				t.Errorf("Plan error = %v, want %q", plan.Error, tc.wantErr)
 			}
 		})
@@ -531,7 +531,7 @@ func TestServiceCreateTaskImageDriftDefaultsToWarn(t *testing.T) {
 	if got := task.imageDriftMode(); got != imageDriftWarn {
 		t.Errorf("imageDriftMode() = %q, want %q", got, imageDriftWarn)
 	}
-	planImageWarning(t, task.Plan())
+	planImageWarning(t, task.Plan(testCtx()))
 }
 
 func TestServiceCreateTaskImageDriftInSyncWhenPinsMatch(t *testing.T) {
@@ -560,7 +560,7 @@ func TestServiceCreateTaskImageDriftInSyncWhenPinsMatch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", tc.running)))()
-			plan := tc.task.Plan()
+			plan := tc.task.Plan(testCtx())
 			if plan.Error != nil {
 				t.Fatalf("unexpected plan error: %v", plan.Error)
 			}
@@ -579,7 +579,7 @@ func TestServiceCreateTaskImageDriftWarnStaysInSync(t *testing.T) {
 
 	task := driftTask()
 	task.ImageDrift = imageDriftWarn
-	w := planImageWarning(t, task.Plan())
+	w := planImageWarning(t, task.Plan(testCtx()))
 	for _, want := range []string{"redis:7.2.4", "redis:7.2.5", "image_drift: upgrade"} {
 		if !strings.Contains(w.Message, want) {
 			t.Errorf("warning message %q does not mention %q", w.Message, want)
@@ -588,7 +588,7 @@ func TestServiceCreateTaskImageDriftWarnStaysInSync(t *testing.T) {
 
 	// ExecutePlan carries plan warnings out of the in-sync branch, so apply
 	// reports the same diagnostic plan did.
-	state := task.Execute()
+	state := task.Execute(testCtx())
 	if state.Error != nil {
 		t.Fatalf("unexpected execute error: %v", state.Error)
 	}
@@ -610,7 +610,7 @@ func TestServiceCreateTaskImageDriftWarnsOnUnreadableImage(t *testing.T) {
 			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "")))()
 			task := driftTask()
 			task.ImageDrift = mode
-			w := planImageWarning(t, task.Plan())
+			w := planImageWarning(t, task.Plan(testCtx()))
 			if !strings.Contains(w.Message, "no running image") {
 				t.Errorf("warning message %q does not say the image could not be read", w.Message)
 			}
@@ -624,7 +624,7 @@ func TestServiceCreateTaskImageDriftIgnoreSkipsTheProbe(t *testing.T) {
 
 	task := driftTask()
 	task.ImageDrift = imageDriftIgnore
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if !plan.InSync || len(plan.Warnings) != 0 {
 		t.Errorf("expected a silent in-sync plan, got InSync=%v warnings=%v", plan.InSync, plan.Warnings)
 	}
@@ -643,7 +643,7 @@ func TestServiceCreateTaskImageDriftSkipsTheProbeWithoutAPin(t *testing.T) {
 	defer subprocess.SetExecRunner(recordingDokku(driftFixture("redis", "cache", "redis:7.2.4"), &calls))()
 
 	task := ServiceCreateTask{Service: "redis", Name: "cache", State: StatePresent}
-	if plan := task.Plan(); !plan.InSync || len(plan.Warnings) != 0 {
+	if plan := task.Plan(testCtx()); !plan.InSync || len(plan.Warnings) != 0 {
 		t.Errorf("expected a silent in-sync plan, got InSync=%v warnings=%v", plan.InSync, plan.Warnings)
 	}
 	for _, call := range calls {
@@ -658,7 +658,7 @@ func TestServiceCreateTaskImageDriftErrorReportsMismatch(t *testing.T) {
 
 	task := driftTask()
 	task.ImageDrift = imageDriftError
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error == nil {
 		t.Fatal("expected a plan error, got none")
 	}
@@ -750,7 +750,7 @@ func TestServiceCreateTaskImageDriftUpgradeCommand(t *testing.T) {
 			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", tc.running)))()
 			task := tc.task
 			task.ImageDrift = imageDriftUpgrade
-			plan := task.Plan()
+			plan := task.Plan(testCtx())
 			if plan.Error != nil {
 				t.Fatalf("unexpected plan error: %v", plan.Error)
 			}
@@ -774,7 +774,7 @@ func TestServiceCreateTaskImageDriftUpgradeReportsTheEffectiveTarget(t *testing.
 	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "custom/redis:7.2.4")))()
 
 	task := ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", ImageDrift: imageDriftUpgrade, State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if want := "image drift: custom/redis:7.2.4 -> custom/redis:7.2.5"; plan.Reason != want {
 		t.Errorf("reason = %q, want %q", plan.Reason, want)
 	}
@@ -810,7 +810,7 @@ func TestServiceCreateTaskImageDriftUpgradeNamesWhatItResets(t *testing.T) {
 			defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis:7.2.4")))()
 			task := tc.task
 			task.ImageDrift = imageDriftUpgrade
-			plan := task.Plan()
+			plan := task.Plan(testCtx())
 			if len(plan.Mutations) != 2 || plan.Mutations[1] != tc.want {
 				t.Errorf("mutations = %v, want %q as the second entry", plan.Mutations, tc.want)
 			}
@@ -823,7 +823,7 @@ func TestServiceCreateTaskImageDriftUpgradeNamesWhatItResets(t *testing.T) {
 		task.ImageDrift = imageDriftUpgrade
 		task.ConfigOptions = "--cpus 2"
 		task.CustomEnv = map[string]string{"A": "one"}
-		if plan := task.Plan(); len(plan.Mutations) != 1 {
+		if plan := task.Plan(testCtx()); len(plan.Mutations) != 1 {
 			t.Errorf("nothing is reset when the recipe declares both, got %v", plan.Mutations)
 		}
 	})
@@ -849,7 +849,7 @@ func TestServiceCreateTaskImageDriftUpgradeRestartsOnlyLinkedApps(t *testing.T) 
 			task := driftTask()
 			task.ImageDrift = imageDriftUpgrade
 			task.RestartApps = tc.restartApps
-			plan := task.Plan()
+			plan := task.Plan(testCtx())
 			if plan.Error != nil {
 				t.Fatalf("unexpected plan error: %v", plan.Error)
 			}
@@ -877,7 +877,7 @@ func TestServiceCreateTaskImageDriftUpgradeMasksSecrets(t *testing.T) {
 	subprocess.SetGlobalSensitive(sensitiveValuesFromTask(&task))
 	defer subprocess.SetGlobalSensitive(nil)
 
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if len(plan.Commands) != 1 {
 		t.Fatalf("expected 1 command, got %v", plan.Commands)
 	}
@@ -898,7 +898,7 @@ func TestServiceCreateTaskImageDriftUpgradeRefusesADigestRef(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(driftFixture("redis", "cache", "redis@sha256:abc123")))()
 
 	task := ServiceCreateTask{Service: "redis", Name: "cache", ImageVersion: "7.2.5", ImageDrift: imageDriftUpgrade, State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error == nil {
 		t.Fatal("expected a plan error, got none")
 	}
@@ -916,7 +916,7 @@ func TestServiceCreateTaskImageDriftAppliesUpgrade(t *testing.T) {
 
 	task := driftTask()
 	task.ImageDrift = imageDriftUpgrade
-	state := task.Execute()
+	state := task.Execute(testCtx())
 	if state.Error != nil {
 		t.Fatalf("unexpected execute error: %v", state.Error)
 	}
@@ -954,7 +954,7 @@ func TestServiceCreateTaskImageDriftPropagatesSSHErrors(t *testing.T) {
 			task := driftTask()
 			task.ImageDrift = imageDriftUpgrade
 			task.RestartApps = true
-			plan := task.Plan()
+			plan := task.Plan(testCtx())
 			var sshErr *subprocess.SSHError
 			if !errors.As(plan.Error, &sshErr) {
 				t.Fatalf("expected an SSHError, got %v", plan.Error)

--- a/tasks/service_export.go
+++ b/tasks/service_export.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -25,8 +26,8 @@ type serviceInstance struct {
 // `<type>:<name>` for its own instances. A transport-level failure
 // (`*subprocess.SSHError`) is propagated; a dokku-level failure (no datastore
 // plugin installed, or an older dokku) degrades to "no services."
-func listServices() ([]serviceInstance, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func listServices(ctx context.Context) ([]serviceInstance, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "plugin:trigger", "service-list"},
 	})
@@ -65,8 +66,8 @@ func listServices() ([]serviceInstance, error) {
 // read from `<service>:links <name>` (one app per line on stdout). A
 // transport-level failure is propagated; a dokku-level failure (the service is
 // gone) degrades to "no links."
-func serviceLinkedApps(service, name string) (map[string]bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func serviceLinkedApps(ctx context.Context, service, name string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", fmt.Sprintf("%s:links", service), name},
 	})
@@ -89,8 +90,8 @@ func serviceLinkedApps(service, name string) (map[string]bool, error) {
 // serviceDSN returns a datastore service's connection string (the value a link
 // injects into an app's config), read from `<service>:info <name> --dsn`. A
 // transport-level failure is propagated; any other failure yields an empty DSN.
-func serviceDSN(service, name string) (string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func serviceDSN(ctx context.Context, service, name string) (string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", fmt.Sprintf("%s:info", service), name, "--dsn"},
 	})
@@ -111,8 +112,8 @@ func serviceDSN(service, name string) (string, error) {
 // `--image-version` reconstruct on another server. A transport-level failure
 // (`*subprocess.SSHError`) is propagated; any other failure yields no image, as
 // does a service whose container is gone - dokku prints nothing in that case.
-func serviceImage(service, name string) (string, string, error) {
-	ref, err := serviceImageRef(service, name)
+func serviceImage(ctx context.Context, service, name string) (string, string, error) {
+	ref, err := serviceImageRef(ctx, service, name)
 	if err != nil {
 		return "", "", err
 	}
@@ -128,8 +129,8 @@ func serviceImage(service, name string) (string, string, error) {
 // `<service>:upgrade`. Error handling is serviceImage's: a transport-level
 // failure propagates, anything else - including a service whose container is
 // gone, where dokku prints nothing - yields the empty ref.
-func serviceImageRef(service, name string) (string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func serviceImageRef(ctx context.Context, service, name string) (string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", fmt.Sprintf("%s:info", service), name, "--version"},
 	})
@@ -161,21 +162,21 @@ func splitImageRef(ref string) (string, string) {
 // new server's credentials), and re-exporting the stale value would clobber the
 // fresh one. Enumerates services, keeps those linked to the app, and reads each
 // linked service's DSN.
-func linkedServiceDSNs(app string) (map[string]bool, error) {
-	services, err := listServices()
+func linkedServiceDSNs(ctx context.Context, app string) (map[string]bool, error) {
+	services, err := listServices(ctx)
 	if err != nil {
 		return nil, err
 	}
 	dsns := map[string]bool{}
 	for _, s := range services {
-		apps, err := serviceLinkedApps(s.Type, s.Name)
+		apps, err := serviceLinkedApps(ctx, s.Type, s.Name)
 		if err != nil {
 			return nil, err
 		}
 		if !apps[app] {
 			continue
 		}
-		dsn, err := serviceDSN(s.Type, s.Name)
+		dsn, err := serviceDSN(ctx, s.Type, s.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/tasks/service_export_test.go
+++ b/tasks/service_export_test.go
@@ -15,7 +15,7 @@ func TestListServicesParsesTypeAndName(t *testing.T) {
 		"--quiet plugin:trigger service-list": "redis:cache\npostgres:my-db\npostgres:analytics\n\nmalformed-line\n:bad\nbad:",
 	}))()
 
-	services, err := listServices()
+	services, err := listServices(testCtx())
 	if err != nil {
 		t.Fatalf("listServices: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestExportServiceCreateEnumeratesInstances(t *testing.T) {
 		"--quiet redis:info cache --version":    "redis:7.2.5",
 	}))()
 
-	bodies, err := ServiceCreateTask{}.ExportGlobal()
+	bodies, err := ServiceCreateTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestExportServiceCreateOmitsUnreadableImage(t *testing.T) {
 		"--quiet plugin:trigger service-list": "redis:cache",
 	}))()
 
-	bodies, err := ServiceCreateTask{}.ExportGlobal()
+	bodies, err := ServiceCreateTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestServiceExposedPortListParsesHostSide(t *testing.T) {
 			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 				"--quiet postgres:info svc --exposed-ports": tc.stdout,
 			}))()
-			got, err := serviceExposedPortList("postgres", "svc")
+			got, err := serviceExposedPortList(testCtx(), "postgres", "svc")
 			if err != nil {
 				t.Fatalf("serviceExposedPortList: %v", err)
 			}
@@ -152,7 +152,7 @@ func TestExportServiceExposeReadsHostPorts(t *testing.T) {
 		"--quiet redis:info cache --exposed-ports":    "-",
 	}))()
 
-	bodies, err := ServiceExposeTask{}.ExportGlobal()
+	bodies, err := ServiceExposeTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestExportServiceBackupParsesSchedule(t *testing.T) {
 		// redis has no schedule: unmapped -> empty content -> parse fails -> skipped
 	}))()
 
-	bodies, err := ServiceBackupTask{}.ExportGlobal()
+	bodies, err := ServiceBackupTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestExportServiceLinkEnumeratesForApp(t *testing.T) {
 		"--quiet redis:links cache":           "worker",
 	}))()
 
-	bodies, err := ServiceLinkTask{}.ExportApp("web")
+	bodies, err := ServiceLinkTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestExportServiceLinkEnumeratesForApp(t *testing.T) {
 		t.Errorf("unexpected link task: %+v", l)
 	}
 
-	bodies, err = ServiceLinkTask{}.ExportApp("worker")
+	bodies, err = ServiceLinkTask{}.ExportApp(testCtx(), "worker")
 	if err != nil {
 		t.Fatalf("ExportApp worker: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestExportAclServiceReadsUsers(t *testing.T) {
 		return subprocess.ExecCommandResponse{Stdout: responses[key], Stderr: stderr[key]}, nil
 	})()
 
-	bodies, err := AclServiceTask{}.ExportGlobal()
+	bodies, err := AclServiceTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestExportConfigExcludesLinkedServiceDSNs(t *testing.T) {
 		"--quiet postgres:info my-db --dsn":       dsn,
 	}))()
 
-	bodies, err := ConfigTask{}.ExportApp("web")
+	bodies, err := ConfigTask{}.ExportApp(testCtx(), "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -320,7 +320,7 @@ func TestExportRecipeIncludesServiceTasks(t *testing.T) {
 		"--quiet postgres:info my-db --version":       "postgres:17.2",
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{})
+	res, err := ExportRecipe(testCtx(), ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/service_expose_task.go
+++ b/tasks/service_expose_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -57,14 +58,14 @@ func (t ServiceExposeTask) ProbeSupport() ProbeSupport {
 // on the server. Discovery is via listServices; the exposed host ports are read
 // from `<service>:info <name> --exposed-ports`. Services with no exposed ports
 // are skipped.
-func (t ServiceExposeTask) ExportGlobal() ([]interface{}, error) {
-	services, err := listServices()
+func (t ServiceExposeTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	services, err := listServices(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var out []interface{}
 	for _, s := range services {
-		ports, err := serviceExposedPortList(s.Type, s.Name)
+		ports, err := serviceExposedPortList(ctx, s.Type, s.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -112,8 +113,8 @@ func (t ServiceExposeTask) Examples() ([]Doc, error) {
 }
 
 // Execute exposes or unexposes a dokku service
-func (t ServiceExposeTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ServiceExposeTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the ServiceExposeTask's inputs without contacting the server.
@@ -125,20 +126,20 @@ func (t ServiceExposeTask) Validate() error {
 }
 
 // Plan reports the drift the ServiceExposeTask would produce.
-func (t ServiceExposeTask) Plan() PlanResult {
+func (t ServiceExposeTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if !exists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			current, err := serviceExposedPortList(t.Service, t.Name)
+			current, err := serviceExposedPortList(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -170,21 +171,21 @@ func (t ServiceExposeTask) Plan() PlanResult {
 				Status:    status,
 				Reason:    fmt.Sprintf("%s service %s not exposed on %s", t.Service, t.Name, strings.Join(t.Ports, " ")),
 				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if !exists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			current, err := serviceExposedPortList(t.Service, t.Name)
+			current, err := serviceExposedPortList(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -200,9 +201,9 @@ func (t ServiceExposeTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%s service %s exposed", t.Service, t.Name),
 				Mutations: []string{fmt.Sprintf("%s:unexpose %s", t.Service, t.Name)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -217,8 +218,8 @@ func (t ServiceExposeTask) Plan() PlanResult {
 // Ports field holds. A transport-level failure (`*subprocess.SSHError`) is
 // propagated; a dokku-level non-zero exit (e.g. service not exposed) is treated
 // as "no ports exposed."
-func serviceExposedPortList(service, name string) ([]string, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func serviceExposedPortList(ctx context.Context, service, name string) ([]string, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",

--- a/tasks/service_expose_task_integration_test.go
+++ b/tasks/service_expose_task_integration_test.go
@@ -14,15 +14,15 @@ func TestIntegrationServiceExposeIdempotent(t *testing.T) {
 	serviceType := "redis"
 	serviceName := "docket-test-expose-svc"
 
-	destroyService(serviceType, serviceName)
-	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+	destroyService(testCtx(), serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to create service: %v", r.Error)
 	}
-	defer destroyService(serviceType, serviceName)
+	defer destroyService(testCtx(), serviceType, serviceName)
 
 	exposeTask := ServiceExposeTask{Service: serviceType, Name: serviceName, Ports: []string{"11111"}, State: StatePresent}
 
-	result := exposeTask.Execute()
+	result := exposeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to expose service: %v", result.Error)
 	}
@@ -33,7 +33,7 @@ func TestIntegrationServiceExposeIdempotent(t *testing.T) {
 		t.Errorf("expected state 'present', got %q", result.State)
 	}
 
-	result = exposeTask.Execute()
+	result = exposeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent expose failed: %v", result.Error)
 	}
@@ -41,7 +41,7 @@ func TestIntegrationServiceExposeIdempotent(t *testing.T) {
 		t.Error("expected changed=false when the service is already exposed on the same ports")
 	}
 
-	ports, err := serviceExposedPortList(serviceType, serviceName)
+	ports, err := serviceExposedPortList(testCtx(), serviceType, serviceName)
 	if err != nil {
 		t.Fatalf("failed to read exposed ports: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestIntegrationServiceExposeIdempotent(t *testing.T) {
 	}
 
 	unexposeTask := ServiceExposeTask{Service: serviceType, Name: serviceName, State: StateAbsent}
-	result = unexposeTask.Execute()
+	result = unexposeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unexpose service: %v", result.Error)
 	}
@@ -61,7 +61,7 @@ func TestIntegrationServiceExposeIdempotent(t *testing.T) {
 		t.Errorf("expected state 'absent', got %q", result.State)
 	}
 
-	result = unexposeTask.Execute()
+	result = unexposeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent unexpose failed: %v", result.Error)
 	}

--- a/tasks/service_expose_task_test.go
+++ b/tasks/service_expose_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestServiceExposeTaskInvalidState(t *testing.T) {
 	task := ServiceExposeTask{Service: "redis", Name: "test-service", Ports: []string{"6379"}, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -18,7 +18,7 @@ func TestServiceExposeTaskInvalidState(t *testing.T) {
 
 func TestServiceExposeTaskPresentRequiresPorts(t *testing.T) {
 	task := ServiceExposeTask{Service: "redis", Name: "test-service"}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with present state and no ports should return an error")
 	}
@@ -74,7 +74,7 @@ func TestServiceExposeSameOrderInSync(t *testing.T) {
 		"--quiet redis:info my-svc --exposed-ports": "1111->1111 2222->2222",
 	}))()
 
-	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan()
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -88,7 +88,7 @@ func TestServiceExposeReorderReportsDrift(t *testing.T) {
 		"--quiet redis:info my-svc --exposed-ports": "1111->1111 2222->2222",
 	}))()
 
-	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"2222", "1111"}, State: StatePresent}.Plan()
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"2222", "1111"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -121,7 +121,7 @@ func TestServiceExposeCreatesWhenNotExposed(t *testing.T) {
 		"--quiet redis:info my-svc --exposed-ports": "",
 	}))()
 
-	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan()
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"github.com/dokku/docket/subprocess"
 )
@@ -54,14 +55,14 @@ func (t ServiceLinkTask) ProbeSupport() ProbeSupport {
 // app appears in (serviceLinkedApps). The link, not dokku_config, is the source
 // of truth for the injected `<ALIAS>_URL`, so config export drops those values
 // (see linkedServiceDSNs).
-func (t ServiceLinkTask) ExportApp(app string) ([]interface{}, error) {
-	services, err := listServices()
+func (t ServiceLinkTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	services, err := listServices(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var out []interface{}
 	for _, s := range services {
-		apps, err := serviceLinkedApps(s.Type, s.Name)
+		apps, err := serviceLinkedApps(ctx, s.Type, s.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -110,29 +111,29 @@ func (t ServiceLinkTask) Examples() ([]Doc, error) {
 }
 
 // Execute links or unlinks a dokku service to an app
-func (t ServiceLinkTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ServiceLinkTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Plan reports the drift the ServiceLinkTask would produce.
-func (t ServiceLinkTask) Plan() PlanResult {
+func (t ServiceLinkTask) Plan(ctx context.Context) PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			svcExists, err := serviceExists(t.Service, t.Name)
+			svcExists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if !svcExists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			appOK, err := appExists(t.App)
+			appOK, err := appExists(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if !appOK {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
 			}
-			linked, err := serviceLinked(t.Service, t.Name, t.App)
+			linked, err := serviceLinked(ctx, t.Service, t.Name, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -148,28 +149,28 @@ func (t ServiceLinkTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("%s service %s not linked to %s", t.Service, t.Name, t.App),
 				Mutations: []string{fmt.Sprintf("%s:link %s %s", t.Service, t.Name, t.App)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			svcExists, err := serviceExists(t.Service, t.Name)
+			svcExists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if !svcExists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			appOK, err := appExists(t.App)
+			appOK, err := appExists(ctx, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if !appOK {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
 			}
-			linked, err := serviceLinked(t.Service, t.Name, t.App)
+			linked, err := serviceLinked(ctx, t.Service, t.Name, t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -185,9 +186,9 @@ func (t ServiceLinkTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%s service %s linked to %s", t.Service, t.Name, t.App),
 				Mutations: []string{fmt.Sprintf("%s:unlink %s %s", t.Service, t.Name, t.App)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -198,8 +199,8 @@ func (t ServiceLinkTask) Plan() PlanResult {
 // (false, err) when the probe could not run - a transport failure, a
 // missing dokku binary, or a cancellation; (false, nil) when dokku
 // reports no link; (true, nil) when linked.
-func serviceLinked(service, name, app string) (bool, error) {
-	return subprocess.Probe(subprocess.ExecCommandInput{
+func serviceLinked(ctx context.Context, service, name, app string) (bool, error) {
+	return subprocess.Probe(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",

--- a/tasks/service_link_task_integration_test.go
+++ b/tasks/service_link_task_integration_test.go
@@ -17,28 +17,28 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	serviceType := "redis"
 
 	// ensure clean state
-	destroyApp(appName)
-	destroyService(serviceType, serviceName)
+	destroyApp(testCtx(), appName)
+	destroyService(testCtx(), serviceType, serviceName)
 
 	// create prerequisites
-	createApp(appName)
-	defer destroyApp(appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	createTask := ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}
-	createResult := createTask.Execute()
+	createResult := createTask.Execute(testCtx())
 	if createResult.Error != nil {
 		t.Fatalf("failed to create service: %v", createResult.Error)
 	}
 	defer func() {
 		// unlink before destroying service
 		unlinkTask := ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StateAbsent}
-		unlinkTask.Execute()
-		destroyService(serviceType, serviceName)
+		unlinkTask.Execute(testCtx())
+		destroyService(testCtx(), serviceType, serviceName)
 	}()
 
 	// verify service container is running via docker inspect
 	containerName := fmt.Sprintf("dokku.%s.%s", serviceType, serviceName)
-	inspectResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	inspectResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"inspect", "--format", "{{.State.Running}}", containerName},
 	})
@@ -51,7 +51,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 
 	// link service to app
 	linkTask := ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StatePresent}
-	result := linkTask.Execute()
+	result := linkTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to link service: %v", result.Error)
 	}
@@ -63,7 +63,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	}
 
 	// verify REDIS_URL config var was set by the link
-	configResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	configResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"config:get", appName, "REDIS_URL"},
 	})
@@ -79,7 +79,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	}
 
 	// verify the service container exposes the expected network alias via docker inspect
-	aliasResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	aliasResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"inspect", "--format", "{{.Config.Hostname}}", containerName},
 	})
@@ -96,13 +96,13 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 		Image: "dokku/smoke-test-app:dockerfile",
 		State: StateDeployed,
 	}
-	deployResult := deployTask.Execute()
+	deployResult := deployTask.Execute(testCtx())
 	if deployResult.Error != nil {
 		t.Fatalf("failed to deploy app: %v", deployResult.Error)
 	}
 
 	// find the running app container
-	appContainerResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	appContainerResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"ps", "--filter", fmt.Sprintf("label=com.dokku.app-name=%s", appName), "--filter", "label=com.dokku.process-type=web", "--format", "{{.ID}}"},
 	})
@@ -118,7 +118,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	appContainerID = appContainerIDs[0]
 
 	// verify the app container is running via docker inspect
-	appInspectResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	appInspectResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"inspect", "--format", "{{.State.Running}}", appContainerID},
 	})
@@ -130,7 +130,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	}
 
 	// verify REDIS_URL is present inside the running container via docker exec
-	execResult, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	execResult, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "docker",
 		Args:    []string{"exec", appContainerID, "env"},
 	})
@@ -143,7 +143,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	}
 
 	// linking again should be idempotent
-	result = linkTask.Execute()
+	result = linkTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent link failed: %v", result.Error)
 	}
@@ -156,7 +156,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 
 	// unlink service from app
 	unlinkTask := ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StateAbsent}
-	result = unlinkTask.Execute()
+	result = unlinkTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unlink service: %v", result.Error)
 	}
@@ -168,7 +168,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	}
 
 	// verify REDIS_URL config var was removed by the unlink
-	configResult, err = subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	configResult, err = subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"config:get", appName, "REDIS_URL"},
 	})
@@ -177,7 +177,7 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	}
 
 	// unlinking again should be idempotent
-	result = unlinkTask.Execute()
+	result = unlinkTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent unlink failed: %v", result.Error)
 	}

--- a/tasks/service_link_task_test.go
+++ b/tasks/service_link_task_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestServiceLinkTaskInvalidState(t *testing.T) {
 	task := ServiceLinkTask{App: "test-app", Service: "redis", Name: "test-service", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}

--- a/tasks/service_property_task.go
+++ b/tasks/service_property_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -94,8 +95,8 @@ func (t ServicePropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or clears the dokku service property
-func (t ServicePropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t ServicePropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the ServicePropertyTask's inputs without contacting the server.
@@ -115,13 +116,13 @@ func (t ServicePropertyTask) Validate() error {
 // Plan reports the drift the ServicePropertyTask would produce. dokku has no
 // reliable way to read back a service set key, so the plan reports drift
 // unconditionally once the service is confirmed to exist.
-func (t ServicePropertyTask) Plan() PlanResult {
+func (t ServicePropertyTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -137,14 +138,14 @@ func (t ServicePropertyTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "service property state not probed",
 				Mutations: []string{fmt.Sprintf("%s:set %s %s %s", t.Service, t.Name, t.Property, t.Value)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := serviceExists(t.Service, t.Name)
+			exists, err := serviceExists(ctx, t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -160,9 +161,9 @@ func (t ServicePropertyTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "service property state not probed",
 				Mutations: []string{fmt.Sprintf("%s:set %s %s (clear)", t.Service, t.Name, t.Property)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/service_property_task_test.go
+++ b/tasks/service_property_task_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestServicePropertyTaskInvalidState(t *testing.T) {
 	task := ServicePropertyTask{Service: "redis", Name: "test-service", Property: "restart-policy", Value: "always", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -16,7 +16,7 @@ func TestServicePropertyTaskInvalidState(t *testing.T) {
 
 func TestServicePropertyTaskPresentRequiresValue(t *testing.T) {
 	task := ServicePropertyTask{Service: "redis", Name: "test-service", Property: "restart-policy"}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with present state and no value should return an error")
 	}
@@ -24,7 +24,7 @@ func TestServicePropertyTaskPresentRequiresValue(t *testing.T) {
 
 func TestServicePropertyTaskAbsentRejectsValue(t *testing.T) {
 	task := ServicePropertyTask{Service: "redis", Name: "test-service", Property: "restart-policy", Value: "always", State: StateAbsent}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with absent state and a value should return an error")
 	}
@@ -32,7 +32,7 @@ func TestServicePropertyTaskAbsentRejectsValue(t *testing.T) {
 
 func TestServicePropertyTaskRequiresProperty(t *testing.T) {
 	task := ServicePropertyTask{Service: "redis", Name: "test-service", Value: "always"}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with no property should return an error")
 	}

--- a/tasks/ssh_key_task.go
+++ b/tasks/ssh_key_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -74,8 +75,8 @@ func (t SshKeyTask) Examples() ([]Doc, error) {
 }
 
 // Execute adds or removes the SSH key
-func (t SshKeyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t SshKeyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the SshKeyTask's inputs without contacting the server.
@@ -95,14 +96,14 @@ func (t SshKeyTask) Validate() error {
 }
 
 // Plan reports the drift the SshKeyTask would produce.
-func (t SshKeyTask) Plan() PlanResult {
+func (t SshKeyTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			pub, _, _, _, _ := ssh.ParseAuthorizedKey([]byte(t.Key))
-			keys, err := sshKeysList()
+			keys, err := sshKeysList(ctx)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -126,9 +127,9 @@ func (t SshKeyTask) Plan() PlanResult {
 					Status:    PlanStatusModify,
 					Reason:    "key contents changed",
 					Mutations: []string{fmt.Sprintf("rotate ssh key %s", t.Name)},
-					Commands:  resolveCommands(inputs),
-					apply: func() TaskOutputState {
-						return runExecInputs(TaskOutputState{State: StatePresent}, StatePresent, inputs)
+					Commands:  resolveCommands(ctx, inputs),
+					apply: func(ctx context.Context) TaskOutputState {
+						return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StatePresent, inputs)
 					},
 				}
 			}
@@ -138,14 +139,14 @@ func (t SshKeyTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "key missing",
 				Mutations: []string{fmt.Sprintf("add ssh key %s", t.Name)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			keys, err := sshKeysList()
+			keys, err := sshKeysList(ctx)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -160,9 +161,9 @@ func (t SshKeyTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "key present",
 				Mutations: []string{fmt.Sprintf("remove ssh key %s", t.Name)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -181,8 +182,8 @@ type sshKeyEntry struct {
 // sshKeysList returns the installed ssh keys keyed by name. A dokku-level
 // non-zero exit (e.g. no keys configured) is treated as an empty set; only a
 // transport-level failure (*subprocess.SSHError) is propagated.
-func sshKeysList() (map[string]sshKeyEntry, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func sshKeysList(ctx context.Context) (map[string]sshKeyEntry, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "ssh-keys:list", "--format", "json"},
 	})
@@ -221,8 +222,8 @@ func sshKeyMatches(entry sshKeyEntry, pub ssh.PublicKey) bool {
 // ExportGlobal reconstructs the server's SSH keys from ssh-keys:list, which
 // exposes both the name and the public-key body, so each key is reproduced
 // faithfully.
-func (t SshKeyTask) ExportGlobal() ([]interface{}, error) {
-	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func (t SshKeyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	response, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "ssh-keys:list", "--format", "json"},
 	})

--- a/tasks/ssh_key_task_integration_test.go
+++ b/tasks/ssh_key_task_integration_test.go
@@ -12,7 +12,7 @@ func TestIntegrationSshKey(t *testing.T) {
 	keyName := "docket-test-ssh-key"
 
 	removeSSHKey := func() {
-		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 			Command: "dokku",
 			Args:    []string{"--quiet", "ssh-keys:remove", keyName},
 		})
@@ -23,7 +23,7 @@ func TestIntegrationSshKey(t *testing.T) {
 
 	assertPresent := func(t *testing.T, label string, want bool) {
 		t.Helper()
-		keys, err := sshKeysList()
+		keys, err := sshKeysList(testCtx())
 		if err != nil {
 			t.Fatalf("%s: sshKeysList failed: %v", label, err)
 		}
@@ -36,7 +36,7 @@ func TestIntegrationSshKey(t *testing.T) {
 
 	// add the key
 	addTask := SshKeyTask{Name: keyName, Key: testSSHKey1, State: StatePresent}
-	result := addTask.Execute()
+	result := addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to add key: %v", result.Error)
 	}
@@ -49,7 +49,7 @@ func TestIntegrationSshKey(t *testing.T) {
 	assertPresent(t, "after add", true)
 
 	// add the same key again - idempotent
-	result = addTask.Execute()
+	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
 	}
@@ -59,7 +59,7 @@ func TestIntegrationSshKey(t *testing.T) {
 
 	// rotate to a different key under the same name
 	rotateTask := SshKeyTask{Name: keyName, Key: testSSHKey2, State: StatePresent}
-	result = rotateTask.Execute()
+	result = rotateTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to rotate key: %v", result.Error)
 	}
@@ -69,7 +69,7 @@ func TestIntegrationSshKey(t *testing.T) {
 	assertPresent(t, "after rotate", true)
 
 	// rotation is now idempotent
-	result = rotateTask.Execute()
+	result = rotateTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second rotate: %v", result.Error)
 	}
@@ -79,7 +79,7 @@ func TestIntegrationSshKey(t *testing.T) {
 
 	// remove the key
 	removeTask := SshKeyTask{Name: keyName, State: StateAbsent}
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to remove key: %v", result.Error)
 	}
@@ -92,7 +92,7 @@ func TestIntegrationSshKey(t *testing.T) {
 	assertPresent(t, "after remove", false)
 
 	// remove again - idempotent
-	result = removeTask.Execute()
+	result = removeTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second remove: %v", result.Error)
 	}

--- a/tasks/ssh_key_task_test.go
+++ b/tasks/ssh_key_task_test.go
@@ -19,28 +19,28 @@ const (
 
 func TestSshKeyTaskInvalidState(t *testing.T) {
 	task := SshKeyTask{Name: "deploy-bot", Key: testSSHKey1, State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
 }
 
 func TestSshKeyTaskRequiresName(t *testing.T) {
-	result := SshKeyTask{Key: testSSHKey1, State: StatePresent}.Plan()
+	result := SshKeyTask{Key: testSSHKey1, State: StatePresent}.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan without 'name' should return an error")
 	}
 }
 
 func TestSshKeyTaskRequiresKeyWhenPresent(t *testing.T) {
-	result := SshKeyTask{Name: "deploy-bot", State: StatePresent}.Plan()
+	result := SshKeyTask{Name: "deploy-bot", State: StatePresent}.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with state 'present' and no 'key' should return an error")
 	}
 }
 
 func TestSshKeyTaskInvalidKey(t *testing.T) {
-	result := SshKeyTask{Name: "deploy-bot", Key: "not-a-key", State: StatePresent}.Plan()
+	result := SshKeyTask{Name: "deploy-bot", Key: "not-a-key", State: StatePresent}.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("Plan with an unparseable key should return an error")
 	}

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -78,8 +79,8 @@ func (t StorageEnsureTask) Examples() ([]Doc, error) {
 }
 
 // Execute ensures the storage for a given app
-func (t StorageEnsureTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t StorageEnsureTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the StorageEnsureTask's inputs without contacting the server.
@@ -133,7 +134,7 @@ func (t StorageEnsureTask) ensureArgs() []string {
 // Plan reports the drift the StorageEnsureTask would produce. dokku does
 // not expose a probe for storage:ensure-directory, so the plan reports
 // drift unconditionally.
-func (t StorageEnsureTask) Plan() PlanResult {
+func (t StorageEnsureTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
@@ -149,9 +150,9 @@ func (t StorageEnsureTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "directory presence not probed",
 				Mutations: []string{strings.Join(args[1:], " ")},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},

--- a/tasks/storage_ensure_task_integration_test.go
+++ b/tasks/storage_ensure_task_integration_test.go
@@ -9,16 +9,16 @@ func TestIntegrationStorageEnsure(t *testing.T) {
 
 	appName := "docket-test-storage"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	task := StorageEnsureTask{
 		App:   appName,
 		Chown: "herokuish",
 		State: StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to ensure storage: %v", result.Error)
 	}
@@ -32,16 +32,16 @@ func TestIntegrationStorageEnsureOmittedChown(t *testing.T) {
 
 	appName := "docket-test-storage-nochown"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// chown omitted: dokku applies its default (herokuish) ownership.
 	task := StorageEnsureTask{
 		App:   appName,
 		State: StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to ensure storage without chown: %v", result.Error)
 	}
@@ -55,9 +55,9 @@ func TestIntegrationStorageEnsureNumericChown(t *testing.T) {
 
 	appName := "docket-test-storage-numeric-chown"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// A raw numeric uid is accepted by dokku (ownership set to <uid>:<uid>).
 	task := StorageEnsureTask{
@@ -65,7 +65,7 @@ func TestIntegrationStorageEnsureNumericChown(t *testing.T) {
 		Chown: "32767",
 		State: StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to ensure storage with numeric chown: %v", result.Error)
 	}

--- a/tasks/storage_ensure_task_test.go
+++ b/tasks/storage_ensure_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestStorageEnsureTaskInvalidState(t *testing.T) {
 	task := StorageEnsureTask{App: "test-app", Chown: "heroku", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -46,7 +46,7 @@ func TestStorageEnsureInvalidChownValue(t *testing.T) {
 
 func TestStorageEnsureAbsentStateReturnsError(t *testing.T) {
 	task := StorageEnsureTask{App: "test-app", Chown: "heroku", State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with absent state should return an error for storage ensure")
 	}

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -161,8 +162,8 @@ func (t StorageEntryTask) Examples() ([]Doc, error) {
 }
 
 // Execute creates or destroys the storage entry
-func (t StorageEntryTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t StorageEntryTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // createArgs builds the storage:create command arguments. Every flag is
@@ -413,18 +414,18 @@ func validateKVFlag(name string, values map[string]string) error {
 }
 
 // Plan reports the drift the StorageEntryTask would produce.
-func (t StorageEntryTask) Plan() PlanResult {
+func (t StorageEntryTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			entry, err := lookupStorageEntry(t.Name)
+			entry, err := lookupStorageEntry(ctx, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
 			if entry != nil {
-				return planStorageEntryAttributes(t, *entry)
+				return planStorageEntryAttributes(ctx, t, *entry)
 			}
 			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: t.createArgs()}}
 			return PlanResult{
@@ -432,14 +433,14 @@ func (t StorageEntryTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "entry missing",
 				Mutations: []string{fmt.Sprintf("create storage entry %s", t.Name)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			entry, err := lookupStorageEntry(t.Name)
+			entry, err := lookupStorageEntry(ctx, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -468,9 +469,9 @@ func (t StorageEntryTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "entry present",
 				Mutations: []string{formatStorageEntryDestroy(t, *entry)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -547,7 +548,7 @@ func mutableStorageEntryAttributes(t StorageEntryTask, e storageEntry) []storage
 // It is a package-level func rather than a method because
 // TestProbeSupportMatchesPlanWiring walks the tasks package for
 // plan-returning methods and allows exactly one per task, Plan itself.
-func planStorageEntryAttributes(t StorageEntryTask, entry storageEntry) PlanResult {
+func planStorageEntryAttributes(ctx context.Context, t StorageEntryTask, entry storageEntry) PlanResult {
 	for _, attr := range immutableStorageEntryAttributes(t, entry) {
 		if !attr.drifted() {
 			continue
@@ -606,9 +607,9 @@ func planStorageEntryAttributes(t StorageEntryTask, entry storageEntry) PlanResu
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d attribute(s) to set", len(inputs)),
 		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StatePresent, inputs)
+		Commands:  resolveCommands(ctx, inputs),
+		apply: func(ctx context.Context) TaskOutputState {
+			return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StatePresent, inputs)
 		},
 	}
 }
@@ -659,8 +660,8 @@ func formatStorageEntryDestroy(t StorageEntryTask, entry storageEntry) string {
 // k3s entry the task's own validation rejects. destroy_host_dir is not
 // exported because it is not state - it modifies a destroy the exported
 // recipe does not perform.
-func (t StorageEntryTask) ExportGlobal() ([]interface{}, error) {
-	entries, err := storageEntries()
+func (t StorageEntryTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	entries, err := storageEntries(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -709,8 +710,8 @@ type storageEntry struct {
 // failure (`*subprocess.SSHError`) is propagated; a dokku-level non-zero
 // exit or unparseable output is treated as an empty registry, since a
 // server without the entries directory has none to report.
-func storageEntries() ([]storageEntry, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func storageEntries(ctx context.Context) ([]storageEntry, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "storage:list-entries", "--format", "json"},
 	})
@@ -735,8 +736,8 @@ func storageEntries() ([]storageEntry, error) {
 // compared against what the registry records. A transport-level failure
 // (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit is
 // treated as "no entry."
-func lookupStorageEntry(name string) (*storageEntry, error) {
-	entries, err := storageEntries()
+func lookupStorageEntry(ctx context.Context, name string) (*storageEntry, error) {
+	entries, err := storageEntries(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/storage_entry_task_integration_test.go
+++ b/tasks/storage_entry_task_integration_test.go
@@ -20,10 +20,10 @@ func TestIntegrationStorageEntry(t *testing.T) {
 
 	// Start clean.
 	destroy := StorageEntryTask{Name: name, State: StateAbsent}
-	destroy.Execute()
+	destroy.Execute(testCtx())
 
 	create := StorageEntryTask{Name: name, Chown: "herokuish", State: StatePresent}
-	result := create.Execute()
+	result := create.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create entry: %v", result.Error)
 	}
@@ -35,7 +35,7 @@ func TestIntegrationStorageEntry(t *testing.T) {
 	}
 
 	// Re-apply: should be idempotent.
-	result = create.Execute()
+	result = create.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent create failed: %v", result.Error)
 	}
@@ -44,7 +44,7 @@ func TestIntegrationStorageEntry(t *testing.T) {
 	}
 
 	// Destroy.
-	result = destroy.Execute()
+	result = destroy.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to destroy entry: %v", result.Error)
 	}
@@ -56,7 +56,7 @@ func TestIntegrationStorageEntry(t *testing.T) {
 	}
 
 	// Destroy again: idempotent.
-	result = destroy.Execute()
+	result = destroy.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent destroy failed: %v", result.Error)
 	}
@@ -74,11 +74,11 @@ func TestIntegrationStorageEntryNumericChown(t *testing.T) {
 	// dokku_storage_entry passes chown through unrestricted, so numeric uids
 	// already work here (unlike the historically narrower dokku_storage_ensure).
 	destroy := StorageEntryTask{Name: name, State: StateAbsent}
-	destroy.Execute()
-	defer destroy.Execute()
+	destroy.Execute(testCtx())
+	defer destroy.Execute(testCtx())
 
 	create := StorageEntryTask{Name: name, Chown: "32767", State: StatePresent}
-	result := create.Execute()
+	result := create.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create entry with numeric chown: %v", result.Error)
 	}
@@ -100,8 +100,8 @@ func TestIntegrationStorageEntryAnnotationsAndLabels(t *testing.T) {
 	// entry whatever the scheduler, so a docker-local entry is enough to
 	// prove the pairs survive the flag round trip intact.
 	destroy := StorageEntryTask{Name: name, State: StateAbsent}
-	destroy.Execute()
-	defer destroy.Execute()
+	destroy.Execute(testCtx())
+	defer destroy.Execute(testCtx())
 
 	create := StorageEntryTask{
 		Name:        name,
@@ -110,7 +110,7 @@ func TestIntegrationStorageEntryAnnotationsAndLabels(t *testing.T) {
 		Labels:      map[string]string{"docket-managed": "true"},
 		State:       StatePresent,
 	}
-	result := create.Execute()
+	result := create.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to create entry with annotations and labels: %v", result.Error)
 	}
@@ -118,7 +118,7 @@ func TestIntegrationStorageEntryAnnotationsAndLabels(t *testing.T) {
 		t.Error("expected changed=true for new entry")
 	}
 
-	entries, err := storageEntries()
+	entries, err := storageEntries(testCtx())
 	if err != nil {
 		t.Fatalf("failed to read storage entries: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestIntegrationStorageEntryAnnotationsAndLabels(t *testing.T) {
 
 	// ExportGlobal reconstructs the same values, so `docket export`
 	// reproduces the entry rather than a lossy shell of it.
-	exported, err := StorageEntryTask{}.ExportGlobal()
+	exported, err := StorageEntryTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal returned an error: %v", err)
 	}
@@ -176,11 +176,11 @@ func TestIntegrationStorageEntryConvergesChown(t *testing.T) {
 	name := "docket-test-entry-converge-chown"
 
 	destroy := StorageEntryTask{Name: name, State: StateAbsent}
-	destroy.Execute()
-	defer destroy.Execute()
+	destroy.Execute(testCtx())
+	defer destroy.Execute(testCtx())
 
 	create := StorageEntryTask{Name: name, Chown: "herokuish", State: StatePresent}
-	if result := create.Execute(); result.Error != nil {
+	if result := create.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to create entry: %v", result.Error)
 	}
 
@@ -189,12 +189,12 @@ func TestIntegrationStorageEntryConvergesChown(t *testing.T) {
 	// re-runs the chown on the host directory instead of only recording a
 	// new value.
 	converge := StorageEntryTask{Name: name, Chown: "root", State: StatePresent}
-	plan := converge.Plan()
+	plan := converge.Plan(testCtx())
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
 	}
 
-	result := converge.Execute()
+	result := converge.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to converge chown: %v", result.Error)
 	}
@@ -211,7 +211,7 @@ func TestIntegrationStorageEntryConvergesChown(t *testing.T) {
 	}
 
 	// A third run settles: the recipe now matches what the registry holds.
-	result = converge.Execute()
+	result = converge.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("re-applying the converged entry failed: %v", result.Error)
 	}
@@ -226,11 +226,11 @@ func TestIntegrationStorageEntryConvergesMode(t *testing.T) {
 	name := "docket-test-entry-converge-mode"
 
 	destroy := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
-	destroy.Execute()
-	defer destroy.Execute()
+	destroy.Execute(testCtx())
+	defer destroy.Execute(testCtx())
 
 	create := StorageEntryTask{Name: name, Mode: "0750", State: StatePresent}
-	if result := create.Execute(); result.Error != nil {
+	if result := create.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to create entry: %v", result.Error)
 	}
 	hostDir := filepath.Join(dokkuStorageRoot, name)
@@ -240,12 +240,12 @@ func TestIntegrationStorageEntryConvergesMode(t *testing.T) {
 	// storage:set rather than a second storage:create - which is what re-runs
 	// the chmod on the host directory instead of only recording a new value.
 	converge := StorageEntryTask{Name: name, Mode: "0777", State: StatePresent}
-	plan := converge.Plan()
+	plan := converge.Plan(testCtx())
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
 	}
 
-	result := converge.Execute()
+	result := converge.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to converge mode: %v", result.Error)
 	}
@@ -259,7 +259,7 @@ func TestIntegrationStorageEntryConvergesMode(t *testing.T) {
 	assertDirModeT(t, hostDir, 0o777)
 
 	// A third run settles: the recipe now matches what the registry holds.
-	if result := converge.Execute(); result.Changed {
+	if result := converge.Execute(testCtx()); result.Changed {
 		t.Error("expected changed=false once the mode matches")
 	}
 }
@@ -270,14 +270,14 @@ func TestIntegrationStorageEntryNormalizesAThreeDigitMode(t *testing.T) {
 	name := "docket-test-entry-mode-normalize"
 
 	destroy := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
-	destroy.Execute()
-	defer destroy.Execute()
+	destroy.Execute(testCtx())
+	defer destroy.Execute(testCtx())
 
 	// dokku records the 4 digit form whatever the recipe wrote. docket has to
 	// compare the same way, or this recipe would report drift on every run and
 	// re-apply a mode that was already correct.
 	create := StorageEntryTask{Name: name, Mode: "700", State: StatePresent}
-	if result := create.Execute(); result.Error != nil {
+	if result := create.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to create entry: %v", result.Error)
 	}
 	if entry := findStorageEntryT(t, name); entry.Mode != "0700" {
@@ -285,7 +285,7 @@ func TestIntegrationStorageEntryNormalizesAThreeDigitMode(t *testing.T) {
 	}
 	assertDirModeT(t, filepath.Join(dokkuStorageRoot, name), 0o700)
 
-	if result := create.Execute(); result.Changed {
+	if result := create.Execute(testCtx()); result.Changed {
 		t.Error("expected changed=false for a three digit mode that is already applied")
 	}
 }
@@ -297,11 +297,11 @@ func TestIntegrationStorageEntryDestroyHostDir(t *testing.T) {
 	hostDir := filepath.Join(dokkuStorageRoot, name)
 
 	cleanup := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
-	cleanup.Execute()
-	defer cleanup.Execute()
+	cleanup.Execute(testCtx())
+	defer cleanup.Execute(testCtx())
 
 	create := StorageEntryTask{Name: name, State: StatePresent}
-	if result := create.Execute(); result.Error != nil {
+	if result := create.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to create entry: %v", result.Error)
 	}
 	if _, err := os.Stat(hostDir); err != nil {
@@ -310,7 +310,7 @@ func TestIntegrationStorageEntryDestroyHostDir(t *testing.T) {
 
 	// A plain destroy deregisters the entry and leaves the directory, which is
 	// the half dokku_storage_entry has always covered.
-	if result := (StorageEntryTask{Name: name, State: StateAbsent}).Execute(); result.Error != nil {
+	if result := (StorageEntryTask{Name: name, State: StateAbsent}).Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to destroy entry: %v", result.Error)
 	}
 	if _, err := os.Stat(hostDir); err != nil {
@@ -318,12 +318,12 @@ func TestIntegrationStorageEntryDestroyHostDir(t *testing.T) {
 	}
 
 	// The flag is the other half: re-create, then destroy the directory too.
-	if result := create.Execute(); result.Error != nil {
+	if result := create.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to re-create entry: %v", result.Error)
 	}
 
 	destroy := StorageEntryTask{Name: name, DestroyHostDir: true, State: StateAbsent}
-	plan := destroy.Plan()
+	plan := destroy.Plan(testCtx())
 	if plan.Status != PlanStatusDestroy {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusDestroy, plan.Status, plan.Error)
 	}
@@ -331,7 +331,7 @@ func TestIntegrationStorageEntryDestroyHostDir(t *testing.T) {
 		t.Errorf("expected the plan to name %s, got %v", hostDir, plan.Mutations)
 	}
 
-	result := destroy.Execute()
+	result := destroy.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to destroy entry and host directory: %v", result.Error)
 	}
@@ -349,15 +349,15 @@ func TestIntegrationStorageEntryConvergesOneAnnotationKey(t *testing.T) {
 	name := "docket-test-entry-converge-metadata"
 
 	destroy := StorageEntryTask{Name: name, State: StateAbsent}
-	destroy.Execute()
-	defer destroy.Execute()
+	destroy.Execute(testCtx())
+	defer destroy.Execute(testCtx())
 
 	create := StorageEntryTask{
 		Name:        name,
 		Annotations: map[string]string{"docket.io/team": "platform", "docket.io/tier": "data"},
 		State:       StatePresent,
 	}
-	if result := create.Execute(); result.Error != nil {
+	if result := create.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to create entry: %v", result.Error)
 	}
 
@@ -369,7 +369,7 @@ func TestIntegrationStorageEntryConvergesOneAnnotationKey(t *testing.T) {
 		Annotations: map[string]string{"docket.io/team": "sre"},
 		State:       StatePresent,
 	}
-	result := converge.Execute()
+	result := converge.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to converge the annotation: %v", result.Error)
 	}
@@ -385,7 +385,7 @@ func TestIntegrationStorageEntryConvergesOneAnnotationKey(t *testing.T) {
 		t.Errorf("expected the undeclared annotation to survive, got %v", entry.Annotations)
 	}
 
-	if result := converge.Execute(); result.Changed {
+	if result := converge.Execute(testCtx()); result.Changed {
 		t.Error("expected changed=false once the annotation matches")
 	}
 }
@@ -396,18 +396,18 @@ func TestIntegrationStorageEntryRefusesAPathChange(t *testing.T) {
 	name := "docket-test-entry-immutable-path"
 
 	destroy := StorageEntryTask{Name: name, State: StateAbsent}
-	destroy.Execute()
-	defer destroy.Execute()
+	destroy.Execute(testCtx())
+	defer destroy.Execute(testCtx())
 
 	create := StorageEntryTask{Name: name, State: StatePresent}
-	if result := create.Execute(); result.Error != nil {
+	if result := create.Execute(testCtx()); result.Error != nil {
 		t.Fatalf("failed to create entry: %v", result.Error)
 	}
 
 	// dokku has no command that moves an entry's host path, so the plan
 	// says so rather than reporting a change it could never apply.
 	move := StorageEntryTask{Name: name, Path: "/mnt/docket-test-entry-elsewhere", State: StatePresent}
-	plan := move.Plan()
+	plan := move.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 	}
@@ -435,7 +435,7 @@ func assertDirModeT(t *testing.T, dir string, want os.FileMode) {
 // test when the server does not report it.
 func findStorageEntryT(t *testing.T, name string) storageEntry {
 	t.Helper()
-	entry, err := lookupStorageEntry(name)
+	entry, err := lookupStorageEntry(testCtx(), name)
 	if err != nil {
 		t.Fatalf("failed to read storage entries: %v", err)
 	}

--- a/tasks/storage_entry_task_test.go
+++ b/tasks/storage_entry_task_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestStorageEntryTaskInvalidState(t *testing.T) {
 	task := StorageEntryTask{Name: "test-entry", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -21,7 +21,7 @@ func TestStorageEntryAbsentStateAllowed(t *testing.T) {
 	// because dokku isn't reachable, but the failure must not be the
 	// "absent state is not supported" sentinel.
 	task := StorageEntryTask{Name: "test-entry", State: StateAbsent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil && result.Error.Error() == "the absent state is not supported for storage:ensure" {
 		t.Errorf("absent should be supported for storage_entry, got: %v", result.Error)
 	}
@@ -471,7 +471,7 @@ func TestStorageEntryPlanReportsValidationError(t *testing.T) {
 	// Validate runs before the probe, so an invalid input never reaches
 	// the server.
 	task := StorageEntryTask{Name: "app-data", Chown: "packeto", State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 	}
@@ -491,7 +491,7 @@ func TestStorageEntryPlanCreateCarriesEveryFlag(t *testing.T) {
 		Annotations: map[string]string{"team": "platform"},
 		State:       StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusCreate {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusCreate, plan.Status)
 	}
@@ -544,7 +544,7 @@ func storageEntriesFixture() map[string]string {
 func TestStorageEntryExportGlobal(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(storageEntriesFixture()))()
 
-	exported, err := StorageEntryTask{}.ExportGlobal()
+	exported, err := StorageEntryTask{}.ExportGlobal(testCtx())
 	if err != nil {
 		t.Fatalf("ExportGlobal returned an error: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestStorageEntryPlanInSyncWhenEveryDeclaredFieldMatches(t *testing.T) {
 		Chown:     "herokuish",
 		State:     StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q reason %q", plan.Status, plan.Reason)
 	}
@@ -651,7 +651,7 @@ func TestStorageEntryPlanLeavesUndeclaredAttributesAlone(t *testing.T) {
 		Chown:     "herokuish",
 		State:     StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q reason %q mutations %v", plan.Status, plan.Reason, plan.Mutations)
 	}
@@ -661,7 +661,7 @@ func TestStorageEntryPlanConvergesChown(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", Chown: "root", State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusModify, plan.Status)
 	}
@@ -696,7 +696,7 @@ func TestStorageEntryPlanConvergesMode(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", Mode: "0777", State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
 	}
@@ -717,7 +717,7 @@ func TestStorageEntryPlanReadsAThreeDigitModeAsItsFourDigitForm(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", Mode: "755", State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q mutations %v", plan.Status, plan.Mutations)
 	}
@@ -729,7 +729,7 @@ func TestStorageEntryPlanNormalizesAThreeDigitModeItSets(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", Mode: "700", State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	want := []string{"dokku --quiet storage:set app-data mode 0700"}
 	if !equalStrings(plan.Commands, want) {
 		t.Errorf("expected commands %v, got %v", want, plan.Commands)
@@ -743,7 +743,7 @@ func TestStorageEntryPlanConvergesChownBeforeMode(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", Chown: "root", Mode: "0777", State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	want := []string{
 		"dokku --quiet storage:set app-data chown root",
 		"dokku --quiet storage:set app-data mode 0777",
@@ -781,7 +781,7 @@ func TestStorageEntryPlanConvergesEveryMutableAttributeInFieldOrder(t *testing.T
 		Labels:        map[string]string{"tier": "data"},
 		State:         StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
 	}
@@ -831,7 +831,7 @@ func TestStorageEntryPlanConvergesMapKeysWithoutDisturbingSiblings(t *testing.T)
 		Annotations: map[string]string{"team": "data"},
 		State:       StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	want := []string{"dokku --quiet storage:annotations:set app-data team data"}
 	if !equalStrings(plan.Commands, want) {
 		t.Errorf("expected commands %v, got %v", want, plan.Commands)
@@ -884,7 +884,7 @@ func TestStorageEntryPlanRejectsImmutableDrift(t *testing.T) {
 			defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(test.entry)))()
 
 			test.task.State = StatePresent
-			plan := test.task.Plan()
+			plan := test.task.Plan(testCtx())
 			if plan.Status != PlanStatusError {
 				t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 			}
@@ -907,7 +907,7 @@ func TestStorageEntryPlanReadsAnOmittedSchedulerAsDockerLocal(t *testing.T) {
 	)))()
 
 	task := StorageEntryTask{Name: "app-data", State: StatePresent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 	}
@@ -922,7 +922,7 @@ func TestStorageEntryPlanAbsentIgnoresAttributes(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusDestroy {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusDestroy, plan.Status)
 	}
@@ -936,7 +936,7 @@ func TestStorageEntryPlanAbsentDestroysTheHostDirectoryOnRequest(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusDestroy {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusDestroy, plan.Status, plan.Error)
 	}
@@ -964,7 +964,7 @@ func TestStorageEntryPlanAbsentReportsAReclaimDeleteRemoval(t *testing.T) {
 	}`)))()
 
 	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	want := []string{"dokku --quiet storage:destroy --force app-data"}
 	if !equalStrings(plan.Commands, want) {
 		t.Errorf("expected commands %v, got %v", want, plan.Commands)
@@ -979,7 +979,7 @@ func TestStorageEntryPlanAbsentLeavesTheHostDirectoryAloneByDefault(t *testing.T
 	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
 
 	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	wantMutations := []string{"destroy storage entry app-data"}
 	if !equalStrings(plan.Mutations, wantMutations) {
 		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
@@ -994,7 +994,7 @@ func TestStorageEntryPlanAbsentRejectsDestroyHostDirOnANonDockerLocalEntry(t *te
 	)))()
 
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Status != PlanStatusError {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 	}
@@ -1012,7 +1012,7 @@ func TestStorageEntryPlanAbsentIgnoresDestroyHostDirWhenTheEntryIsGone(t *testin
 	}))()
 
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q (error %v)", plan.Status, plan.Error)
 	}
@@ -1029,7 +1029,7 @@ func TestStorageEntryExecuteAppliesAttributeDrift(t *testing.T) {
 	})()
 
 	task := StorageEntryTask{Name: "app-data", Chown: "root", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("expected the apply to succeed, got: %v", result.Error)
 	}

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -165,8 +166,8 @@ func (t StorageMountTask) Examples() ([]Doc, error) {
 }
 
 // Execute attaches or detaches storage for a given app
-func (t StorageMountTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t StorageMountTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // Validate checks the StorageMountTask's inputs without contacting the server.
@@ -178,13 +179,13 @@ func (t StorageMountTask) Validate() error {
 }
 
 // Plan reports the drift the StorageMountTask would produce.
-func (t StorageMountTask) Plan() PlanResult {
+func (t StorageMountTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			existing, err := findMount(t.App, t.EntryName, t.HostDir, t.ContainerDir)
+			existing, err := findMount(ctx, t.App, t.EntryName, t.HostDir, t.ContainerDir)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -214,14 +215,14 @@ func (t StorageMountTask) Plan() PlanResult {
 				Status:    status,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("mount %s on %s", t.describeMount(), t.App)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
-			existing, err := findMount(t.App, t.EntryName, t.HostDir, t.ContainerDir)
+			existing, err := findMount(ctx, t.App, t.EntryName, t.HostDir, t.ContainerDir)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -237,9 +238,9 @@ func (t StorageMountTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "mount present",
 				Mutations: []string{fmt.Sprintf("unmount %s on %s", t.describeMount(), t.App)},
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				Commands:  resolveCommands(ctx, inputs),
+				apply: func(ctx context.Context) TaskOutputState {
+					return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},
@@ -366,8 +367,8 @@ type existingMount struct {
 // "legacy-" entry name) use the host_dir form; named registry entries use the
 // entry_name form. Phases and process_type that match dokku's defaults are
 // omitted so the exported recipe stays minimal.
-func (t StorageMountTask) ExportApp(app string) ([]interface{}, error) {
-	attachments, err := readStorageAttachments(app)
+func (t StorageMountTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	attachments, err := readStorageAttachments(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -425,8 +426,8 @@ type reportAttachment struct {
 // A transport-level failure (*subprocess.SSHError) is propagated; a dokku-level
 // non-zero exit (e.g. app does not exist) or a JSON parse failure is treated as
 // "no attachments."
-func readStorageAttachments(app string) ([]reportAttachment, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+func readStorageAttachments(ctx context.Context, app string) ([]reportAttachment, error) {
+	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "storage:report", app, "--format", "json"},
 	})
@@ -522,8 +523,8 @@ func isDefaultPhases(phases []string) bool {
 // only reports the deploy phase, which would hide run-only mounts. A
 // transport-level failure (`*subprocess.SSHError`) is propagated; a dokku-level
 // non-zero exit (e.g. app does not exist) is treated as "no mount."
-func findMount(app, entryName, hostDir, containerDir string) (*existingMount, error) {
-	attachments, err := readStorageAttachments(app)
+func findMount(ctx context.Context, app, entryName, hostDir, containerDir string) (*existingMount, error) {
+	attachments, err := readStorageAttachments(ctx, app)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks/storage_mount_task_integration_test.go
+++ b/tasks/storage_mount_task_integration_test.go
@@ -14,12 +14,12 @@ func TestIntegrationStorageMount(t *testing.T) {
 	containerDir := "/app/storage"
 	entryName := "docket-test-mount-entry"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	// ensure storage directory exists
-	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "mkdir",
 		Args:    []string{"-p", hostDir},
 	})
@@ -31,7 +31,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 		ContainerDir: containerDir,
 		State:        StatePresent,
 	}
-	result := mountTask.Execute()
+	result := mountTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to mount storage (legacy): %v", result.Error)
 	}
@@ -43,7 +43,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 	}
 
 	// mount again should be idempotent
-	result = mountTask.Execute()
+	result = mountTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent mount failed: %v", result.Error)
 	}
@@ -58,7 +58,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 		ContainerDir: containerDir,
 		State:        StateAbsent,
 	}
-	result = unmountTask.Execute()
+	result = unmountTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unmount storage (legacy): %v", result.Error)
 	}
@@ -70,7 +70,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 	}
 
 	// unmount again should be idempotent
-	result = unmountTask.Execute()
+	result = unmountTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent unmount failed: %v", result.Error)
 	}
@@ -84,12 +84,12 @@ func TestIntegrationStorageMount(t *testing.T) {
 		Chown: "herokuish",
 		State: StatePresent,
 	}
-	if r := entry.Execute(); r.Error != nil {
+	if r := entry.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to create entry: %v", r.Error)
 	}
 	defer func() {
 		destroy := StorageEntryTask{Name: entryName, State: StateAbsent}
-		destroy.Execute()
+		destroy.Execute(testCtx())
 	}()
 
 	namedMount := StorageMountTask{
@@ -99,7 +99,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 		Phases:       []string{"deploy", "run"},
 		State:        StatePresent,
 	}
-	result = namedMount.Execute()
+	result = namedMount.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to mount named entry: %v", result.Error)
 	}
@@ -108,7 +108,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 	}
 
 	// idempotent re-apply
-	result = namedMount.Execute()
+	result = namedMount.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent named-entry mount failed: %v", result.Error)
 	}
@@ -123,14 +123,14 @@ func TestIntegrationStorageMount(t *testing.T) {
 		ContainerDir: "/app/named",
 		State:        StateAbsent,
 	}
-	result = namedUnmount.Execute()
+	result = namedUnmount.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to unmount named entry: %v", result.Error)
 	}
 	if !result.Changed {
 		t.Error("expected changed=true for named-entry unmount")
 	}
-	result = namedUnmount.Execute()
+	result = namedUnmount.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent named-entry unmount failed: %v", result.Error)
 	}
@@ -147,11 +147,11 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 	containerDir := "/app/storage"
 	entryName := "docket-test-mount-opts-entry"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
-	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+	subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "mkdir",
 		Args:    []string{"-p", hostDir},
 	})
@@ -164,14 +164,14 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 		VolumeOptions: "Z",
 		State:         StatePresent,
 	}
-	result := withOpts.Execute()
+	result := withOpts.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to mount with volume_options=Z: %v", result.Error)
 	}
 	if !result.Changed {
 		t.Error("expected changed=true for new legacy mount with options")
 	}
-	result = withOpts.Execute()
+	result = withOpts.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent mount with volume_options failed: %v", result.Error)
 	}
@@ -187,10 +187,10 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 		ContainerDir: containerDir,
 		State:        StatePresent,
 	}
-	if plan := withoutOpts.Plan(); plan.Status != PlanStatusModify {
+	if plan := withoutOpts.Plan(testCtx()); plan.Status != PlanStatusModify {
 		t.Errorf("expected Modify status for volume_options drift on an existing mount, got %q (reason %q)", plan.Status, plan.Reason)
 	}
-	result = withoutOpts.Execute()
+	result = withoutOpts.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to re-mount without volume_options: %v", result.Error)
 	}
@@ -205,18 +205,18 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 		ContainerDir: containerDir,
 		State:        StateAbsent,
 	}
-	if r := unmount.Execute(); r.Error != nil {
+	if r := unmount.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to unmount legacy with options: %v", r.Error)
 	}
 
 	// named-entry form with multi-option round-trip
 	entry := StorageEntryTask{Name: entryName, Chown: "herokuish", State: StatePresent}
-	if r := entry.Execute(); r.Error != nil {
+	if r := entry.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to create entry: %v", r.Error)
 	}
 	defer func() {
 		destroy := StorageEntryTask{Name: entryName, State: StateAbsent}
-		destroy.Execute()
+		destroy.Execute(testCtx())
 	}()
 
 	namedWithOpts := StorageMountTask{
@@ -226,14 +226,14 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 		VolumeOptions: "noexec,nosuid",
 		State:         StatePresent,
 	}
-	result = namedWithOpts.Execute()
+	result = namedWithOpts.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed to mount named entry with options: %v", result.Error)
 	}
 	if !result.Changed {
 		t.Error("expected changed=true for new named-entry mount with options")
 	}
-	result = namedWithOpts.Execute()
+	result = namedWithOpts.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("idempotent named-entry mount with options failed: %v", result.Error)
 	}
@@ -247,7 +247,7 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 		ContainerDir: "/app/named",
 		State:        StateAbsent,
 	}
-	if r := namedUnmount.Execute(); r.Error != nil {
+	if r := namedUnmount.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to unmount named entry with options: %v", r.Error)
 	}
 }
@@ -263,17 +263,17 @@ func TestIntegrationStorageMountExportRoundTrip(t *testing.T) {
 	entryName := "docket-test-mount-export-entry"
 	containerDir := "/app/exported"
 
-	destroyApp(appName)
-	createApp(appName)
-	defer destroyApp(appName)
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
 
 	entry := StorageEntryTask{Name: entryName, Chown: "herokuish", State: StatePresent}
-	if r := entry.Execute(); r.Error != nil {
+	if r := entry.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to create entry: %v", r.Error)
 	}
 	defer func() {
 		destroy := StorageEntryTask{Name: entryName, State: StateAbsent}
-		destroy.Execute()
+		destroy.Execute(testCtx())
 	}()
 
 	mount := StorageMountTask{
@@ -285,11 +285,11 @@ func TestIntegrationStorageMountExportRoundTrip(t *testing.T) {
 		Readonly:     true,
 		State:        StatePresent,
 	}
-	if r := mount.Execute(); r.Error != nil {
+	if r := mount.Execute(testCtx()); r.Error != nil {
 		t.Fatalf("failed to mount named entry: %v", r.Error)
 	}
 
-	bodies, err := StorageMountTask{}.ExportApp(appName)
+	bodies, err := StorageMountTask{}.ExportApp(testCtx(), appName)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestIntegrationStorageMountExportRoundTrip(t *testing.T) {
 
 	// The exporter omits state; set it so the body can be planned directly.
 	got.State = StatePresent
-	if plan := got.Plan(); !plan.InSync {
+	if plan := got.Plan(testCtx()); !plan.InSync {
 		t.Errorf("exported mount should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }

--- a/tasks/storage_mount_task_test.go
+++ b/tasks/storage_mount_task_test.go
@@ -14,7 +14,7 @@ func TestStorageMountTaskInvalidState(t *testing.T) {
 		ContainerDir: "/container",
 		State:        "invalid",
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -39,7 +39,7 @@ func TestStorageMountRequiresExactlyOneSource(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.task.Plan()
+			result := tc.task.Plan(testCtx())
 			if result.Error == nil {
 				t.Fatalf("expected error %q, got nil", tc.want)
 			}
@@ -58,7 +58,7 @@ func TestStorageMountRejectsInvalidPhase(t *testing.T) {
 		Phases:       []string{"deploy", "boot"},
 		State:        StatePresent,
 	}
-	result := task.Plan()
+	result := task.Plan(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error for invalid phase")
 	}
@@ -187,7 +187,7 @@ func exportMounts(t *testing.T, app, report string) []StorageMountTask {
 		"--quiet storage:report " + app + " --format json": report,
 	}))()
 
-	bodies, err := StorageMountTask{}.ExportApp(app)
+	bodies, err := StorageMountTask{}.ExportApp(testCtx(), app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -335,7 +335,7 @@ func TestStorageMountExportRecipeEmitsFields(t *testing.T) {
 		"--quiet storage:report node-js-app --format json": report,
 	}))()
 
-	res, err := ExportRecipe(ExportOptions{Apps: []string{"node-js-app"}})
+	res, err := ExportRecipe(testCtx(), ExportOptions{Apps: []string{"node-js-app"}})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestStorageMountPlanFindsRunOnlyMount(t *testing.T) {
 		Phases:       []string{"run"},
 		State:        StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("Plan returned error: %v", plan.Error)
 	}
@@ -415,7 +415,7 @@ func TestStorageMountPlanVolumeOptionsDriftReportsModify(t *testing.T) {
 		VolumeOptions: "noexec,nosuid",
 		State:         StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("Plan returned error: %v", plan.Error)
 	}
@@ -443,7 +443,7 @@ func TestStorageMountPlanMissingReportsCreate(t *testing.T) {
 		ContainerDir: "/app/storage",
 		State:        StatePresent,
 	}
-	plan := task.Plan()
+	plan := task.Plan(testCtx())
 	if plan.Error != nil {
 		t.Fatalf("Plan returned error: %v", plan.Error)
 	}

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -45,7 +46,10 @@ type ToggleContext struct {
 // (state: present) position. nil from a probe (or a non-nil error) is
 // treated as "drift, must mutate" so we still run the underlying command,
 // except an SSH transport failure, which is surfaced as a plan error.
-type ToggleProbe func(ctx ToggleContext) (enabled bool, err error)
+//
+// The Go context comes first, as everywhere else; tc is the toggle's own
+// addressing context.
+type ToggleProbe func(ctx context.Context, tc ToggleContext) (enabled bool, err error)
 
 // planToggle is the shared Plan() implementation for toggle tasks. The
 // probe reports whether the underlying plugin is currently in the
@@ -54,13 +58,13 @@ type ToggleProbe func(ctx ToggleContext) (enabled bool, err error)
 // underlying enable/disable command. An SSH transport failure short-
 // circuits to a plan error so an unreachable host is not mistaken for
 // drift.
-func planToggle(state State, app string, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
-	ctx := ToggleContext{App: app}
+func planToggle(ctx context.Context, state State, app string, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
+	tc := ToggleContext{App: app}
 
 	return DispatchPlan(state, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			if probe != nil {
-				enabled, err := probe(ctx)
+				enabled, err := probe(ctx, tc)
 				if err != nil {
 					var sshErr *subprocess.SSHError
 					if errors.As(err, &sshErr) {
@@ -77,13 +81,13 @@ func planToggle(state State, app string, enableCmd, disableCmd string, probe Tog
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("would run %s on %s", enableCmd, app),
 				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, app)},
-				Commands:  resolveCommands(inputs),
+				Commands:  resolveCommands(ctx, inputs),
 				apply:     applyToggle(enableCmd, app, StatePresent),
 			}
 		},
 		StateAbsent: func() PlanResult {
 			if probe != nil {
-				enabled, err := probe(ctx)
+				enabled, err := probe(ctx, tc)
 				if err != nil {
 					var sshErr *subprocess.SSHError
 					if errors.As(err, &sshErr) {
@@ -100,7 +104,7 @@ func planToggle(state State, app string, enableCmd, disableCmd string, probe Tog
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("would run %s on %s", disableCmd, app),
 				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, app)},
-				Commands:  resolveCommands(inputs),
+				Commands:  resolveCommands(ctx, inputs),
 				apply:     applyToggle(disableCmd, app, StateAbsent),
 			}
 		},
@@ -118,9 +122,9 @@ func toggleInputs(subcommand, target string) []subprocess.ExecCommandInput {
 // reports the resulting state. The original initial state matches finalState
 // (preserved from the pre-refactor behavior), so on error the reported State
 // remains finalState.
-func applyToggle(subcommand, target string, finalState State) func() TaskOutputState {
+func applyToggle(subcommand, target string, finalState State) func(ctx context.Context) TaskOutputState {
 	inputs := toggleInputs(subcommand, target)
-	return func() TaskOutputState {
-		return runExecInputs(TaskOutputState{State: finalState}, finalState, inputs)
+	return func(ctx context.Context) TaskOutputState {
+		return runExecInputs(ctx, TaskOutputState{State: finalState}, finalState, inputs)
 	}
 }

--- a/tasks/toggle_test.go
+++ b/tasks/toggle_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,10 +18,10 @@ func TestPlanToggleSurfacesSSHTransportError(t *testing.T) {
 		Host:   "dokku@unreachable",
 		Stderr: "ssh: connect to host unreachable port 22: Connection refused",
 	}
-	probe := func(ToggleContext) (bool, error) { return false, sshErr }
+	probe := func(context.Context, ToggleContext) (bool, error) { return false, sshErr }
 
 	for _, state := range []State{StatePresent, StateAbsent} {
-		plan := planToggle(state, "web", "checks:enable", "checks:disable", probe)
+		plan := planToggle(testCtx(), state, "web", "checks:enable", "checks:disable", probe)
 		if plan.Status != PlanStatusError {
 			t.Errorf("state %s: Status = %q, want %q", state, plan.Status, PlanStatusError)
 		}
@@ -38,7 +39,7 @@ func TestPlanToggleSurfacesSSHTransportError(t *testing.T) {
 // "nil/failed probe = drift, must mutate" behavior for non-transport errors
 // (e.g. a plugin that does not support the report command).
 func TestPlanToggleTreatsNonSSHProbeErrorAsDrift(t *testing.T) {
-	probe := func(ToggleContext) (bool, error) { return false, fmt.Errorf("dokku: no such app") }
+	probe := func(context.Context, ToggleContext) (bool, error) { return false, fmt.Errorf("dokku: no such app") }
 
 	for _, tc := range []struct {
 		state State
@@ -47,7 +48,7 @@ func TestPlanToggleTreatsNonSSHProbeErrorAsDrift(t *testing.T) {
 		{StatePresent, "checks:enable"},
 		{StateAbsent, "checks:disable"},
 	} {
-		plan := planToggle(tc.state, "web", "checks:enable", "checks:disable", probe)
+		plan := planToggle(testCtx(), tc.state, "web", "checks:enable", "checks:disable", probe)
 		if plan.Error != nil {
 			t.Errorf("state %s: non-SSH probe error should not surface as a plan error, got %v", tc.state, plan.Error)
 		}
@@ -66,8 +67,8 @@ func TestPlanToggleTreatsNonSSHProbeErrorAsDrift(t *testing.T) {
 // TestPlanTogglePresentInSyncWhenEnabled covers the happy path: present desired
 // and the probe reports enabled means no change.
 func TestPlanTogglePresentInSyncWhenEnabled(t *testing.T) {
-	probe := func(ToggleContext) (bool, error) { return true, nil }
-	plan := planToggle(StatePresent, "web", "checks:enable", "checks:disable", probe)
+	probe := func(context.Context, ToggleContext) (bool, error) { return true, nil }
+	plan := planToggle(testCtx(), StatePresent, "web", "checks:enable", "checks:disable", probe)
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Errorf("present+enabled: InSync=%v Status=%q, want InSync=true Status=%q", plan.InSync, plan.Status, PlanStatusOK)
 	}
@@ -76,8 +77,8 @@ func TestPlanTogglePresentInSyncWhenEnabled(t *testing.T) {
 // TestPlanToggleAbsentInSyncWhenDisabled covers the happy path: absent desired
 // and the probe reports disabled means no change.
 func TestPlanToggleAbsentInSyncWhenDisabled(t *testing.T) {
-	probe := func(ToggleContext) (bool, error) { return false, nil }
-	plan := planToggle(StateAbsent, "web", "checks:enable", "checks:disable", probe)
+	probe := func(context.Context, ToggleContext) (bool, error) { return false, nil }
+	plan := planToggle(testCtx(), StateAbsent, "web", "checks:enable", "checks:disable", probe)
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Errorf("absent+disabled: InSync=%v Status=%q, want InSync=true Status=%q", plan.InSync, plan.Status, PlanStatusOK)
 	}
@@ -86,8 +87,8 @@ func TestPlanToggleAbsentInSyncWhenDisabled(t *testing.T) {
 // TestPlanTogglePresentDriftTargetsApp locks the #322 fix: with the global
 // machinery removed, a drift always targets the app and never a --global scope.
 func TestPlanTogglePresentDriftTargetsApp(t *testing.T) {
-	probe := func(ToggleContext) (bool, error) { return false, nil }
-	plan := planToggle(StatePresent, "web", "checks:enable", "checks:disable", probe)
+	probe := func(context.Context, ToggleContext) (bool, error) { return false, nil }
+	plan := planToggle(testCtx(), StatePresent, "web", "checks:enable", "checks:disable", probe)
 	if plan.InSync {
 		t.Fatal("expected drift when probe reports disabled and present is desired")
 	}

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "context"
+
 // TraefikPropertyTask manages the traefik configuration for a given dokku application
 type TraefikPropertyTask PropertyFields
 
@@ -63,8 +65,8 @@ func (t TraefikPropertyTask) Examples() ([]Doc, error) {
 }
 
 // Execute sets or unsets the traefik property
-func (t TraefikPropertyTask) Execute() TaskOutputState {
-	return ExecutePlan(t.Plan())
+func (t TraefikPropertyTask) Execute(ctx context.Context) TaskOutputState {
+	return ExecutePlan(ctx, t.Plan(ctx))
 }
 
 // traefikPropertyTable maps traefik property names to the JSON keys emitted
@@ -103,20 +105,20 @@ func (t TraefikPropertyTask) Validate() error {
 }
 
 // Plan reports the drift the TraefikPropertyTask would produce.
-func (t TraefikPropertyTask) Plan() PlanResult {
-	return planProperty(t, t.State, t.App, t.Global, t.Property, t.Value)
+func (t TraefikPropertyTask) Plan(ctx context.Context) PlanResult {
+	return planProperty(ctx, t, t.State, t.App, t.Global, t.Property, t.Value)
 }
 
 // ExportApp reconstructs the app's explicitly-set properties.
-func (t TraefikPropertyTask) ExportApp(app string) ([]interface{}, error) {
-	return exportProperties(t, app, func(app, property, value string) interface{} {
+func (t TraefikPropertyTask) ExportApp(ctx context.Context, app string) ([]interface{}, error) {
+	return exportProperties(ctx, t, app, func(app, property, value string) interface{} {
 		return TraefikPropertyTask{App: app, Property: property, Value: value}
 	})
 }
 
 // ExportGlobal reconstructs the globally-set properties.
-func (t TraefikPropertyTask) ExportGlobal() ([]interface{}, error) {
-	return exportGlobalProperties(t, func(property, value string) interface{} {
+func (t TraefikPropertyTask) ExportGlobal(ctx context.Context) ([]interface{}, error) {
+	return exportGlobalProperties(ctx, t, func(property, value string) interface{} {
 		return TraefikPropertyTask{Global: true, Property: property, Value: value}
 	})
 }

--- a/tasks/traefik_property_task_integration_test.go
+++ b/tasks/traefik_property_task_integration_test.go
@@ -31,7 +31,7 @@ func TestIntegrationTraefikPropertyAll(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.property+"/global", func(t *testing.T) {
 			unsetTask := TraefikPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
-			defer unsetTask.Execute()
+			defer unsetTask.Execute(testCtx())
 			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
 				label:     "traefik global " + tc.property,
 				setTask:   TraefikPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},
@@ -44,11 +44,11 @@ func TestIntegrationTraefikPropertyAll(t *testing.T) {
 	// isDynamicProperty fallback path.
 	t.Run("dns-provider-CLOUDFLARE_API_TOKEN/dynamic", func(t *testing.T) {
 		set := TraefikPropertyTask{Global: true, Property: "dns-provider-CLOUDFLARE_API_TOKEN", Value: "token123", State: StatePresent}
-		if r := set.Execute(); r.Error != nil {
+		if r := set.Execute(testCtx()); r.Error != nil {
 			t.Fatalf("set dynamic dns-provider key: %v", r.Error)
 		}
 		unset := TraefikPropertyTask{Global: true, Property: "dns-provider-CLOUDFLARE_API_TOKEN", State: StateAbsent}
-		if r := unset.Execute(); r.Error != nil {
+		if r := unset.Execute(testCtx()); r.Error != nil {
 			t.Fatalf("unset dynamic dns-provider key: %v", r.Error)
 		}
 	})

--- a/tasks/traefik_property_task_test.go
+++ b/tasks/traefik_property_task_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTraefikPropertyTaskInvalidState(t *testing.T) {
 	task := TraefikPropertyTask{Global: true, Property: "letsencrypt-email", State: "invalid"}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
@@ -15,7 +15,7 @@ func TestTraefikPropertyTaskInvalidState(t *testing.T) {
 
 func TestTraefikPropertyTaskMissingApp(t *testing.T) {
 	task := TraefikPropertyTask{Property: "letsencrypt-email", Value: "admin@example.com", State: StatePresent}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("Execute without app and global=false should return an error")
 	}
@@ -29,7 +29,7 @@ func TestTraefikPropertyTaskGlobalWithAppSet(t *testing.T) {
 		Value:    "admin@example.com",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when both global and app are set")
 	}
@@ -45,7 +45,7 @@ func TestTraefikPropertyTaskPresentWithoutValue(t *testing.T) {
 		Value:    "",
 		State:    StatePresent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when present state has no value")
 	}
@@ -61,7 +61,7 @@ func TestTraefikPropertyTaskAbsentWithValue(t *testing.T) {
 		Value:    "admin@example.com",
 		State:    StateAbsent,
 	}
-	result := task.Execute()
+	result := task.Execute(testCtx())
 	if result.Error == nil {
 		t.Fatal("expected error when absent state has a value")
 	}

--- a/tests/bats/cancel.bats
+++ b/tests/bats/cancel.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# HANG_HOST is an RFC 5737 documentation address, guaranteed never to be routed
+# to a real machine. An `ssh` to it blocks in the TCP handshake, which is the
+# shape of hang docket cannot detect on its own and the operator ends by
+# pressing Ctrl-C.
+HANG_HOST="192.0.2.1"
+
+# require_hanging_host skips unless connecting to HANG_HOST really does hang.
+# On a network that answers "no route to host" the ssh child exits at once,
+# apply fails on its own, and there is nothing left for an interrupt to
+# demonstrate.
+require_hanging_host() {
+  if [ "$(uname -s)" != "Linux" ]; then
+    skip "interrupt tests run on Linux only"
+  fi
+  if ! command -v timeout >/dev/null 2>&1; then
+    skip "timeout(1) not available"
+  fi
+  if ! command -v ssh >/dev/null 2>&1; then
+    skip "ssh client not available"
+  fi
+  local rc=0
+  timeout 3 ssh -o BatchMode=yes -o StrictHostKeyChecking=no "$HANG_HOST" true >/dev/null 2>&1 || rc=$?
+  # 124 is timeout(1) reporting it had to stop a process that was still running.
+  if [ "$rc" -ne 124 ]; then
+    skip "connecting to $HANG_HOST does not hang on this network"
+  fi
+}
+
+setup() {
+  require_hanging_host
+  docket_build
+  # Two plays, not two tasks in one: an error already ends the play it happened
+  # in, so a second task in the same play would prove nothing. A second *play*
+  # is what a run that only cancelled the task in flight would go on to start -
+  # hanging on its own SSH handshake until timeout escalated to SIGKILL.
+  write_tasks_file <<EOF
+---
+- name: one
+  tasks:
+    - name: first
+      dokku_app:
+        app: docket-test-cancel-one
+- name: two
+  tasks:
+    - name: second
+      dokku_app:
+        app: docket-test-cancel-two
+EOF
+}
+
+@test "SIGINT aborts the whole apply, not just the task in flight" {
+  # The first task blocks in the SSH handshake. SIGINT arrives two seconds in;
+  # SIGKILL follows eight seconds after that if docket ignored it. Cancelling
+  # the run context ends the run, so docket exits on the interrupt and the
+  # second play never opens a connection of its own - which used to take one
+  # Ctrl-C per remaining play.
+  #
+  # --preserve-status is what makes the status meaningful: without it timeout
+  # reports 124 whenever its timer fired, however the command then behaved.
+  # With it, 1 is docket choosing its own exit code and 137 is timeout having
+  # to SIGKILL a process that ignored the interrupt.
+  run timeout --preserve-status --kill-after=8 --signal=INT 2 \
+    env DOKKU_HOST="$HANG_HOST" "$(docket_bin)" apply --tasks "$TASKS_FILE"
+
+  assert_output --partial "run cancelled"
+  [ "$status" -eq 1 ]
+  refute_output --partial "second"
+}
+
+@test "SIGINT aborts the whole plan" {
+  run timeout --preserve-status --kill-after=8 --signal=INT 2 \
+    env DOKKU_HOST="$HANG_HOST" "$(docket_bin)" plan --tasks "$TASKS_FILE"
+
+  assert_output --partial "run cancelled"
+  [ "$status" -eq 1 ]
+  refute_output --partial "second"
+}


### PR DESCRIPTION
A task had no way to be cancelled. `Plan()` and `Execute()` took no arguments, so every task bottomed out in a `context.Background()` manufactured inside `subprocess`, and a long `git:sync`, a slow `letsencrypt:enable`, or an SSH connection that hung after the TCP handshake ran to completion no matter what the caller wanted. Both methods now take a context, as do the shared plan helpers, the `apply` closure on `PlanResult`, and the exporters. The closure takes one rather than capturing the one `Plan()` ran under, since `ExecutePlan` invokes it separately and should hand it the caller's current context. `DispatchPlan` keeps its argument-free branch signature and the branches capture the context lexically.

The signal handler moves with it. Every subprocess call used to register its own handler with `signal.Notify` and never call `signal.Stop`, leaking a goroutine, a channel registration and a derived context per dokku command, and cancelling only the child in flight - so an interrupt aborted one task and the run marched on to the next. One `signal.NotifyContext` in `main.go` now cancels the run context instead: `apply` and `plan` stop at the next task, report `run cancelled`, and exit 1 rather than the `--detailed-exitcode` code for "completed with changes". A second interrupt kills the process, which was previously impossible.

Nothing about the transport changes. The host, sudo setting and host-key policy still come from the package globals; making those per-invocation is #423, which this makes possible.

Refs #424.
