### PR TITLE
fix: stop tests leaking sensitive values into one another

### DIFF
--- a/commands/fmt_test.go
+++ b/commands/fmt_test.go
@@ -298,6 +298,14 @@ func TestFmtColorNeverProducesPlainOutput(t *testing.T) {
 }
 
 func TestFmtColorAlwaysProducesAnsiEvenInPipe(t *testing.T) {
+	// `--color always` turns color.NoColor off process-wide, so the previous
+	// value is saved and put back rather than assumed. Restoring a hardcoded
+	// `true` is right only for as long as nothing else can have changed it,
+	// which stops being true the moment tests run in parallel. Same shape as
+	// TestFormatterColorOnEmitsAnsi in output_test.go.
+	prev := color.NoColor
+	t.Cleanup(func() { color.NoColor = prev })
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "tasks.yml")
 	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
@@ -311,8 +319,6 @@ func TestFmtColorAlwaysProducesAnsiEvenInPipe(t *testing.T) {
 	if !strings.Contains(captured, "\x1b[") {
 		t.Errorf("--color always should force ANSI escapes:\n%q", captured)
 	}
-	// Restore default so other tests are not affected.
-	color.NoColor = true
 }
 
 func TestFmtColorInvalidValueFails(t *testing.T) {

--- a/tasks/context_test.go
+++ b/tasks/context_test.go
@@ -1,6 +1,11 @@
 package tasks
 
-import "context"
+import (
+	"context"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
 
 // testCtx is the context unit tests pass to Plan, Execute and the helpers
 // below them. It exists so a test file can call `t.Plan(testCtx())` without
@@ -11,4 +16,20 @@ import "context"
 // Tests that need cancellation or a target build their own context instead.
 func testCtx() context.Context {
 	return context.Background()
+}
+
+// isolateMaskRegistry gives the test an empty sensitive-value registry and puts
+// the previous set back when it finishes.
+//
+// Restoring rather than clearing is what lets TestMain's end-of-run check mean
+// anything. Production code in this package registers sensitive values and
+// never clears them - tasks/properties.go does it for a property marked
+// sensitive, registerSensitiveMapValues does it for a map field - so residue
+// outlives the test that created it. A test that cleared on the way out would
+// wipe an earlier test's residue and hide exactly what that check looks for.
+func isolateMaskRegistry(t *testing.T) {
+	t.Helper()
+	prev := subprocess.GlobalSensitive()
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(prev) })
 }

