### PR TITLE
feat: make the target host per-invocation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
           go-version-file: go.mod
       - name: run unit tests
         run: go test -v -count=1 . ./commands/ ./tasks/ ./subprocess/ ./generate/
+      # The concurrency tests around the per-invocation target assert that two
+      # runs in one process do not interfere, which only means something with
+      # the detector on.
+      - name: run unit tests under the race detector
+        run: go test -race -count=1 . ./commands/ ./tasks/ ./subprocess/ ./generate/
 
   integration-test:
     name: integration-test

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,10 @@ docs:
 test:
 	go test -v -count=1 . ./commands/ ./tasks/ ./subprocess/ ./generate/
 
+.PHONY: test-race
+test-race:
+	go test -race -count=1 . ./commands/ ./tasks/ ./subprocess/ ./generate/
+
 .PHONY: test-integration
 test-integration:
 	go test -v -count=1 -timeout 20m -run TestIntegration ./tasks/

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -97,7 +97,7 @@ func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line. Values from inputs declared `sensitive: true` and from task struct fields tagged `sensitive:\"true\"` are masked as `***`. Ignored when --json is set; the JSON output already includes the resolved commands.")
 	f.BoolVar(&c.json, "json", false, "emit one JSON-lines event per play/task/summary instead of human-readable output. Schema is keyed by `version: 1`; sensitive values mask to `***`.")
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
-	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
+	f.BoolVar(&c.sudo, "sudo", false, "run dokku as root via `sudo -n` - remotely with --host, locally without. Covers dokku only, not the local helper commands some tasks run. Equivalent to DOKKU_SUDO=1.")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
 	f.StringSliceVar(&c.tags, "tags", nil, "comma-separated tag list; only tasks whose `tags:` set intersects this list run")
 	f.StringSliceVar(&c.skipTags, "skip-tags", nil, "comma-separated tag list; tasks whose `tags:` set intersects this list are skipped")
@@ -191,7 +191,11 @@ func (c *ApplyCommand) Run(args []string) int {
 	}
 
 	ctx := runContext(c.Ctx)
-	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
+	// The target rides on the run context, so every task planned or executed
+	// below routes to the same server without any of them holding a reference
+	// to it - and a second run in the same process can carry a different one.
+	target := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
+	ctx = subprocess.ContextWithTarget(ctx, target)
 
 	formatOverride, err := parseRecipeFormatFlag("--tasks-format", c.tasksFormatFlag)
 	if err != nil {
@@ -291,8 +295,8 @@ func (c *ApplyCommand) Run(args []string) int {
 		})
 	}
 
-	if resolvedHost != "" {
-		defer subprocess.CloseSshControlMaster(resolvedHost)
+	if target.Host != "" {
+		defer subprocess.CloseSshControlMaster(target.Host)
 	}
 
 	emitter := c.newEmitter()
@@ -345,7 +349,7 @@ playLoop:
 			}
 		}
 
-		emitter.PlayStart(play.Name, resolvedHost)
+		emitter.PlayStart(play.Name, target.Host)
 
 		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(inputCtx, play.Inputs, userSet))
 

--- a/commands/export.go
+++ b/commands/export.go
@@ -101,7 +101,7 @@ func (c *ExportCommand) FlagSet() *flag.FlagSet {
 	f.StringArrayVar(&c.apps, "app", nil, "restrict the export to the named app (repeatable)")
 	f.StringArrayVar(&c.resources, "resource", nil, "restrict the export to the named resource address, e.g. 'dokku_config[app=my-app]' (repeatable); a bare task type exports every resource of that type")
 	f.StringVar(&c.host, "host", "", "remote [user@]host[:port] to read over SSH; overrides DOKKU_HOST")
-	f.BoolVar(&c.sudo, "sudo", false, "wrap the remote dokku call in sudo -n")
+	f.BoolVar(&c.sudo, "sudo", false, "run dokku as root via sudo -n, remotely with --host and locally without")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "trust an unknown SSH host key on first connect")
 	return f
 }
@@ -189,9 +189,13 @@ func (c *ExportCommand) Run(args []string) int {
 	}
 
 	ctx := runContext(c.Ctx)
-	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
-	if resolvedHost != "" {
-		defer subprocess.CloseSshControlMaster(resolvedHost)
+	// The target rides on the run context, so every exporter reads the same
+	// server without any of them holding a reference to it - and a second
+	// export in the same process can read a different one.
+	target := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
+	ctx = subprocess.ContextWithTarget(ctx, target)
+	if target.Host != "" {
+		defer subprocess.CloseSshControlMaster(target.Host)
 	}
 
 	toStdout := c.output == taskFileStdin

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -95,7 +95,7 @@ func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f.BoolVar(&c.json, "json", false, "emit one JSON-lines event per play/task/summary instead of human-readable output. Schema is keyed by `version: 1`; sensitive values mask to `***`.")
 	f.BoolVar(&c.detailedExitCode, "detailed-exitcode", false, "exit 0 when no drift is detected, 2 when drift is detected, 1 on error. Without this flag plan exits 0 regardless of drift.")
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
-	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
+	f.BoolVar(&c.sudo, "sudo", false, "run dokku as root via `sudo -n` - remotely with --host, locally without. Covers dokku only, not the local helper commands some tasks run. Equivalent to DOKKU_SUDO=1.")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
 	f.StringSliceVar(&c.tags, "tags", nil, "comma-separated tag list; only tasks whose `tags:` set intersects this list are planned")
 	f.StringSliceVar(&c.skipTags, "skip-tags", nil, "comma-separated tag list; tasks whose `tags:` set intersects this list are skipped")
@@ -181,7 +181,11 @@ func (c *PlanCommand) Run(args []string) int {
 	}
 
 	ctx := runContext(c.Ctx)
-	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
+	// The target rides on the run context, so every task planned or executed
+	// below routes to the same server without any of them holding a reference
+	// to it - and a second run in the same process can carry a different one.
+	target := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
+	ctx = subprocess.ContextWithTarget(ctx, target)
 
 	formatOverride, err := parseRecipeFormatFlag("--tasks-format", c.tasksFormatFlag)
 	if err != nil {
@@ -269,8 +273,8 @@ func (c *PlanCommand) Run(args []string) int {
 		})
 	}
 
-	if resolvedHost != "" {
-		defer subprocess.CloseSshControlMaster(resolvedHost)
+	if target.Host != "" {
+		defer subprocess.CloseSshControlMaster(target.Host)
 	}
 
 	emitter := c.newEmitter()
@@ -315,7 +319,7 @@ playLoop:
 			}
 		}
 
-		emitter.PlayStart(play.Name, resolvedHost)
+		emitter.PlayStart(play.Name, target.Host)
 
 		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(inputCtx, play.Inputs, userSet))
 

--- a/commands/ssh_flags.go
+++ b/commands/ssh_flags.go
@@ -7,32 +7,37 @@ import (
 	"github.com/dokku/docket/subprocess"
 )
 
-// resolveSshFlags merges the apply/plan SSH-related CLI flags with their
-// env-var counterparts and applies the result to package state for the
-// rest of the run:
+// resolveSshFlags merges the SSH-related CLI flags with their env-var
+// counterparts and returns the target for this run. Each setting takes the
+// flag when it is set and the environment otherwise:
 //
-//   - --host wins over DOKKU_HOST; the resolved value is stored on the
-//     subprocess package via SetDefaultHost so the dispatcher can read
-//     it from ExecCommandInput.Host without consulting the environment.
-//   - --sudo and --accept-new-host-keys are bridged to the env vars
-//     subprocess/ssh.go reads at argv-build time (DOKKU_SUDO,
-//     DOKKU_SSH_ACCEPT_NEW_HOST_KEYS).
+//   - --host over DOKKU_HOST
+//   - --sudo over DOKKU_SUDO=1
+//   - --accept-new-host-keys over DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1
 //
-// Returns the resolved host so callers can use it for play-header
-// rendering and ControlMaster teardown without re-reading env state.
-func resolveSshFlags(hostFlag string, sudo, acceptNewHostKeys bool) string {
-	host := hostFlag
-	if host == "" {
-		host = os.Getenv("DOKKU_HOST")
+// The caller puts the result on the run context with
+// subprocess.ContextWithTarget, and every dokku invocation under that context
+// reads it from there. Nothing is written to package state or to the process
+// environment: --sudo and --accept-new-host-keys used to be bridged through
+// os.Setenv so the SSH argv builder could read them back, which made them
+// sticky for the life of the process and impossible to vary per call.
+func resolveSshFlags(hostFlag string, sudo, acceptNewHostKeys bool) subprocess.Target {
+	return subprocess.Target{
+		Host:              firstNonEmpty(hostFlag, os.Getenv("DOKKU_HOST")),
+		Sudo:              sudo || os.Getenv("DOKKU_SUDO") == "1",
+		AcceptNewHostKeys: acceptNewHostKeys || os.Getenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS") == "1",
 	}
-	subprocess.SetDefaultHost(host)
-	if sudo {
-		_ = os.Setenv("DOKKU_SUDO", "1")
+}
+
+// firstNonEmpty returns the first of its arguments that is not the empty
+// string, which is how a flag beats the env var it shadows.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
 	}
-	if acceptNewHostKeys {
-		_ = os.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "1")
-	}
-	return host
+	return ""
 }
 
 // runContext returns the context every task in this run is planned and