--- a/tasks/identity_test.go
+++ b/tasks/identity_test.go
@@ -138,8 +138,8 @@ func TestIdentityAddressMasksQuotedSensitiveValue(t *testing.T) {
 		{name: "a tab is escaped once the value is quoted", option: "--label tab,\tzzz"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			isolateMaskRegistry(t)
 			subprocess.SetGlobalSensitive([]string{tt.option})
-			defer subprocess.SetGlobalSensitive(nil)
 
 			address := IdentityAddress("dokku_docker_options", DockerOptionsTask{
 				App:    "api",

--- a/tasks/integration_helpers_test.go
+++ b/tasks/integration_helpers_test.go
@@ -10,7 +10,33 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Exit(m.Run())
+	code := m.Run()
+
+	// Production code in this package registers sensitive values into a
+	// process-wide registry and never clears it: tasks/properties.go does it
+	// for a property the plugin marks sensitive, and registerSensitiveMapValues
+	// does it for a map field. Harmless in a CLI that exits afterwards; in a
+	// test binary the residue outlives the test that created it and masks any
+	// literal a later test expects to read back in the clear.
+	//
+	// Four property tests were doing exactly that, each leaving its secret
+	// registered for every test that ran after it. It went unnoticed because
+	// the tests that set the registry directly cleared it to nil on the way
+	// out, wiping the evidence before anything could observe it - so this
+	// check is only sound because isolateMaskRegistry restores the previous
+	// set instead. Nothing wipes residue any more, so anything a test
+	// registers survives to here.
+	if leaked := subprocess.GlobalSensitive(); len(leaked) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"mask registry is not empty after the package run: %q\n"+
+				"a test registered a sensitive value without restoring the previous set; "+
+				"use isolateMaskRegistry\n", leaked)
+		if code == 0 {
+			code = 1
+		}
+	}
+
+	os.Exit(code)
 }
 
 func dokkuAvailable() bool {
@@ -27,6 +53,14 @@ func skipIfNoDokkuT(t *testing.T) {
 	if !dokkuAvailable() {
 		t.Skip("skipping integration test: dokku not available")
 	}
+	// Applying a task for real is exactly what makes production register a
+	// sensitive value - the documented dokku_letsencrypt_property example sets
+	// a dns-provider-* credential, and planProperty registers it. That is the
+	// behaviour under test, not a leak, but the residue would still outlive the
+	// test and trip TestMain's end-of-run check. Isolating at the one gate every
+	// integration test already passes through covers all of them without each
+	// having to know whether the task it applies happens to be sensitive.
+	isolateMaskRegistry(t)
 }
 
 func dokkuPluginInstalled(plugin string) bool {

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -41,8 +41,7 @@ func TestGetPropertyArgsGlobal(t *testing.T) {
 }
 
 func TestPlanPropertyMasksSensitiveDriftValue(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 
 	keys := map[string]PropertyKeys{
 		"secret-prop": {PerApp: "", Global: "global-secret-prop", Sensitive: true},
@@ -75,8 +74,7 @@ func TestPlanPropertyMasksSensitiveDriftValue(t *testing.T) {
 }
 
 func TestPlanPropertyAbsentMasksSensitiveOldValue(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 
 	keys := map[string]PropertyKeys{
 		"secret-prop": {PerApp: "", Global: "global-secret-prop", Sensitive: true},
@@ -97,8 +95,7 @@ func TestPlanPropertyAbsentMasksSensitiveOldValue(t *testing.T) {
 }
 
 func TestPlanPropertyDoesNotMaskBenignDriftValue(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 
 	keys := map[string]PropertyKeys{
 		"timeout": {PerApp: "", Global: "global-timeout"},
@@ -228,8 +225,7 @@ func TestUnknownPropertyWarningInvalidFlag(t *testing.T) {
 // secret that reaches it must mask at emit time. The message is stored raw
 // (like PlanResult.Reason) so the assertion masks it the way the emitter does.
 func TestUnknownPropertyWarningMasksSensitiveStderr(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 	subprocess.AddGlobalSensitive("s3cr3t")
 
 	execErr := &subprocess.ExecError{
@@ -431,6 +427,7 @@ func TestDynamicPropertiesFromReport(t *testing.T) {
 // dns-provider-* credential that already matches the recipe plans as in sync
 // instead of reporting drift on every run.
 func TestPlanPropertyDynamicLetsencryptInSync(t *testing.T) {
+	isolateMaskRegistry(t)
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"token123"}`,
 	}))()
@@ -448,6 +445,7 @@ func TestPlanPropertyDynamicLetsencryptInSync(t *testing.T) {
 }
 
 func TestPlanPropertyDynamicLetsencryptGlobalInSync(t *testing.T) {
+	isolateMaskRegistry(t)
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report --global --format json": `{"global-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
 	}))()
@@ -465,8 +463,7 @@ func TestPlanPropertyDynamicLetsencryptGlobalInSync(t *testing.T) {
 // mark on the synthesized keys: the probed credential reaches the drift reason
 // and must be registered with the masker.
 func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"oldtoken"}`,
@@ -496,6 +493,7 @@ func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
 // state: the plugin only emits a row once the property holds a value, so an
 // absent row is an unset property and not a probe failure worth warning about.
 func TestPlanPropertyDynamicLetsencryptMissingRowPlansCreate(t *testing.T) {
+	isolateMaskRegistry(t)
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
 	}))()
@@ -530,8 +528,7 @@ func TestPlanPropertyDynamicLetsencryptAbsentMissingRowIsInSync(t *testing.T) {
 }
 
 func TestPlanPropertyDynamicLetsencryptAbsentPlansDestroy(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"livetoken"}`,
@@ -553,6 +550,7 @@ func TestPlanPropertyDynamicLetsencryptAbsentPlansDestroy(t *testing.T) {
 // family on the unprobed path while dokku/dokku#8928 is open (#450): it must not
 // even attempt a report read.
 func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
+	isolateMaskRegistry(t)
 	var ran []string
 	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		ran = append(ran, strings.Join(in.Args, " "))
@@ -578,8 +576,7 @@ func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
 // all the same, so the desired value must reach the masker before it lands in
 // the command echo or the plan mutation line.
 func TestPlanPropertyDynamicTraefikMasksCredential(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 
 	defer subprocess.SetExecRunner(func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		return subprocess.ExecCommandResponse{}, nil

--- a/tasks/scheduler_k3s_autoscaling_auth_task_test.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task_test.go
@@ -39,8 +39,7 @@ func TestSchedulerK3sAutoscalingAuthTaskSensitiveValuesAbsentEmpty(t *testing.T)
 }
 
 func TestSchedulerK3sAutoscalingAuthUnsetMasksProbedSecrets(t *testing.T) {
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	isolateMaskRegistry(t)
 
 	// The server holds two metadata keys; the task clears one, so the other
 	// survives and is read back (with its secret value) for the restore call.

--- a/tasks/service_create_task_test.go
+++ b/tasks/service_create_task_test.go
@@ -243,8 +243,8 @@ func TestServiceCreateTaskMasksSecretsInCommands(t *testing.T) {
 		State:        StatePresent,
 	}
 
+	isolateMaskRegistry(t)
 	subprocess.SetGlobalSensitive(sensitiveValuesFromTask(&task))
-	defer subprocess.SetGlobalSensitive(nil)
 	defer subprocess.SetExecRunner(serviceMissing())()
 
 	got := planCreateCommand(t, task)
@@ -874,8 +874,8 @@ func TestServiceCreateTaskImageDriftUpgradeMasksSecrets(t *testing.T) {
 	task := driftTask()
 	task.ImageDrift = imageDriftUpgrade
 	task.CustomEnv = map[string]string{"GREETING": "s3cret"}
+	isolateMaskRegistry(t)
 	subprocess.SetGlobalSensitive(sensitiveValuesFromTask(&task))
-	defer subprocess.SetGlobalSensitive(nil)
 
 	plan := task.Plan(testCtx())
 	if len(plan.Commands) != 1 {


### PR DESCRIPTION
Four property tests register a secret and never clear it, so it stays registered for every test that runs afterwards and any of them reading that literal back would see `***` instead. Nothing fails today, because no test happens to assert on `token123` or `deploy-bot` - but the exposure is one unlucky fixture value away, and it becomes a real hazard the moment tests run in parallel and the set of tests that ran first stops being fixed.

Production code is the source and is behaving correctly: `planProperty` registers a sensitive property's desired and probed values so a drift reason cannot echo a credential, and nothing in `tasks` clears the registry afterwards because a CLI process exits. The four tests that reach that path now take an empty registry and put the previous set back when they finish, through a shared `isolateMaskRegistry` helper, and the seven tests that were already managing the registry by hand use the same helper instead of clearing to nil.

Restoring rather than clearing is what makes the leak observable at all. Clearing is why it went unnoticed: the tests that set the registry directly wiped it on the way out, so residue never survived far enough to be seen - an end-of-run check came back clean until those cleanups stopped wiping. With nothing wiping, `TestMain` can assert the registry is empty when the package finishes and fail the run when it is not, which is what pins this rather than leaving it to be rediscovered.

Integration tests register through the same production path, and there the registration is the behaviour under test rather than a leak - the documented `dokku_letsencrypt_property` example sets a `dns-provider-*` credential. They are isolated at `skipIfNoDokkuT`, the one gate all 139 of them already pass through, so none has to know whether the task it applies happens to be sensitive.

`commands` needs none of it: every command clears the registry on the way out of `Run`, so residue cannot accumulate there.

Also saves and restores `color.NoColor` in the fmt colour test rather than assuming the previous value was `true`, matching `TestFormatterColorOnEmitsAnsi`.

Prerequisite for #502.