--- a/commands/ssh_flags_test.go
+++ b/commands/ssh_flags_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"os"
+	"testing"
+)
+
+// clearSshEnv removes the three env vars resolveSshFlags reads so a test
+// starts from a known state whatever the developer's shell exports.
+func clearSshEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"DOKKU_HOST", "DOKKU_SUDO", "DOKKU_SSH_ACCEPT_NEW_HOST_KEYS"} {
+		t.Setenv(name, "")
+		os.Unsetenv(name)
+	}
+}
+
+func TestResolveSshFlagsDefaultsToLocal(t *testing.T) {
+	clearSshEnv(t)
+
+	got := resolveSshFlags("", false, false)
+	if got.Host != "" || got.Sudo || got.AcceptNewHostKeys {
+		t.Errorf("resolveSshFlags = %+v, want the zero Target", got)
+	}
+}
+
+// TestResolveSshFlagsReadsTheEnvironment pins that the three env vars work on
+// their own, with no flag. They are documented equivalents of the flags, and
+// they used to work by a different route: the SSH argv builder read
+// DOKKU_SUDO and DOKKU_SSH_ACCEPT_NEW_HOST_KEYS directly out of the process
+// environment. Now that resolveSshFlags is the only reader, forgetting one
+// here is how they would silently stop working.
+func TestResolveSshFlagsReadsTheEnvironment(t *testing.T) {
+	clearSshEnv(t)
+	t.Setenv("DOKKU_HOST", "deploy@dokku.example.com")
+	t.Setenv("DOKKU_SUDO", "1")
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "1")
+
+	got := resolveSshFlags("", false, false)
+	if got.Host != "deploy@dokku.example.com" {
+		t.Errorf("Host = %q, want it read from DOKKU_HOST", got.Host)
+	}
+	if !got.Sudo {
+		t.Error("Sudo should be set by DOKKU_SUDO=1 with no --sudo flag")
+	}
+	if !got.AcceptNewHostKeys {
+		t.Error("AcceptNewHostKeys should be set by DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1 with no flag")
+	}
+}
+
+// TestResolveSshFlagsOnlyHonorsTheDocumentedEnvValue pins that the two boolean
+// env vars mean "1", not "any value". `DOKKU_SUDO=0` reads as off.
+func TestResolveSshFlagsOnlyHonorsTheDocumentedEnvValue(t *testing.T) {
+	clearSshEnv(t)
+	t.Setenv("DOKKU_SUDO", "0")
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "false")
+
+	got := resolveSshFlags("", false, false)
+	if got.Sudo {
+		t.Error("DOKKU_SUDO=0 must not enable sudo")
+	}
+	if got.AcceptNewHostKeys {
+		t.Error("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=false must not enable accept-new")
+	}
+}
+
+func TestResolveSshFlagsFlagWinsOverEnv(t *testing.T) {
+	clearSshEnv(t)
+	t.Setenv("DOKKU_HOST", "from-env")
+
+	got := resolveSshFlags("from-flag", true, true)
+	if got.Host != "from-flag" {
+		t.Errorf("Host = %q, want --host to win over DOKKU_HOST", got.Host)
+	}
+	if !got.Sudo || !got.AcceptNewHostKeys {
+		t.Errorf("flags alone should set the booleans; got %+v", got)
+	}
+}
+
+// TestResolveSshFlagsDoesNotMutateProcessEnv is the lock on removing the
+// os.Setenv bridge. --sudo and --accept-new-host-keys used to be written into
+// the process environment so the SSH argv builder could read them back, which
+// meant one invocation's flags applied to every later one in the same process
+// - the concrete reason these settings could not be per-invocation.
+func TestResolveSshFlagsDoesNotMutateProcessEnv(t *testing.T) {
+	clearSshEnv(t)
+
+	resolveSshFlags("deploy@dokku.example.com", true, true)
+
+	for _, name := range []string{"DOKKU_HOST", "DOKKU_SUDO", "DOKKU_SSH_ACCEPT_NEW_HOST_KEYS"} {
+		if v, ok := os.LookupEnv(name); ok && v != "" {
+			t.Errorf("%s = %q; resolving flags must not write the process environment", name, v)
+		}
+	}
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -237,7 +237,7 @@ optimistically predicting `[+] create` for state it never actually read.
 | `--skip-tags <list>` | Skip tasks whose tags intersect the list. See [task envelope](task-envelope.md#tags). |
 | `--list-tasks` | Print the resolved plan and exit without contacting the server. See [inspecting and resuming](#inspecting-and-resuming). |
 | `--host <user@host:port>` | Plan against a remote server over SSH. Overrides `DOKKU_HOST`. See [remote execution](remote-execution.md). |
-| `--sudo` | Wrap the remote `dokku` call in `sudo -n`. See [remote execution](remote-execution.md). |
+| `--sudo` | Run `dokku` as root via `sudo -n`, remotely with `--host` and locally without. See [remote execution](remote-execution.md). |
 | `--accept-new-host-keys` | Trust an unknown SSH host key on first connect. See [remote execution](remote-execution.md). |
 
 ```bash
@@ -298,7 +298,7 @@ recipe cannot be loaded or a `when:` fails to evaluate, and `0` otherwise.
 | `--list-tasks` | Print the resolved plan and exit without running. See [inspecting and resuming](#inspecting-and-resuming). |
 | `--start-at-task <name>` | Skip every task before the named one, then run from there. See [inspecting and resuming](#inspecting-and-resuming). |
 | `--host <user@host:port>` | Apply against a remote server over SSH. Overrides `DOKKU_HOST`. See [remote execution](remote-execution.md). |
-| `--sudo` | Wrap the remote `dokku` call in `sudo -n`. See [remote execution](remote-execution.md). |
+| `--sudo` | Run `dokku` as root via `sudo -n`, remotely with `--host` and locally without. See [remote execution](remote-execution.md). |
 | `--accept-new-host-keys` | Trust an unknown SSH host key on first connect. See [remote execution](remote-execution.md). |
 
 A multi-command task renders one continuation line per invocation under `--verbose`:
@@ -525,7 +525,7 @@ matches nothing on the server is reported by name and exits non-zero, the same w
 | `--app <name>` | Restrict the export to the named app. Repeatable. |
 | `--resource <address>` | Restrict the export to a [resource address](task-envelope.md#names-and-resource-addresses), e.g. `dokku_config[app=api]`. A bare task type takes every resource of that type. Repeatable; not valid with `--app`. See [exporting one resource](#exporting-one-resource). |
 | `--host <user@host:port>` | Read a remote server over SSH. Overrides `DOKKU_HOST`. See [remote execution](remote-execution.md). |
-| `--sudo` | Wrap the remote `dokku` call in `sudo -n`. |
+| `--sudo` | Run `dokku` as root via `sudo -n`, remotely with `--host` and locally without. |
 | `--accept-new-host-keys` | Trust an unknown SSH host key on first connect. |
 
 The output format follows `--format` when given, otherwise the `--output` extension (`.json` /

--- a/docs/remote-execution.md
+++ b/docs/remote-execution.md
@@ -23,8 +23,13 @@ You do not need to teach docket about any of it.
 | Flag | Effect |
 |------|--------|
 | `--host <user@host:port>` | The remote host to ssh into. Overrides `DOKKU_HOST`. |
-| `--sudo` | Wrap the remote `dokku` call in `sudo -n` (passwordless sudo only). Equivalent to `DOKKU_SUDO=1`. |
+| `--sudo` | Run `dokku` as root, with passwordless sudo only. Equivalent to `DOKKU_SUDO=1`. |
 | `--accept-new-host-keys` | Pass `-o StrictHostKeyChecking=accept-new` so SSH trusts an unknown host on first connect. Equivalent to `DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1`. |
+
+`--sudo` works on both sides of the transport: with `--host` it wraps the remote invocation in
+`sudo -n`, and without one it runs the local `dokku` under `sudo -n -u root`. Either way it covers
+`dokku` alone - the `docker` and `curl` calls a few tasks make locally are docket's own plumbing and
+are never elevated. `-n` never prompts, so the account has to have passwordless sudo already.
 
 `--accept-new-host-keys` is convenient in CI, where seeding `known_hosts` ahead of time is awkward,
 but it gives up man-in-the-middle protection on the first connection. When you can, prefer seeding

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 
 	execute "github.com/alexellis/go-execute/v2"
 	"github.com/fatih/color"
@@ -38,16 +39,6 @@ type ExecCommandInput struct {
 
 	// StderrWriter is the writer to write stderr to
 	StderrWriter io.Writer
-
-	// Sudo runs the command with sudo -n -u root
-	Sudo bool
-
-	// Host, when non-empty, routes the command through an `ssh` subprocess
-	// against [user@]host[:port] instead of executing locally. Only used
-	// when Command is "dokku"; non-dokku commands always run locally
-	// (the remote side may not have those binaries). When empty, the
-	// dispatcher consults the package default set by SetDefaultHost.
-	Host string
 }
 
 // ExecError wraps a CallExecCommand failure with the underlying
@@ -136,29 +127,24 @@ func (ecr ExecCommandResponse) StdoutBytes() []byte {
 }
 
 // ResolveCommandString returns the masked command line ExecCommandResponse.Command
-// would carry if input were executed now. Used by tasks' Plan() methods so
-// PlanResult.Commands renders byte-identical to the strings apply emits via
+// would carry if input were executed under ctx now. Used by tasks' Plan() methods
+// so PlanResult.Commands renders byte-identical to the strings apply emits via
 // state.Commands; sharing the rendering logic keeps the two views from drifting.
 //
-// The function mirrors the dispatch in CallExecCommand and CallSshCommand:
-// when the (possibly defaulted) Host is set and the command is `dokku`, the
-// SSH transport's bare `cmd args` form is returned because remote sudo is
-// wrapped server-side via DOKKU_SUDO and never appears in the displayed
-// command. Otherwise the local path's sudo-wrap-when-true form is returned.
-//
-// ctx is not read yet. It is here because this function has to mirror that
-// dispatch, and the dispatch is what reads the per-invocation target once
-// #423 moves it off the package global.
+// The function mirrors the dispatch in defaultExecRunner, and reads the target
+// from the same place, so plan and apply cannot disagree about where a command
+// was going. When the target names a host and the command is `dokku`, the SSH
+// transport's bare `cmd args` form is returned: remote sudo is wrapped
+// server-side and never appears in the displayed command. Otherwise the local
+// form is returned, sudo-wrapped when the target asks for it.
 func ResolveCommandString(ctx context.Context, input ExecCommandInput) string {
-	if input.Host == "" {
-		input.Host = GetDefaultHost()
-	}
-	if input.Host != "" && input.Command == "dokku" {
+	target := TargetFromContext(ctx)
+	if target.Host != "" && input.Command == "dokku" {
 		return resolveSshCommandString(input.Command, input.Args)
 	}
 	cmd := input.Command
 	args := input.Args
-	if input.Sudo {
+	if target.Sudo && input.Command == "dokku" {
 		args = append([]string{"-n", "-u", "root", cmd}, args...)
 		cmd = "sudo"
 	}
@@ -183,33 +169,85 @@ func resolveSshCommandString(command string, args []string) string {
 	return MaskString(command + " " + strings.Join(args, " "))
 }
 
-// execRunner is the executor CallExecCommand delegates to. It defaults to
-// defaultExecRunner (the real implementation) and can be swapped in tests via
-// SetExecRunner so unit tests return canned responses without spawning a
-// process or contacting a server. Production code must never reassign it.
-//
-// The swap mutates package state and is therefore test-only and not safe under
-// t.Parallel().
-var execRunner = defaultExecRunner
+// ExecRunner is the shape of the executor CallExecCommand delegates to. A test
+// supplies one to return canned responses without spawning a process or
+// contacting a server.
+type ExecRunner func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error)
 
-// SetExecRunner swaps the executor and returns a function that restores the
-// previous one. Intended for tests:
+// runnerKey is the context key a per-invocation ExecRunner is stored under.
+type runnerKey struct{}
+
+// ContextWithRunner returns a copy of ctx whose dokku commands go to fn
+// instead of to a real process. It is the per-invocation form of
+// SetExecRunner: because the executor travels on the context rather than in a
+// package variable, two tests can install different fakes at the same time and
+// so can call t.Parallel().
 //
-//	defer subprocess.SetExecRunner(fake)()
-func SetExecRunner(fn func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error)) func() {
-	prev := execRunner
-	execRunner = fn
-	return func() { execRunner = prev }
+// Production code must not use it. The seam exists so a test can drive a task
+// without a server; a caller that wants to change where commands actually run
+// sets a Target.
+func ContextWithRunner(ctx context.Context, fn ExecRunner) context.Context {
+	return context.WithValue(ctx, runnerKey{}, fn)
 }
 
-// CallExecCommand executes a command on the local host under ctx.
+// runnerFromContext returns the executor for this call: the context's, when it
+// carries one, else the package-level fallback.
+func runnerFromContext(ctx context.Context) ExecRunner {
+	if ctx != nil {
+		if fn, ok := ctx.Value(runnerKey{}).(ExecRunner); ok && fn != nil {
+			return fn
+		}
+	}
+	return globalExecRunner()
+}
+
+// execRunner is the package-level fallback for calls whose context carries no
+// runner. It defaults to defaultExecRunner (the real implementation) and can be
+// swapped in tests via SetExecRunner. Production code must never reassign it.
 //
-// When `input.Host` is set (or a default has been configured via
-// SetDefaultHost) and the command is `dokku`, dispatch is routed
-// through the SSH transport so the dokku invocation runs on the remote
-// host. Non-dokku subprocesses (echo/git/etc.) always run locally even
-// when a host is configured, since the remote side may not have those
-// binaries (and tests expect local execution).
+// The mutex is not for correctness under normal use - production never writes
+// it - but so that a test which does write it cannot race a concurrent test
+// reading it, which is otherwise a data race the moment anything runs in
+// parallel. Prefer ContextWithRunner in new tests; this exists for the ones
+// written before the seam moved onto the context.
+var (
+	execRunnerMu sync.RWMutex
+	execRunner   ExecRunner = defaultExecRunner
+)
+
+func globalExecRunner() ExecRunner {
+	execRunnerMu.RLock()
+	defer execRunnerMu.RUnlock()
+	return execRunner
+}
+
+// SetExecRunner swaps the package-level executor and returns a function that
+// restores the previous one. Intended for tests:
+//
+//	defer subprocess.SetExecRunner(fake)()
+//
+// It replaces process-wide state, so a test using it still cannot call
+// t.Parallel(); ContextWithRunner is the form that can.
+func SetExecRunner(fn ExecRunner) func() {
+	execRunnerMu.Lock()
+	prev := execRunner
+	execRunner = fn
+	execRunnerMu.Unlock()
+	return func() {
+		execRunnerMu.Lock()
+		execRunner = prev
+		execRunnerMu.Unlock()
+	}
+}
+
+// CallExecCommand executes a command under ctx, locally or on the remote the
+// context's Target names.
+//
+// When that target names a host and the command is `dokku`, dispatch is routed
+// through the SSH transport so the dokku invocation runs on the remote host.
+// Non-dokku subprocesses (echo/git/etc.) always run locally even when a host is
+// configured, since the remote side may not have those binaries (and tests
+// expect local execution).
 //
 // The context is the caller's: cancelling it kills the child process, and a
 // deadline on it bounds the call. Nothing in this package installs a signal
@@ -217,20 +255,19 @@ func SetExecRunner(fn func(ctx context.Context, input ExecCommandInput) (ExecCom
 // signal.NotifyContext, so one interrupt aborts the run rather than the
 // current task.
 //
-// The call is routed through the swappable execRunner so tests can substitute a
-// fake executor; defaultExecRunner is the production path.
+// The call is routed through a swappable executor so tests can substitute a
+// fake; defaultExecRunner is the production path.
 func CallExecCommand(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-	return execRunner(ctx, input)
+	return runnerFromContext(ctx)(ctx, input)
 }
 
 // defaultExecRunner is the production executor: it runs the command locally, or
-// routes dokku commands through the SSH transport when a host is configured.
+// routes dokku commands through the SSH transport when the context's target
+// names a host.
 func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-	if input.Host == "" {
-		input.Host = GetDefaultHost()
-	}
-	if input.Host != "" && input.Command == "dokku" {
-		return CallSshCommand(ctx, input.Host, input)
+	target := TargetFromContext(ctx)
+	if target.Host != "" && input.Command == "dokku" {
+		return CallSshCommand(ctx, target, input)
 	}
 
 	// isatty reports whether our own stdout is a terminal, which is the
@@ -239,7 +276,11 @@ func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommand
 
 	command := input.Command
 	commandArgs := input.Args
-	if input.Sudo {
+	// Elevation is scoped to dokku for the same reason routing is: a task's
+	// local helper commands (docker, curl, tar) are docket's own plumbing, and
+	// requiring passwordless root for them because the operator asked for a
+	// sudo-wrapped dokku would be a surprise.
+	if target.Sudo && input.Command == "dokku" {
 		commandArgs = append([]string{"-n", "-u", "root", command}, commandArgs...)
 		command = "sudo"
 	}

--- a/subprocess/exec_test.go
+++ b/subprocess/exec_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestResolveCommandString(t *testing.T) {
 	t.Cleanup(func() { SetGlobalSensitive(nil) })
-	t.Cleanup(func() { SetDefaultHost("") })
 
 	tests := []struct {
 		name      string
+		target    Target
 		input     ExecCommandInput
 		sensitive []string
 		want      string
@@ -31,9 +31,16 @@ func TestResolveCommandString(t *testing.T) {
 			want:  "dokku --quiet apps:create api",
 		},
 		{
-			name:  "sudo wraps the command and args",
-			input: ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Sudo: true},
-			want:  "sudo -n -u root dokku apps:create api",
+			name:   "a sudo target wraps the local command and args",
+			target: Target{Sudo: true},
+			input:  ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}},
+			want:   "sudo -n -u root dokku apps:create api",
+		},
+		{
+			name:   "a sudo target leaves a non-dokku helper alone",
+			target: Target{Sudo: true},
+			input:  ExecCommandInput{Command: "docker", Args: []string{"image", "inspect", "api"}},
+			want:   "docker image inspect api",
 		},
 		{
 			name:      "sensitive values are masked",
@@ -42,34 +49,41 @@ func TestResolveCommandString(t *testing.T) {
 			want:      "dokku config:set api KEY=***",
 		},
 		{
-			name:  "ssh transport returns the bare form even with Sudo set",
-			input: ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Host: "alice@host", Sudo: true},
-			want:  "dokku apps:create api",
+			name:   "ssh transport returns the bare form even with sudo set",
+			target: Target{Host: "alice@host", Sudo: true},
+			input:  ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}},
+			want:   "dokku apps:create api",
 		},
 		{
-			name:  "non-dokku command runs locally even with Host set",
-			input: ExecCommandInput{Command: "echo", Args: []string{"hi"}, Host: "alice@host"},
-			want:  "echo hi",
+			name:   "non-dokku command runs locally even with a host set",
+			target: Target{Host: "alice@host"},
+			input:  ExecCommandInput{Command: "echo", Args: []string{"hi"}},
+			want:   "echo hi",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			SetGlobalSensitive(tc.sensitive)
 			t.Cleanup(func() { SetGlobalSensitive(nil) })
-			if got := ResolveCommandString(context.Background(), tc.input); got != tc.want {
+			ctx := ContextWithTarget(context.Background(), tc.target)
+			if got := ResolveCommandString(ctx, tc.input); got != tc.want {
 				t.Errorf("ResolveCommandString = %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestResolveCommandStringHonorsDefaultHost(t *testing.T) {
-	t.Cleanup(func() { SetDefaultHost("") })
-	SetDefaultHost("alice@host")
-	got := ResolveCommandString(context.Background(), ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Sudo: true})
-	want := "dokku apps:create api"
-	if got != want {
-		t.Errorf("ResolveCommandString with default host = %q, want %q", got, want)
+// TestResolveCommandStringWithoutATargetRunsLocally pins the zero value: a
+// context carrying no target renders the local form, which is what docket does
+// when neither --host nor DOKKU_HOST is set.
+func TestResolveCommandStringWithoutATargetRunsLocally(t *testing.T) {
+	t.Parallel()
+	got := ResolveCommandString(context.Background(), ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"apps:create", "api"},
+	})
+	if want := "dokku apps:create api"; got != want {
+		t.Errorf("ResolveCommandString = %q, want %q", got, want)
 	}
 }
 

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -32,6 +32,14 @@ var (
 // Callers (typically commands/apply.go and commands/plan.go) collect this set
 // from input values declared `sensitive: true` and from task struct fields
 // tagged `sensitive:"true"` before any subprocess runs, then defer a clear.
+// Note on scope: this registry is process-wide, and SetGlobalSensitive
+// *replaces* it, which is the one part of masking that does not survive two
+// runs sharing a process - the first run's deferred clear would blank the
+// second run's secrets while it is still writing output. AddGlobalSensitive
+// has no such problem. Masking stayed global when the target moved onto the
+// context because it is output rendering rather than routing: a shared
+// registry over-masks, which is fail-closed, and sensitiveMu already makes it
+// race-safe. Making it per-invocation is #501.
 func SetGlobalSensitive(values []string) {
 	cleaned := cleanSensitive(values)
 

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -1,10 +1,11 @@
 // Package subprocess SSH transport.
 //
-// When DOKKU_HOST is set, every dokku subprocess invocation is routed
-// through an `ssh` subprocess wrapper instead of executing locally. We
-// shell out to the user's `ssh` binary rather than using a Go SSH
-// library so we inherit the user's `~/.ssh/config`, `ProxyJump`, agent,
-// and known_hosts handling for free.
+// When the context's Target names a host - resolved by the commands layer from
+// --host or DOKKU_HOST - every dokku subprocess invocation is routed through an
+// `ssh` subprocess wrapper instead of executing locally. We shell out to the
+// user's `ssh` binary rather than using a Go SSH library so we inherit the
+// user's `~/.ssh/config`, `ProxyJump`, agent, and known_hosts handling for
+// free.
 //
 // All invocations in a single docket run share one TCP+SSH handshake
 // via OpenSSH ControlMaster multiplexing. The first `ssh` invocation
@@ -27,10 +28,11 @@
 // as the underlying error so the formatter renders it as a `dokku:`
 // failure.
 //
-// `input.Sudo` in `ExecCommandInput` means "wrap with local sudo" and
-// is meaningless when DOKKU_HOST is set. SSH dispatch ignores
-// `input.Sudo` and consults `DOKKU_SUDO=1` to decide whether to wrap
-// the *remote* dokku invocation in `sudo -n`.
+// Where a command runs, whether it is sudo-wrapped, and whether an unknown
+// host key is accepted all travel on the context as a `Target`. SSH dispatch
+// reads it the same way the local path does, so `--sudo` means "run dokku as
+// root" on both sides - remotely as `sudo -n` inside the ssh argv, locally as
+// `sudo -n -u root` around the child.
 package subprocess
 
 import (
@@ -167,24 +169,27 @@ func controlPath(host string, pid int) string {
 // shell (a non-printable byte such as a tab, newline, or null) yields an
 // error rather than a corrupted remote command.
 //
-// Reads two env vars at build time: DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1
-// adds `-o StrictHostKeyChecking=accept-new`; DOKKU_SUDO=1 wraps the
-// remote command in `sudo -n`.
-func buildSshArgv(target sshTarget, remote []string) ([]string, error) {
+// The sudo and host-key settings come from opts, the caller's per-invocation
+// Target. They used to be read from DOKKU_SUDO and
+// DOKKU_SSH_ACCEPT_NEW_HOST_KEYS here, which meant the commands layer had to
+// write them into the process environment to communicate them - and once
+// written, they applied to every invocation in the process for the rest of its
+// life.
+func buildSshArgv(parsed sshTarget, opts Target, remote []string) ([]string, error) {
 	argv := []string{
 		"-o", "ControlMaster=auto",
-		"-o", "ControlPath=" + controlPath(target.UserHost(), os.Getpid()),
+		"-o", "ControlPath=" + controlPath(parsed.UserHost(), os.Getpid()),
 		"-o", "ControlPersist=60",
 		"-o", "BatchMode=yes",
 	}
-	if os.Getenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS") == "1" {
+	if opts.AcceptNewHostKeys {
 		argv = append(argv, "-o", "StrictHostKeyChecking=accept-new")
 	}
-	if target.Port != "" && target.Port != "22" {
-		argv = append(argv, "-p", target.Port)
+	if parsed.Port != "" && parsed.Port != "22" {
+		argv = append(argv, "-p", parsed.Port)
 	}
-	argv = append(argv, target.UserHost(), "--")
-	if os.Getenv("DOKKU_SUDO") == "1" {
+	argv = append(argv, parsed.UserHost(), "--")
+	if opts.Sudo {
 		argv = append(argv, "sudo", "-n")
 	}
 	for _, arg := range remote {
@@ -202,16 +207,6 @@ func buildSshArgv(target sshTarget, remote []string) ([]string, error) {
 var (
 	sshLookPathOnce sync.Once
 	sshLookPathErr  error
-)
-
-// defaultHost is the package-level fallback used by CallExecCommand
-// when the per-call ExecCommandInput.Host is empty. The commands layer
-// (commands/apply.go and commands/plan.go) sets this once at start-of-
-// run from the resolved CLI flag / env var so tasks can keep building
-// transport-agnostic ExecCommandInput values.
-var (
-	defaultHostMu sync.RWMutex
-	defaultHost   string
 )
 
 // Probe runs input as a state probe and reports whether it matched
@@ -255,23 +250,6 @@ func Probe(ctx context.Context, input ExecCommandInput) (bool, error) {
 	return result.ExitCode == 0, nil
 }
 
-// SetDefaultHost registers the host that CallExecCommand
-// should use when ExecCommandInput.Host is empty. Pass an empty string
-// to clear the default. Mirrors the SetGlobalSensitive pattern.
-func SetDefaultHost(host string) {
-	defaultHostMu.Lock()
-	defer defaultHostMu.Unlock()
-	defaultHost = host
-}
-
-// GetDefaultHost returns the currently registered default host (or
-// empty string when none).
-func GetDefaultHost() string {
-	defaultHostMu.RLock()
-	defer defaultHostMu.RUnlock()
-	return defaultHost
-}
-
 func ensureSshAvailable() error {
 	sshLookPathOnce.Do(func() {
 		_, err := exec.LookPath("ssh")
@@ -282,22 +260,27 @@ func ensureSshAvailable() error {
 	return sshLookPathErr
 }
 
-// CallSshCommand executes a remote command over ssh against host under
-// ctx. The execution pipeline mirrors CallExecCommand (same DOKKU_TRACE
-// logging, masking, stdio wiring) so callers see identical behavior aside
-// from the transport.
+// CallSshCommand executes a remote command over ssh against target under ctx.
+// The execution pipeline mirrors CallExecCommand (same DOKKU_TRACE logging,
+// masking, stdio wiring) so callers see identical behavior aside from the
+// transport.
+//
+// It takes the whole Target rather than a host string because the argv it
+// builds depends on the sudo and host-key settings too, and a signature that
+// carried only the host would have to fetch those from somewhere else - which
+// is exactly how they ended up in the process environment.
 //
 // On exit code 255 (OpenSSH's transport-failure code), the returned
 // error is `*SSHError`. On any other non-zero exit, the returned error
 // is the plain underlying error so the formatter renders the failure
 // as a remote dokku error.
-func CallSshCommand(ctx context.Context, host string, input ExecCommandInput) (ExecCommandResponse, error) {
-	target, err := parseDokkuHost(host)
+func CallSshCommand(ctx context.Context, target Target, input ExecCommandInput) (ExecCommandResponse, error) {
+	parsed, err := parseDokkuHost(target.Host)
 	if err != nil {
-		return ExecCommandResponse{}, &SSHError{Host: host, Err: err}
+		return ExecCommandResponse{}, &SSHError{Host: target.Host, Err: err}
 	}
 	if err := ensureSshAvailable(); err != nil {
-		return ExecCommandResponse{}, &SSHError{Host: target.UserHost(), Err: err}
+		return ExecCommandResponse{}, &SSHError{Host: parsed.UserHost(), Err: err}
 	}
 
 	// isatty reports whether our own stdout is a terminal, which is the
@@ -305,9 +288,9 @@ func CallSshCommand(ctx context.Context, host string, input ExecCommandInput) (E
 	isatty := !color.NoColor
 
 	remote := append([]string{input.Command}, input.Args...)
-	argv, err := buildSshArgv(target, remote)
+	argv, err := buildSshArgv(parsed, target, remote)
 	if err != nil {
-		return ExecCommandResponse{}, &SSHError{Host: target.UserHost(), Command: remote, Err: err}
+		return ExecCommandResponse{}, &SSHError{Host: parsed.UserHost(), Command: remote, Err: err}
 	}
 
 	// The `ssh` client inherits docket's environment and directory; nothing is
@@ -354,7 +337,7 @@ func CallSshCommand(ctx context.Context, host string, input ExecCommandInput) (E
 		Cancelled: res.Cancelled,
 	}
 
-	return classifySshResult(target, remote, resp, runErr)
+	return classifySshResult(parsed, remote, resp, runErr)
 }
 
 // classifySshResult maps an ssh ExecTask result onto the docket error

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -110,11 +110,10 @@ func TestControlPathExtension(t *testing.T) {
 }
 
 func TestBuildSshArgvDefault(t *testing.T) {
-	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
-	t.Setenv("DOKKU_SUDO", "")
+	t.Parallel()
 
-	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv, err := buildSshArgv(target, []string{"dokku", "apps:list"})
+	parsed := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv, err := buildSshArgv(parsed, Target{}, []string{"dokku", "apps:list"})
 	if err != nil {
 		t.Fatalf("buildSshArgv returned error: %v", err)
 	}
@@ -151,16 +150,15 @@ func TestBuildSshArgvDefault(t *testing.T) {
 		t.Errorf("argv should not include -p for default port 22: %v", argv)
 	}
 	if containsExact(argv, "StrictHostKeyChecking=accept-new") {
-		t.Errorf("argv should not include accept-new without env var: %v", argv)
+		t.Errorf("argv should not include accept-new for a target that did not ask for it: %v", argv)
 	}
 }
 
 func TestBuildSshArgvNonStandardPort(t *testing.T) {
-	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
-	t.Setenv("DOKKU_SUDO", "")
+	t.Parallel()
 
-	target := sshTarget{User: "alice", Host: "host", Port: "2222"}
-	argv, err := buildSshArgv(target, []string{"dokku", "version"})
+	parsed := sshTarget{User: "alice", Host: "host", Port: "2222"}
+	argv, err := buildSshArgv(parsed, Target{}, []string{"dokku", "version"})
 	if err != nil {
 		t.Fatalf("buildSshArgv returned error: %v", err)
 	}
@@ -173,11 +171,10 @@ func TestBuildSshArgvNonStandardPort(t *testing.T) {
 }
 
 func TestBuildSshArgvAcceptNewHostKeys(t *testing.T) {
-	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "1")
-	t.Setenv("DOKKU_SUDO", "")
+	t.Parallel()
 
-	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv, err := buildSshArgv(target, []string{"dokku", "version"})
+	parsed := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv, err := buildSshArgv(parsed, Target{AcceptNewHostKeys: true}, []string{"dokku", "version"})
 	if err != nil {
 		t.Fatalf("buildSshArgv returned error: %v", err)
 	}
@@ -188,11 +185,10 @@ func TestBuildSshArgvAcceptNewHostKeys(t *testing.T) {
 }
 
 func TestBuildSshArgvDokkuSudo(t *testing.T) {
-	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
-	t.Setenv("DOKKU_SUDO", "1")
+	t.Parallel()
 
-	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv, err := buildSshArgv(target, []string{"dokku", "version"})
+	parsed := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv, err := buildSshArgv(parsed, Target{Sudo: true}, []string{"dokku", "version"})
 	if err != nil {
 		t.Fatalf("buildSshArgv returned error: %v", err)
 	}
@@ -213,7 +209,7 @@ func TestBuildSshArgvDokkuSudo(t *testing.T) {
 
 func TestBuildSshArgvDoubleDashSeparator(t *testing.T) {
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv, err := buildSshArgv(target, []string{"dokku", "config:set", "--no-restart"})
+	argv, err := buildSshArgv(target, Target{}, []string{"dokku", "config:set", "--no-restart"})
 	if err != nil {
 		t.Fatalf("buildSshArgv returned error: %v", err)
 	}
@@ -232,7 +228,7 @@ func TestBuildSshArgvQuotesRemoteArgs(t *testing.T) {
 	t.Setenv("DOKKU_SUDO", "")
 
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv, err := buildSshArgv(target, []string{"dokku", "ps:set", "app", "start-cmd", "npm run start"})
+	argv, err := buildSshArgv(target, Target{}, []string{"dokku", "ps:set", "app", "start-cmd", "npm run start"})
 	if err != nil {
 		t.Fatalf("buildSshArgv returned error: %v", err)
 	}
@@ -255,7 +251,7 @@ func TestBuildSshArgvQuotesInjection(t *testing.T) {
 	t.Setenv("DOKKU_SUDO", "")
 
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv, err := buildSshArgv(target, []string{"dokku", "config:set", "app", "x; rm -rf ~"})
+	argv, err := buildSshArgv(target, Target{}, []string{"dokku", "config:set", "app", "x; rm -rf ~"})
 	if err != nil {
 		t.Fatalf("buildSshArgv returned error: %v", err)
 	}
@@ -284,7 +280,7 @@ func TestBuildSshArgvQuotesServiceCreateFlags(t *testing.T) {
 	t.Setenv("DOKKU_SUDO", "")
 
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv, err := buildSshArgv(target, []string{
+	argv, err := buildSshArgv(target, Target{}, []string{
 		"dokku", "--quiet", "postgres:create", "my-db",
 		"--image", "postgis/postgis",
 		"--image-version", "13-master",
@@ -316,13 +312,13 @@ func TestBuildSshArgvRejectsUnquotable(t *testing.T) {
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
 	// A newline has no POSIX-shell escape, so we refuse to build the remote
 	// command rather than corrupt it.
-	if _, err := buildSshArgv(target, []string{"dokku", "config:set", "app", "a\nb"}); err == nil {
+	if _, err := buildSshArgv(target, Target{}, []string{"dokku", "config:set", "app", "a\nb"}); err == nil {
 		t.Fatal("expected error for argument containing a newline")
 	}
 
 	// The same failure surfaces through the dispatcher as a transport-level
 	// *SSHError so plan/apply render it with the `ssh:` prefix.
-	_, err := CallSshCommand(context.Background(), "alice@host", ExecCommandInput{
+	_, err := CallSshCommand(context.Background(), Target{Host: "alice@host"}, ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"config:set", "app", "a\nb"},
 	})
@@ -418,7 +414,7 @@ func TestClassifySshResultSuccess(t *testing.T) {
 }
 
 func TestCallSshCommandReturnsSshErrorOnEmptyHost(t *testing.T) {
-	_, err := CallSshCommand(context.Background(), "", ExecCommandInput{Command: "dokku", Args: []string{"version"}})
+	_, err := CallSshCommand(context.Background(), Target{}, ExecCommandInput{Command: "dokku", Args: []string{"version"}})
 	if err == nil {
 		t.Fatal("expected error for empty host")
 	}
@@ -449,13 +445,15 @@ func TestProbeDokkuLevelFailure(t *testing.T) {
 }
 
 func TestProbeSshTransportErrorPropagates(t *testing.T) {
-	// Inject a default host that points at a closed port so the SSH
-	// dispatcher routes the probe and OpenSSH exits 255 (transport
-	// failure). Dispatch only triggers for input.Command=="dokku".
-	t.Cleanup(func() { SetDefaultHost("") })
-	SetDefaultHost("docket-test@127.0.0.1:1")
+	t.Parallel()
 
-	matched, err := Probe(context.Background(), ExecCommandInput{
+	// A target pointing at a closed port routes the probe through SSH and
+	// OpenSSH exits 255 (transport failure). Dispatch only triggers for
+	// input.Command=="dokku". The target rides on this call's context, so the
+	// test needs nothing process-wide and can run alongside the others.
+	ctx := ContextWithTarget(context.Background(), Target{Host: "docket-test@127.0.0.1:1"})
+
+	matched, err := Probe(ctx, ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "apps:exists", "anything"},
 	})
@@ -525,18 +523,6 @@ func TestProbeExecRanFlagControlsAbsence(t *testing.T) {
 			t.Errorf("propagated error should wrap context.Canceled, got %v", err)
 		}
 	})
-}
-
-func TestSetAndGetDefaultHost(t *testing.T) {
-	t.Cleanup(func() { SetDefaultHost("") })
-	SetDefaultHost("alice@host:2222")
-	if got := GetDefaultHost(); got != "alice@host:2222" {
-		t.Errorf("GetDefaultHost() = %q, want %q", got, "alice@host:2222")
-	}
-	SetDefaultHost("")
-	if got := GetDefaultHost(); got != "" {
-		t.Errorf("GetDefaultHost() = %q, want empty after clear", got)
-	}
 }
 
 // helpers

--- a/subprocess/target.go
+++ b/subprocess/target.go
@@ -1,0 +1,55 @@
+package subprocess
+
+import "context"
+
+// Target describes where a dokku command runs and how it is wrapped. It is the
+// per-invocation replacement for what used to be three pieces of process
+// state: the `defaultHost` package variable, and the DOKKU_SUDO and
+// DOKKU_SSH_ACCEPT_NEW_HOST_KEYS environment variables the SSH argv builder
+// read back at dispatch time. Being per-invocation is what lets one process
+// talk to two servers - concurrently, or from a caller embedding this package
+// as a library.
+//
+// The zero Target runs dokku locally with no elevation, which is docket's
+// behaviour when neither --host nor DOKKU_HOST is set.
+type Target struct {
+	// Host is the remote as [user@]host[:port]. When non-empty, `dokku`
+	// invocations are routed through an `ssh` subprocess instead of running
+	// locally. Only `dokku` is routed: a task's local helper commands (docker,
+	// curl, tar) stay local, because the remote side may not have them.
+	Host string
+
+	// Sudo wraps the dokku invocation so it runs as root: `sudo -n` on the
+	// remote when Host is set, `sudo -n -u root` locally when it is not.
+	// Passwordless sudo only - `-n` never prompts. Like Host, this applies to
+	// `dokku` alone, so a task's local helper commands are not elevated.
+	Sudo bool
+
+	// AcceptNewHostKeys adds `-o StrictHostKeyChecking=accept-new`, so ssh
+	// trusts an unknown host on first connect. Only meaningful with Host.
+	AcceptNewHostKeys bool
+}
+
+// targetKey is the context key Target is stored under. An unexported struct
+// type cannot collide with a key from any other package.
+type targetKey struct{}
+
+// ContextWithTarget returns a copy of ctx carrying target. The commands layer
+// calls it once per run with the resolved flags and env; a caller that wants a
+// single command sent somewhere else derives a child context rather than
+// setting a field on the input, which keeps "which server" a question with one
+// answer per call.
+func ContextWithTarget(ctx context.Context, target Target) context.Context {
+	return context.WithValue(ctx, targetKey{}, target)
+}
+
+// TargetFromContext returns the target ctx carries, or the zero Target when it
+// carries none. A nil context is treated the same way, so a caller that has not
+// been threaded a context yet still runs locally rather than panicking.
+func TargetFromContext(ctx context.Context) Target {
+	if ctx == nil {
+		return Target{}
+	}
+	target, _ := ctx.Value(targetKey{}).(Target)
+	return target
+}

--- a/subprocess/target_test.go
+++ b/subprocess/target_test.go
@@ -1,0 +1,165 @@
+package subprocess
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestContextWithTargetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := Target{Host: "deploy@dokku.example.com:2222", Sudo: true, AcceptNewHostKeys: true}
+	if got := TargetFromContext(ContextWithTarget(context.Background(), want)); got != want {
+		t.Errorf("TargetFromContext = %+v, want %+v", got, want)
+	}
+}
+
+// TestTargetFromContextDefaultsToLocal pins the zero value. A context that
+// carries no target - a library caller who never set one, or docket run
+// without --host - runs dokku locally without elevation, which is the
+// behaviour the CLI has when neither flag nor env var is set.
+func TestTargetFromContextDefaultsToLocal(t *testing.T) {
+	t.Parallel()
+
+	if got := TargetFromContext(context.Background()); got != (Target{}) {
+		t.Errorf("TargetFromContext = %+v, want the zero Target", got)
+	}
+	//nolint:staticcheck // deliberately passing nil: a caller not yet threaded
+	// a context should run locally rather than panic.
+	if got := TargetFromContext(nil); got != (Target{}) {
+		t.Errorf("TargetFromContext(nil) = %+v, want the zero Target", got)
+	}
+}
+
+// TestChildContextOverridesTheTarget pins how a single call is sent somewhere
+// else: by deriving a context, not by setting a field on the input. That is
+// what keeps "which server" a question with exactly one answer per call, and
+// it is the mechanism a per-play host would use.
+func TestChildContextOverridesTheTarget(t *testing.T) {
+	t.Parallel()
+
+	run := ContextWithTarget(context.Background(), Target{Host: "a@one"})
+	child := ContextWithTarget(run, Target{Host: "b@two"})
+
+	if got := TargetFromContext(child).Host; got != "b@two" {
+		t.Errorf("child target host = %q, want %q", got, "b@two")
+	}
+	if got := TargetFromContext(run).Host; got != "a@one" {
+		t.Errorf("deriving a child must not disturb the parent; parent host = %q", got)
+	}
+}
+
+// TestConcurrentTargetsDoNotInterfere is the acceptance test for #423: two
+// targets in flight at once inside one process, each command reaching the
+// server its own caller asked for. While the host lived in a package variable
+// this was not expressible at all - the second caller to set it silently
+// redirected the first one's commands.
+func TestConcurrentTargetsDoNotInterfere(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string][]string{}
+
+	defer SetExecRunner(func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		host := TargetFromContext(ctx).Host
+		mu.Lock()
+		defer mu.Unlock()
+		seen[host] = append(seen[host], input.Args[len(input.Args)-1])
+		return ExecCommandResponse{}, nil
+	})()
+
+	const perHost = 25
+	hosts := []string{"alice@one", "bob@two"}
+
+	var wg sync.WaitGroup
+	for _, host := range hosts {
+		for i := 0; i < perHost; i++ {
+			wg.Add(1)
+			go func(host string, i int) {
+				defer wg.Done()
+				ctx := ContextWithTarget(context.Background(), Target{Host: host})
+				_, err := CallExecCommand(ctx, ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"apps:create", fmt.Sprintf("%s-%d", host, i)},
+				})
+				if err != nil {
+					t.Errorf("CallExecCommand: %v", err)
+				}
+			}(host, i)
+		}
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != len(hosts) {
+		t.Fatalf("commands reached %d hosts, want %d: %v", len(seen), len(hosts), seen)
+	}
+	for _, host := range hosts {
+		args := seen[host]
+		if len(args) != perHost {
+			t.Errorf("%s saw %d commands, want %d", host, len(args), perHost)
+		}
+		// Every app name is prefixed with the host its goroutine targeted, so a
+		// command that reached the wrong host is visible in the payload rather
+		// than only in the count.
+		for _, arg := range args {
+			if len(arg) < len(host) || arg[:len(host)] != host {
+				t.Errorf("%s received a command meant for another host: %q", host, arg)
+			}
+		}
+	}
+}
+
+// TestContextRunnerIsPerInvocation pins the seam #423 names as the reason no
+// test in this repo could call t.Parallel(): with the executor on the context
+// rather than in a package variable, two tests can install different fakes at
+// the same time.
+func TestContextRunnerIsPerInvocation(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"first", "second"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := ContextWithRunner(context.Background(), func(context.Context, ExecCommandInput) (ExecCommandResponse, error) {
+				return ExecCommandResponse{Stdout: name}, nil
+			})
+			resp, err := CallExecCommand(ctx, ExecCommandInput{Command: "dokku", Args: []string{"version"}})
+			if err != nil {
+				t.Fatalf("CallExecCommand: %v", err)
+			}
+			if resp.Stdout != name {
+				t.Errorf("stdout = %q, want %q; the other subtest's runner answered", resp.Stdout, name)
+			}
+		})
+	}
+}
+
+// TestContextRunnerBeatsThePackageRunner pins the precedence the two seams
+// have while both exist, so the tests still using SetExecRunner keep working
+// and a context-scoped one is never quietly ignored.
+func TestContextRunnerBeatsThePackageRunner(t *testing.T) {
+	defer SetExecRunner(func(context.Context, ExecCommandInput) (ExecCommandResponse, error) {
+		return ExecCommandResponse{Stdout: "package"}, nil
+	})()
+
+	ctx := ContextWithRunner(context.Background(), func(context.Context, ExecCommandInput) (ExecCommandResponse, error) {
+		return ExecCommandResponse{Stdout: "context"}, nil
+	})
+	resp, err := CallExecCommand(ctx, ExecCommandInput{Command: "dokku"})
+	if err != nil {
+		t.Fatalf("CallExecCommand: %v", err)
+	}
+	if resp.Stdout != "context" {
+		t.Errorf("stdout = %q, want the context runner to win", resp.Stdout)
+	}
+
+	// And a context without one still falls back to the package runner.
+	resp, err = CallExecCommand(context.Background(), ExecCommandInput{Command: "dokku"})
+	if err != nil {
+		t.Fatalf("CallExecCommand: %v", err)
+	}
+	if resp.Stdout != "package" {
+		t.Errorf("stdout = %q, want the package runner as the fallback", resp.Stdout)
+	}
+}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -264,8 +264,11 @@ type PlanResult struct {
 	Mutations []string
 
 	// Commands is the resolved dokku command line(s) that ExecutePlan
-	// would invoke if Plan reported drift, in invocation order. Tasks
-	// populate it via subprocess.ResolveCommandString from the same
+	// would invoke if Plan reported drift, in invocation order. They are
+	// rendered against the target the planning context carried, which is the
+	// same one Execute applies under today; a plan carried across hosts would
+	// have to re-render them. Tasks populate it via
+	// subprocess.ResolveCommandString from the same
 	// ExecCommandInput values the apply closure executes, so plan and
 	// apply render byte-identical strings for the same operation.
 	//

--- a/tasks/target_test.go
+++ b/tasks/target_test.go
@@ -1,0 +1,87 @@
+package tasks
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// recordingRunner answers `apps:exists` differently per host and records which
+// host each command was routed to. The shared fakeDokku keys only on the joined
+// args and drops the target entirely, which is exactly the blindness #423
+// describes - so host-aware tests need their own fake rather than a change to
+// the one every other test depends on.
+func recordingRunner(existsOn map[string]bool, seen *sync.Map) subprocess.ExecRunner {
+	return func(ctx context.Context, input subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		host := subprocess.TargetFromContext(ctx).Host
+		seen.Store(host, true)
+		if strings.Contains(strings.Join(input.Args, " "), "apps:exists") && !existsOn[host] {
+			return subprocess.ExecCommandResponse{ExitCode: 1}, &subprocess.ExecError{Response: subprocess.ExecCommandResponse{ExitCode: 1}, Ran: true}
+		}
+		return subprocess.ExecCommandResponse{}, nil
+	}
+}
+
+// TestPlanRoutesToTheContextTarget pins that the target reaches a task at all.
+// No task has ever set a host on the command it builds, so before the target
+// travelled on the context the only thing deciding where a dokku command went
+// was a package variable the task could not see.
+func TestPlanRoutesToTheContextTarget(t *testing.T) {
+	t.Parallel()
+
+	var seen sync.Map
+	ctx := subprocess.ContextWithRunner(context.Background(), recordingRunner(nil, &seen))
+	ctx = subprocess.ContextWithTarget(ctx, subprocess.Target{Host: "deploy@one"})
+
+	AppTask{App: "demo", State: StatePresent}.Plan(ctx)
+
+	if _, ok := seen.Load("deploy@one"); !ok {
+		var hosts []string
+		seen.Range(func(k, _ any) bool { hosts = append(hosts, k.(string)); return true })
+		t.Errorf("the probe did not reach the context's target; hosts seen: %v", hosts)
+	}
+}
+
+// TestPlanAgainstTwoTargetsConcurrently is the tasks-layer acceptance test for
+// #423: the same task planned against two servers at once, each answer coming
+// from the server that goroutine addressed. This is the case the process-global
+// host made impossible - and it runs in parallel, which nothing in this repo
+// could do while the executor was a package variable too.
+func TestPlanAgainstTwoTargetsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	// The app exists on one host and not the other, so a plan that routed to
+	// the wrong server reports the wrong verdict rather than merely the wrong
+	// host in a log line.
+	existsOn := map[string]bool{"deploy@has-it": true, "deploy@lacks-it": false}
+
+	var seen sync.Map
+	runner := recordingRunner(existsOn, &seen)
+
+	results := make(map[string]PlanResult, len(existsOn))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for host := range existsOn {
+		wg.Add(1)
+		go func(host string) {
+			defer wg.Done()
+			ctx := subprocess.ContextWithRunner(context.Background(), runner)
+			ctx = subprocess.ContextWithTarget(ctx, subprocess.Target{Host: host})
+			plan := AppTask{App: "demo", State: StatePresent}.Plan(ctx)
+			mu.Lock()
+			defer mu.Unlock()
+			results[host] = plan
+		}(host)
+	}
+	wg.Wait()
+
+	if got := results["deploy@has-it"]; !got.InSync {
+		t.Errorf("the host that has the app should plan in sync; got status %q reason %q", got.Status, got.Reason)
+	}
+	if got := results["deploy@lacks-it"]; got.InSync {
+		t.Error("the host that lacks the app should plan a create, not in sync")
+	}
+}

--- a/tests/bats/ssh.bats
+++ b/tests/bats/ssh.bats
@@ -144,3 +144,71 @@ EOF
   assert_success
   assert_output --partial "npm run start"
 }
+
+# argv_recipe is the one-task recipe the transport-argv cases below plan
+# against. They use `plan` rather than `apply` deliberately: the assertion is
+# about the ssh argv docket builds, and probing reads the server without
+# leaving root-owned state behind for the next test to trip over.
+argv_recipe() {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-ssh
+      dokku_app:
+        app: docket-test-ssh
+EOF
+}
+
+@test "--sudo wraps the remote dokku call in sudo -n" {
+  argv_recipe
+  # DOKKU_TRACE echoes the ssh argv, which is the only place the remote sudo
+  # wrap is visible: it happens on the server, so the command docket reports is
+  # the bare `dokku ...` form either way.
+  DOKKU_TRACE=1 DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan \
+    --tasks "$TASKS_FILE" --sudo
+  assert_success
+  assert_output --partial "-- sudo -n dokku"
+}
+
+@test "DOKKU_SUDO=1 is equivalent to --sudo over ssh" {
+  argv_recipe
+  # The argv builder used to read DOKKU_SUDO out of the process environment
+  # itself. It now takes the setting from the target the commands layer
+  # resolved, so this is what proves the env var still reaches it.
+  DOKKU_TRACE=1 DOKKU_SUDO=1 DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan \
+    --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "-- sudo -n dokku"
+}
+
+@test "no sudo wrap without --sudo or DOKKU_SUDO" {
+  argv_recipe
+  DOKKU_TRACE=1 DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan \
+    --tasks "$TASKS_FILE"
+  assert_success
+  refute_output --partial "sudo -n"
+}
+
+@test "--accept-new-host-keys adds the ssh option" {
+  argv_recipe
+  DOKKU_TRACE=1 DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan \
+    --tasks "$TASKS_FILE" --accept-new-host-keys
+  assert_success
+  assert_output --partial "StrictHostKeyChecking=accept-new"
+}
+
+@test "DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1 is equivalent to the flag" {
+  argv_recipe
+  DOKKU_TRACE=1 DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1 DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" \
+    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "StrictHostKeyChecking=accept-new"
+}
+
+@test "the host-key option is absent unless asked for" {
+  argv_recipe
+  DOKKU_TRACE=1 DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan \
+    --tasks "$TASKS_FILE"
+  assert_success
+  refute_output --partial "StrictHostKeyChecking=accept-new"
+}

--- a/tests/bats/sudo.bats
+++ b/tests/bats/sudo.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+APP="docket-test-sudo"
+
+# require_passwordless_sudo skips unless `sudo -n` works without a prompt.
+# --sudo asks for exactly that, so on a box where sudo wants a password there
+# is nothing to assert but a failure.
+require_passwordless_sudo() {
+  require_dokku
+  if ! sudo -n true >/dev/null 2>&1; then
+    skip "passwordless sudo not available"
+  fi
+}
+
+setup() {
+  require_passwordless_sudo
+  docket_build
+  dokku_clean_app "$APP"
+}
+
+teardown() {
+  if command -v dokku >/dev/null 2>&1; then
+    dokku_clean_app "$APP"
+  fi
+}
+
+# write_app_recipe writes the one-task recipe every case here applies. The task
+# has to actually run for --verbose to echo anything, which is why setup
+# destroys the app first.
+write_app_recipe() {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure $APP
+      dokku_app:
+        app: $APP
+EOF
+}
+
+@test "--sudo elevates a local dokku invocation" {
+  write_app_recipe
+
+  # --sudo used to be a no-op without --host: only the SSH argv builder read
+  # it, so a local run silently ignored the flag the name promises.
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --sudo --verbose
+  assert_success
+  assert_output --partial "sudo -n -u root dokku"
+  run dokku apps:exists "$APP"
+  assert_success
+}
+
+@test "a local run without --sudo is not elevated" {
+  write_app_recipe
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
+  assert_success
+  assert_output --partial "dokku --quiet apps:create $APP"
+  refute_output --partial "sudo -n -u root"
+}
+
+@test "DOKKU_SUDO=1 is equivalent to --sudo" {
+  write_app_recipe
+
+  # The env var is documented as the flag's equivalent, and used to reach the
+  # transport by a different route - read straight out of the process
+  # environment when the ssh argv was built. Now that the commands layer is its
+  # only reader, this is what keeps it working.
+  DOKKU_SUDO=1 run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
+  assert_success
+  assert_output --partial "sudo -n -u root dokku"
+}
+
+@test "--sudo applies only to the run that asked for it" {
+  write_app_recipe
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --sudo --verbose
+  assert_success
+  assert_output --partial "sudo -n -u root dokku"
+
+  # The setting used to be written into the process environment and never
+  # cleared, which is what ruled out two differently-configured runs in one
+  # process. Separate processes here, so this held before too - it is the
+  # observable end of the change, kept honest from the outside.
+  dokku_clean_app "$APP"
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
+  assert_success
+  refute_output --partial "sudo -n -u root"
+}


### PR DESCRIPTION
The host, the sudo setting and the host-key policy were process-global, so docket could only ever talk to one server per process. `SetDefaultHost` wrote a package variable that `CallExecCommand` fell back to, and the other two were worse than global: the commands layer bridged them through `os.Setenv` of `DOKKU_SUDO` and `DOKKU_SSH_ACCEPT_NEW_HOST_KEYS` so the SSH argv builder could read them back, which meant one invocation's flags applied to every later one in the same process. All three now travel together on the run context as a `subprocess.Target`, resolved once by `resolveSshFlags` and read where the command is dispatched. Two targets can be in flight at once, an embedding caller can supply its own, and a single call goes elsewhere by deriving a context rather than by setting a field - which is the mechanism a per-play `host:` would use.

`ExecCommandInput.Host` and `ExecCommandInput.Sudo` are gone rather than replaced by a `Target` field. No caller ever set either, and a per-call struct would have made "which server" a question with two answers whose precedence had to be defined; a derived context has one.

`--sudo` now works locally. It was a silent no-op without `--host`, because only the SSH argv builder read it; it wraps the local `dokku` in `sudo -n -u root` the way it wraps the remote one in `sudo -n`. Elevation covers `dokku` alone, so the `docker` and `curl` calls a few tasks make locally are not affected.

The test-only exec seam gains a context-scoped form, `ContextWithRunner`, which takes precedence over `SetExecRunner` and is what lets a test call `t.Parallel()`. The package variable stays as the fallback and is now mutex-guarded; migrating the tests that use it is #502. Masking stays global, with a note on the one API that would have to move first, and is #501. A recipe that spans hosts, which this makes representable, is #500.

Stacked on #503, which threads the context these settings ride on. Review that one first; this branch is based on it.

Fixes #423.
