### PR TITLE
test: move the tasks unit tests onto a per-context exec seam

### DIFF
--- a/tasks/buildpacks_task_test.go
+++ b/tasks/buildpacks_task_test.go
@@ -33,6 +33,7 @@ func assertBuildpacksReplaceInOrder(t *testing.T, plan PlanResult, want []string
 }
 
 func TestBuildpacksTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := BuildpacksTask{App: "test-app", Buildpacks: []string{"https://example.com/bp.git"}, State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -41,6 +42,7 @@ func TestBuildpacksTaskInvalidState(t *testing.T) {
 }
 
 func TestBuildpacksTaskPresentMissingApp(t *testing.T) {
+	t.Parallel()
 	task := BuildpacksTask{Buildpacks: []string{"https://example.com/bp.git"}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -52,6 +54,7 @@ func TestBuildpacksTaskPresentMissingApp(t *testing.T) {
 }
 
 func TestBuildpacksTaskAbsentMissingApp(t *testing.T) {
+	t.Parallel()
 	task := BuildpacksTask{State: StateAbsent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -63,6 +66,7 @@ func TestBuildpacksTaskAbsentMissingApp(t *testing.T) {
 }
 
 func TestBuildpacksTaskPresentEmptyBuildpacks(t *testing.T) {
+	t.Parallel()
 	task := BuildpacksTask{App: "test-app", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -74,11 +78,12 @@ func TestBuildpacksTaskPresentEmptyBuildpacks(t *testing.T) {
 }
 
 func TestBuildpacksSameOrderInSync(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet buildpacks:report test-app --format json": `{"list":"nodejs,nginx"}`,
-	}))()
+	}))
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(testCtx())
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -88,11 +93,12 @@ func TestBuildpacksSameOrderInSync(t *testing.T) {
 }
 
 func TestBuildpacksReorderReportsDrift(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet buildpacks:report test-app --format json": `{"list":"nginx,nodejs"}`,
-	}))()
+	}))
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(testCtx())
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -106,11 +112,12 @@ func TestBuildpacksReorderReportsDrift(t *testing.T) {
 }
 
 func TestBuildpacksPartialSetUsesReplaceInOrder(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet buildpacks:report test-app --format json": `{"list":"nginx"}`,
-	}))()
+	}))
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(testCtx())
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -122,11 +129,12 @@ func TestBuildpacksPartialSetUsesReplaceInOrder(t *testing.T) {
 }
 
 func TestBuildpacksCreateWhenEmpty(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet buildpacks:report test-app --format json": `{"list":""}`,
-	}))()
+	}))
 
-	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs"}, State: StatePresent}.Plan(testCtx())
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -139,6 +147,7 @@ func TestBuildpacksCreateWhenEmpty(t *testing.T) {
 }
 
 func TestGetTasksBuildpacksTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: add buildpacks

--- a/tasks/certs_task_test.go
+++ b/tasks/certs_task_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestCertsTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", Key: "/tmp/key", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -20,6 +21,7 @@ func TestCertsTaskInvalidState(t *testing.T) {
 }
 
 func TestCertsTaskMissingApp(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{Cert: "/tmp/cert", Key: "/tmp/key", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -31,6 +33,7 @@ func TestCertsTaskMissingApp(t *testing.T) {
 }
 
 func TestCertsTaskGlobalWithApp(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{App: "test-app", Global: true, Cert: "/tmp/cert", Key: "/tmp/key", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -42,6 +45,7 @@ func TestCertsTaskGlobalWithApp(t *testing.T) {
 }
 
 func TestCertsTaskPresentMissingCert(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{App: "test-app", Key: "/tmp/key", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -53,6 +57,7 @@ func TestCertsTaskPresentMissingCert(t *testing.T) {
 }
 
 func TestCertsTaskPresentMissingKey(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -64,6 +69,7 @@ func TestCertsTaskPresentMissingKey(t *testing.T) {
 }
 
 func TestCertsTaskInlineMissingKeyContent(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{App: "test-app", CertContent: "cert-pem", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -75,6 +81,7 @@ func TestCertsTaskInlineMissingKeyContent(t *testing.T) {
 }
 
 func TestCertsTaskInlineMixedSources(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", KeyContent: "key-pem", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -86,6 +93,7 @@ func TestCertsTaskInlineMixedSources(t *testing.T) {
 }
 
 func TestCertsTaskInlineBothCertForms(t *testing.T) {
+	t.Parallel()
 	task := CertsTask{App: "test-app", Cert: "/tmp/cert", CertContent: "cert-pem", Key: "/tmp/key", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -97,6 +105,7 @@ func TestCertsTaskInlineBothCertForms(t *testing.T) {
 }
 
 func TestBuildCertTarball(t *testing.T) {
+	t.Parallel()
 	certPEM := "-----BEGIN CERTIFICATE-----\nfake-cert\n-----END CERTIFICATE-----\n"
 	keyPEM := "-----BEGIN PRIVATE KEY-----\nfake-key\n-----END PRIVATE KEY-----\n"
 
@@ -138,6 +147,7 @@ func TestBuildCertTarball(t *testing.T) {
 }
 
 func TestGetTasksCertsTaskInlineParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: install cert
@@ -184,6 +194,7 @@ func TestGetTasksCertsTaskInlineParsedCorrectly(t *testing.T) {
 }
 
 func TestGetTasksCertsTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: install cert
@@ -228,13 +239,14 @@ func TestGetTasksCertsTaskParsedCorrectly(t *testing.T) {
 // global-cert:report so a bare `--global-cert-enabled` flag now reports
 // per-app; only `--global` targets the global certificate itself.
 func TestCertsEnabledGlobalUsesGlobalScope(t *testing.T) {
+	t.Parallel()
 	var gotArgs []string
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		gotArgs = in.Args
 		return subprocess.ExecCommandResponse{Stdout: "true"}, nil
-	})()
+	})
 
-	enabled, err := certsEnabled(testCtx(), CertsTask{Global: true})
+	enabled, err := certsEnabled(ctx, CertsTask{Global: true})
 	if err != nil {
 		t.Fatalf("certsEnabled: %v", err)
 	}

--- a/tasks/checks_toggle_task_test.go
+++ b/tasks/checks_toggle_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestChecksToggleTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := ChecksToggleTask{App: "test-app", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -20,14 +21,15 @@ func TestChecksToggleTaskInvalidState(t *testing.T) {
 // forwards an SSH transport failure so planToggle reports it as a plan error
 // rather than spurious drift (#357).
 func TestChecksToggleTaskPlanSurfacesSSHError(t *testing.T) {
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
 			Host:   "dokku@unreachable",
 			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
 		}
-	})()
+	})
 
-	plan := ChecksToggleTask{App: "web", State: StatePresent}.Plan(testCtx())
+	plan := ChecksToggleTask{App: "web", State: StatePresent}.Plan(ctx)
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}
@@ -46,6 +48,7 @@ func TestChecksToggleTaskPlanSurfacesSSHError(t *testing.T) {
 // ToggleFields` (#467), so this is what proves the shared field set still yields
 // the flat `app` / `state` recipe keys and that SetDefaults still fills `state`.
 func TestGetTasksChecksToggleTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: enable checks

--- a/tasks/config_task_test.go
+++ b/tasks/config_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestConfigTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := ConfigTask{
 		App:    "test-app",
 		Config: map[string]string{"KEY": "VALUE"},
@@ -21,6 +22,7 @@ func TestConfigTaskInvalidState(t *testing.T) {
 }
 
 func TestGetTasksConfigTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set config
@@ -80,6 +82,7 @@ func TestGetTasksConfigTaskParsedCorrectly(t *testing.T) {
 // across both config:set and config:unset. An explicit restart: false must emit
 // --no-restart; an omitted restart (nil) defaults to true and must not.
 func TestConfigTaskRestartFlag(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name         string
 		restart      *bool
@@ -97,16 +100,16 @@ func TestConfigTaskRestartFlag(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+			ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 				"--quiet config:export --format json test-app": tc.current,
-			}))()
+			}))
 
 			plan := ConfigTask{
 				App:     "test-app",
 				Restart: tc.restart,
 				Config:  map[string]string{"KEY": "val"},
 				State:   tc.state,
-			}.Plan(testCtx())
+			}.Plan(ctx)
 			if plan.Error != nil {
 				t.Fatalf("unexpected plan error: %v", plan.Error)
 			}
@@ -128,6 +131,7 @@ func TestConfigTaskRestartFlag(t *testing.T) {
 // pipeline: a recipe with restart: false must still yield a --no-restart
 // command. This is the regression the go-defaults clobber produced.
 func TestConfigTaskRestartFalseEndToEnd(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set config
@@ -137,9 +141,9 @@ func TestConfigTaskRestartFalseEndToEnd(t *testing.T) {
         config:
           KEY: val
 `)
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet config:export --format json test-app": "{}",
-	}))()
+	}))
 
 	parsed, err := GetTasks(data, map[string]interface{}{})
 	if err != nil {
@@ -149,7 +153,7 @@ func TestConfigTaskRestartFalseEndToEnd(t *testing.T) {
 	if task == nil {
 		t.Fatal("task 'set config' not found")
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}

--- a/tasks/context_propagation_test.go
+++ b/tasks/context_propagation_test.go
@@ -18,6 +18,7 @@ type ctxKey struct{}
 // which means applying a plan uses the caller's current cancellation and
 // target rather than whatever was in scope when the plan was computed.
 func TestExecutePlanPassesItsContextToApply(t *testing.T) {
+	t.Parallel()
 	planCtx := context.WithValue(context.Background(), ctxKey{}, "plan")
 	applyCtx := context.WithValue(context.Background(), ctxKey{}, "apply")
 
@@ -50,13 +51,17 @@ func TestExecutePlanPassesItsContextToApply(t *testing.T) {
 // bottomed out in a context.Background() manufactured inside subprocess, so a
 // caller's cancellation and deadline could not reach a running task at all.
 func TestPlanUsesTheContextItWasGiven(t *testing.T) {
+	t.Parallel()
 	var seen string
-	defer subprocess.SetExecRunner(func(ctx context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
-		seen, _ = ctx.Value(ctxKey{}).(string)
-		return subprocess.ExecCommandResponse{}, nil
-	})()
+	// The runner goes on the caller's own context, not a fresh one, so what the
+	// probe observes is the value the caller put there.
+	ctx := subprocess.ContextWithRunner(
+		context.WithValue(context.Background(), ctxKey{}, "caller"),
+		func(ctx context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+			seen, _ = ctx.Value(ctxKey{}).(string)
+			return subprocess.ExecCommandResponse{}, nil
+		})
 
-	ctx := context.WithValue(context.Background(), ctxKey{}, "caller")
 	AppTask{App: "demo", State: StatePresent}.Plan(ctx)
 
 	if seen != "caller" {
@@ -69,12 +74,12 @@ func TestPlanUsesTheContextItWasGiven(t *testing.T) {
 // "the probe did not answer" as "the resource is missing" would have apply
 // mutate a server whose state was never established.
 func TestPlanReportsCancellationAsAnError(t *testing.T) {
-	defer subprocess.SetExecRunner(func(ctx context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
-		return subprocess.ExecCommandResponse{Cancelled: true}, &subprocess.ExecError{Err: context.Canceled}
-	})()
-
-	ctx, cancel := context.WithCancel(context.Background())
+	t.Parallel()
+	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
+	ctx := subprocess.ContextWithRunner(cancelled, func(context.Context, subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{Cancelled: true}, &subprocess.ExecError{Err: context.Canceled}
+	})
 
 	plan := AppTask{App: "demo", State: StatePresent}.Plan(ctx)
 	if plan.Error == nil {

--- a/tasks/domains_task_test.go
+++ b/tasks/domains_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDomainsTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := DomainsTask{App: "test-app", Domains: []string{"example.com"}, State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -17,6 +18,7 @@ func TestDomainsTaskInvalidState(t *testing.T) {
 }
 
 func TestDomainsTaskMissingApp(t *testing.T) {
+	t.Parallel()
 	task := DomainsTask{Domains: []string{"example.com"}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -25,6 +27,7 @@ func TestDomainsTaskMissingApp(t *testing.T) {
 }
 
 func TestDomainsTaskGlobalWithApp(t *testing.T) {
+	t.Parallel()
 	task := DomainsTask{App: "test-app", Global: true, Domains: []string{"example.com"}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -36,6 +39,7 @@ func TestDomainsTaskGlobalWithApp(t *testing.T) {
 }
 
 func TestDomainsTaskEmptyDomains(t *testing.T) {
+	t.Parallel()
 	states := []State{StatePresent, StateAbsent, StateSet}
 	for _, s := range states {
 		task := DomainsTask{App: "test-app", Domains: []string{}, State: s}
@@ -47,6 +51,7 @@ func TestDomainsTaskEmptyDomains(t *testing.T) {
 }
 
 func TestDomainsTaskClearRejectsDomains(t *testing.T) {
+	t.Parallel()
 	// domains:clear takes no domains, so a list here would be silently
 	// discarded rather than removed.
 	task := DomainsTask{App: "test-app", Domains: []string{"example.com"}, State: StateClear}
@@ -60,6 +65,7 @@ func TestDomainsTaskClearRejectsDomains(t *testing.T) {
 }
 
 func TestDomainsTaskClearNoDomains(t *testing.T) {
+	t.Parallel()
 	task := DomainsTask{App: "test-app", State: StateClear}
 	result := task.Execute(testCtx())
 	// Should fail because dokku isn't running, but NOT because of missing domains
@@ -86,11 +92,12 @@ func assertNoGlobalPositional(t *testing.T, commands []string) {
 }
 
 func TestDomainsGlobalSetOmitsGlobalPositional(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"domains:report --global --domains-global-vhosts": "",
-	}))()
+	}))
 
-	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan(testCtx())
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -107,11 +114,12 @@ func TestDomainsGlobalSetOmitsGlobalPositional(t *testing.T) {
 }
 
 func TestDomainsGlobalSetConvergesWhenReportMatches(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"domains:report --global --domains-global-vhosts": "global.example.com",
-	}))()
+	}))
 
-	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan(testCtx())
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -121,11 +129,12 @@ func TestDomainsGlobalSetConvergesWhenReportMatches(t *testing.T) {
 }
 
 func TestDomainsGlobalAddOmitsGlobalPositional(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"domains:report --global --domains-global-vhosts": "",
-	}))()
+	}))
 
-	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StatePresent}.Plan(testCtx())
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -139,11 +148,12 @@ func TestDomainsGlobalAddOmitsGlobalPositional(t *testing.T) {
 }
 
 func TestDomainsGlobalClearOmitsGlobalPositional(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"domains:report --global --domains-global-vhosts": "old.example.com",
-	}))()
+	}))
 
-	plan := DomainsTask{Global: true, State: StateClear}.Plan(testCtx())
+	plan := DomainsTask{Global: true, State: StateClear}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -157,6 +167,7 @@ func TestDomainsGlobalClearOmitsGlobalPositional(t *testing.T) {
 }
 
 func TestGetTasksDomainsTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: add domains
@@ -206,6 +217,7 @@ func TestGetTasksDomainsTaskParsedCorrectly(t *testing.T) {
 }
 
 func TestGetTasksDomainsTaskGlobalParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set global domains

--- a/tasks/domains_toggle_task_test.go
+++ b/tasks/domains_toggle_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDomainsToggleTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := DomainsToggleTask{App: "test-app", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -20,14 +21,15 @@ func TestDomainsToggleTaskInvalidState(t *testing.T) {
 // forwards an SSH transport failure so planToggle reports it as a plan error
 // rather than spurious drift (#357).
 func TestDomainsToggleTaskPlanSurfacesSSHError(t *testing.T) {
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
 			Host:   "dokku@unreachable",
 			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
 		}
-	})()
+	})
 
-	plan := DomainsToggleTask{App: "web", State: StatePresent}.Plan(testCtx())
+	plan := DomainsToggleTask{App: "web", State: StatePresent}.Plan(ctx)
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}

--- a/tasks/export_masking_test.go
+++ b/tasks/export_masking_test.go
@@ -41,9 +41,10 @@ func assertNotRegistered(t *testing.T, res *ExportResult, unwanted string) {
 // dokku_config declares its own sensitive set, and it is the spelling
 // `config:set --encoded` puts on argv.
 func TestExportRegistersConfigValues(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -55,9 +56,10 @@ func TestExportRegistersConfigValues(t *testing.T) {
 // res.Vars after the fact wrong: --redact writes a placeholder there, but the
 // value was still read off the server and can still reach a warning.
 func TestExportRedactStillRegistersTheRealValue(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Redact: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -71,9 +73,10 @@ func TestExportRedactStillRegistersTheRealValue(t *testing.T) {
 // lifts nothing into a vars map at all, yet its warnings print to the same
 // stream as everything else.
 func TestExportInlineRegistersValuesItDoesNotLift(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -88,12 +91,13 @@ func TestExportInlineRegistersValuesItDoesNotLift(t *testing.T) {
 // family's Sensitive flag says the cluster token is credential material. Its
 // benign sibling in the same report is the boundary.
 func TestExportRegistersSensitivePropertyValue(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "",
 		"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken","global-ingress-class":"nginx-ingress"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -106,9 +110,10 @@ func TestExportRegistersSensitivePropertyValue(t *testing.T) {
 // declares them through SensitiveValues(). Inline mode is the interesting one:
 // the hash stays in the streamed body and is lifted nowhere.
 func TestExportRegistersHttpAuthHashes(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -123,12 +128,13 @@ func TestExportRegistersHttpAuthHashes(t *testing.T) {
 // (TestExportLetsencryptBenignPropertyNotLifted). That is exactly what apply
 // masks for the same task, and over-masking is the safe direction.
 func TestExportRegistersEveryLetsencryptPropertyValue(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                            "web",
 		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"tok3n"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -141,12 +147,13 @@ func TestExportRegistersEveryLetsencryptPropertyValue(t *testing.T) {
 // not Sensitive contributes nothing, so an export of a server holding no
 // secrets masks nothing and its diagnostics read exactly as they did before.
 func TestExportRegistersNothingForBenignProperties(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                         "",
 		"--quiet git:report --global --format json": `{"global-deploy-branch":"main","global-archive-max-files":"100","global-keep-git-dir":""}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/export_resource_test.go
+++ b/tasks/export_resource_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -9,13 +10,13 @@ import (
 
 // exportResource runs ExportRecipe restricted to the given addresses against
 // the shared fixture and returns the marshalled recipe plus the report.
-func exportResource(t *testing.T, addresses ...string) (string, ExportReport) {
+func exportResource(t *testing.T, ctx context.Context, addresses ...string) (string, ExportReport) {
 	t.Helper()
 	selectors, err := ParseResourceSelectors(addresses)
 	if err != nil {
 		t.Fatalf("ParseResourceSelectors(%v): %v", addresses, err)
 	}
-	res, err := ExportRecipe(testCtx(), ExportOptions{Resources: selectors, Inline: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Resources: selectors, Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -29,9 +30,10 @@ func exportResource(t *testing.T, addresses ...string) (string, ExportReport) {
 // TestExportResourceSelectsOneResource covers the headline case the issue asks
 // for: reading back a single resource instead of a whole app play.
 func TestExportResourceSelectsOneResource(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	out, report := exportResource(t, "dokku_config[app=app-one]")
+	out, report := exportResource(t, ctx, "dokku_config[app=app-one]")
 
 	if !strings.Contains(out, "dokku_config") {
 		t.Errorf("expected the addressed task in the recipe; got:\n%s", out)
@@ -50,9 +52,10 @@ func TestExportResourceSelectsOneResource(t *testing.T) {
 // TestExportResourceBareTypeSelectsEveryApp covers the wildcard form: an
 // address with no keys means every resource of that type, wherever it lives.
 func TestExportResourceBareTypeSelectsEveryApp(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	out, report := exportResource(t, "dokku_domains")
+	out, report := exportResource(t, ctx, "dokku_domains")
 
 	if !strings.Contains(out, "dokku_domains") {
 		t.Errorf("expected the addressed task type; got:\n%s", out)
@@ -71,9 +74,10 @@ func TestExportResourceBareTypeSelectsEveryApp(t *testing.T) {
 // TestExportResourceCombinesAddresses covers several addresses in one run,
 // including two apps, and asserts each contributes its own play.
 func TestExportResourceCombinesAddresses(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	out, _ := exportResource(t, "dokku_config[app=app-one]", "dokku_domains[app=app-one]")
+	out, _ := exportResource(t, ctx, "dokku_config[app=app-one]", "dokku_domains[app=app-one]")
 
 	for _, want := range []string{"dokku_config", "dokku_domains", "app-one"} {
 		if !strings.Contains(out, want) {
@@ -89,9 +93,10 @@ func TestExportResourceCombinesAddresses(t *testing.T) {
 // nothing for is reported rather than silently exporting nothing, the same
 // contract --app has for a nonexistent app (#346).
 func TestExportResourceReportsUnmatchedAddress(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	_, report := exportResource(t, "dokku_config[app=app-one]", "dokku_domains[app=app-two]")
+	_, report := exportResource(t, ctx, "dokku_config[app=app-one]", "dokku_domains[app=app-two]")
 
 	if len(report.MissingResources) != 1 || report.MissingResources[0] != "dokku_domains[app=app-two]" {
 		t.Errorf("MissingResources = %v, want [dokku_domains[app=app-two]]", report.MissingResources)
@@ -102,14 +107,15 @@ func TestExportResourceReportsUnmatchedAddress(t *testing.T) {
 // leading global play and no app plays at all - distinct from "no app
 // restriction", which would enumerate every app.
 func TestExportResourceGlobalScope(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "app-one",
 		"--quiet plugin:list --format json": `[
 			{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"","branch":""}
 		]`,
-	}))()
+	}))
 
-	out, report := exportResource(t, "dokku_plugin[name=redis]")
+	out, report := exportResource(t, ctx, "dokku_plugin[name=redis]")
 
 	if !strings.Contains(out, "dokku_plugin") {
 		t.Errorf("expected the global task; got:\n%s", out)
@@ -125,6 +131,7 @@ func TestExportResourceGlobalScope(t *testing.T) {
 // TestParseResourceSelectorsRejectsBadAddresses covers the validation that
 // runs before the export contacts the server, so a typo fails instantly.
 func TestParseResourceSelectorsRejectsBadAddresses(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name    string
 		address string
@@ -166,6 +173,7 @@ func TestParseResourceSelectorsRejectsBadAddresses(t *testing.T) {
 // TestParseResourceSelectorsAcceptsValidAddresses is the positive half: every
 // exportable form parses, including a bare type key and a global scope.
 func TestParseResourceSelectorsAcceptsValidAddresses(t *testing.T) {
+	t.Parallel()
 	selectors, err := ParseResourceSelectors([]string{
 		"dokku_config",
 		"dokku_config[app=api]",
@@ -190,9 +198,10 @@ func TestParseResourceSelectorsAcceptsValidAddresses(t *testing.T) {
 // auto-named. If two tasks in a play resolved to the same generated name and
 // nothing disambiguated them, the loader would reject its own export.
 func TestExportedRecipeLoadsWithoutNameCollisions(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -29,6 +29,7 @@ func exportFixture() map[string]string {
 }
 
 func TestAppExportOrderIsValid(t *testing.T) {
+	t.Parallel()
 	for _, key := range appExportOrder {
 		proto, ok := RegisteredTasks[key]
 		if !ok {
@@ -42,6 +43,7 @@ func TestAppExportOrderIsValid(t *testing.T) {
 }
 
 func TestGlobalExportOrderIsValid(t *testing.T) {
+	t.Parallel()
 	for _, key := range globalExportOrder {
 		proto, ok := RegisteredTasks[key]
 		if !ok {
@@ -55,16 +57,17 @@ func TestGlobalExportOrderIsValid(t *testing.T) {
 }
 
 func TestExportPluginsBecomeTasks(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet plugin:list --format json": `[
 			{"name":"00_dokku-standard","core":true,"source_url":"","committish":"","branch":""},
 			{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"c0ffee1234","branch":"master"},
 			{"name":"acl","core":false,"source_url":"https://github.com/dokku/dokku-acl.git","committish":"def4567890abcdef","branch":""},
 			{"name":"tarball-plugin","core":false,"source_url":"","committish":"","branch":""}
 		]`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -115,9 +118,10 @@ func TestExportPluginsBecomeTasks(t *testing.T) {
 }
 
 func TestExportRecipeFileMode(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -187,9 +191,10 @@ func httpAuthExportFixture(users, entries string) map[string]string {
 // operator-supplied password. The hash is still credential material, so it
 // lands in the vars-file behind a sensitive input rather than in the recipe.
 func TestExportHttpAuthUserHashesBecomeVars(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))
 
-	bodies, err := HttpAuthUserTask{}.ExportApp(testCtx(), "web")
+	bodies, err := HttpAuthUserTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -210,11 +215,11 @@ func TestExportHttpAuthUserHashesBecomeVars(t *testing.T) {
 	if err := users.Validate(); err != nil {
 		t.Errorf("exported task must be valid, got: %v", err)
 	}
-	if plan := users.Plan(testCtx()); !plan.InSync {
+	if plan := users.Plan(ctx); !plan.InSync {
 		t.Errorf("re-planning the exported task should report no drift, got status %v reason %q", plan.Status, plan.Reason)
 	}
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -248,9 +253,10 @@ func TestExportHttpAuthUserHashesBecomeVars(t *testing.T) {
 // TestExportHttpAuthUserRedactBlanksTheVar keeps the redacted pair usable: the
 // recipe still references the input, only the vars-file value is withheld.
 func TestExportHttpAuthUserRedactBlanksTheVar(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Redact: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -268,9 +274,10 @@ func TestExportHttpAuthUserRedactBlanksTheVar(t *testing.T) {
 // table (#428): an app serving http-auth emits dokku_http_auth with state
 // present, after the rest of the family so it is authoritative.
 func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))
 
-	bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
+	bodies, err := HttpAuthTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -291,7 +298,7 @@ func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
 		t.Errorf("exported http-auth task must be valid, got: %v", err)
 	}
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -319,11 +326,12 @@ func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
 // nothing else's enable side effect would restore it and this task is the only
 // thing that carries the state.
 func TestExportHttpAuthEnabledWithoutUsersBecomesTask(t *testing.T) {
+	t.Parallel()
 	// export-users is answered explicitly with nothing, so the "no user task"
 	// assertion below tests the empty htpasswd rather than a missing fixture.
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("", "")))()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthExportFixture("", "")))
 
-	bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
+	bodies, err := HttpAuthTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -337,7 +345,7 @@ func TestExportHttpAuthEnabledWithoutUsersBecomesTask(t *testing.T) {
 		t.Errorf("exported http-auth task must be valid, got: %v", err)
 	}
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -356,6 +364,7 @@ func TestExportHttpAuthEnabledWithoutUsersBecomesTask(t *testing.T) {
 // re-applying those turns auth back on, so the export has to state absent
 // explicitly to undo it.
 func TestExportHttpAuthDisabledWithConfigBecomesAbsentTask(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name   string
 		report string
@@ -365,12 +374,12 @@ func TestExportHttpAuthDisabledWithConfigBecomesAbsentTask(t *testing.T) {
 		{"auth domains remain", `{"enabled":"false","users":"","allowed-ips":"","domains":"web.example.com"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+			ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 				"--quiet apps:list":                  "web",
 				"http-auth:report web --format json": tc.report,
-			}))()
+			}))
 
-			bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
+			bodies, err := HttpAuthTask{}.ExportApp(ctx, "web")
 			if err != nil {
 				t.Fatalf("ExportApp: %v", err)
 			}
@@ -385,7 +394,7 @@ func TestExportHttpAuthDisabledWithConfigBecomesAbsentTask(t *testing.T) {
 				t.Errorf("exported http-auth task must be valid, got: %v", err)
 			}
 
-			res, err := ExportRecipe(testCtx(), ExportOptions{})
+			res, err := ExportRecipe(ctx, ExportOptions{})
 			if err != nil {
 				t.Fatalf("ExportRecipe: %v", err)
 			}
@@ -405,12 +414,13 @@ func TestExportHttpAuthDisabledWithConfigBecomesAbsentTask(t *testing.T) {
 // off and nothing configured is the default for every app on a server, so it
 // must not litter every play with a no-op disable task.
 func TestExportHttpAuthDisabledEmitsNoTask(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                  "web",
 		"http-auth:report web --format json": `{"enabled":"false","users":"","allowed-ips":"","domains":""}`,
-	}))()
+	}))
 
-	bodies, err := HttpAuthTask{}.ExportApp(testCtx(), "web")
+	bodies, err := HttpAuthTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -418,7 +428,7 @@ func TestExportHttpAuthDisabledEmitsNoTask(t *testing.T) {
 		t.Errorf("expected no exported task for an unconfigured app, got %v", bodies)
 	}
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -429,12 +439,13 @@ func TestExportHttpAuthDisabledEmitsNoTask(t *testing.T) {
 }
 
 func TestExportMaintenanceCustomPageBecomesInput(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                    "web",
 		"maintenance:report web --format json": `{"enabled":"false","custom-page-sha256":"7b645f273842a941c68302a4022ed03e219bd8db318ef32a92dddb148a72ef05"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -468,6 +479,7 @@ func TestExportMaintenanceCustomPageBecomesInput(t *testing.T) {
 }
 
 func TestExportMaintenanceCustomPageAbsentEmitsNothing(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name   string
 		report string
@@ -476,12 +488,12 @@ func TestExportMaintenanceCustomPageAbsentEmitsNothing(t *testing.T) {
 		{"key absent (old plugin)", `{"enabled":"false"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+			ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 				"--quiet apps:list":                    "web",
 				"maintenance:report web --format json": tc.report,
-			}))()
+			}))
 
-			res, err := ExportRecipe(testCtx(), ExportOptions{})
+			res, err := ExportRecipe(ctx, ExportOptions{})
 			if err != nil {
 				t.Fatalf("ExportRecipe: %v", err)
 			}
@@ -497,9 +509,10 @@ func TestExportMaintenanceCustomPageAbsentEmitsNothing(t *testing.T) {
 }
 
 func TestExportRecipeRedactBlanksVars(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Redact: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -514,9 +527,10 @@ func TestExportRecipeRedactBlanksVars(t *testing.T) {
 }
 
 func TestExportRecipeInlineKeepsValues(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -534,9 +548,10 @@ func TestExportRecipeInlineKeepsValues(t *testing.T) {
 }
 
 func TestExportRecipeAppFilter(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Apps: []string{"app-two"}})
+	res, err := ExportRecipe(ctx, ExportOptions{Apps: []string{"app-two"}})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -550,16 +565,17 @@ func TestExportRecipeAppFilter(t *testing.T) {
 }
 
 func TestExportGlobalCertBecomesGlobalTask(t *testing.T) {
+	t.Parallel()
 	certPEM := "-----BEGIN CERTIFICATE-----\nMIIFAKECERT\n-----END CERTIFICATE-----"
 	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIIFAKEKEY\n-----END PRIVATE KEY-----"
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "",
 		"--quiet global-cert:report --global --global-cert-enabled": "true",
 		"--quiet global-cert:show crt":                              certPEM,
 		"--quiet global-cert:show key":                              keyPEM,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -596,18 +612,19 @@ func TestExportGlobalCertBecomesGlobalTask(t *testing.T) {
 }
 
 func TestExportInlineRedactBlanksSensitiveScalar(t *testing.T) {
+	t.Parallel()
 	// Regression for #311: inline + redact must blank sensitive scalar fields
 	// (cert/key PEM here) in place, not fall back to the original unredacted body.
 	certPEM := "-----BEGIN CERTIFICATE-----\nMIIFAKECERT\n-----END CERTIFICATE-----"
 	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIIFAKEKEY\n-----END PRIVATE KEY-----"
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "",
 		"--quiet global-cert:report --global --global-cert-enabled": "true",
 		"--quiet global-cert:show crt":                              certPEM,
 		"--quiet global-cert:show key":                              keyPEM,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true, Redact: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true, Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -623,20 +640,21 @@ func TestExportInlineRedactBlanksSensitiveScalar(t *testing.T) {
 }
 
 func TestExportAppCertSkippedWhenLetsencryptActive(t *testing.T) {
+	t.Parallel()
 	// Regression for #337: a letsencrypt-managed app reports ssl-enabled, but its
 	// cert is ephemeral and re-issued by dokku_letsencrypt, so it must not be
 	// pinned as a static dokku_certs task.
 	certPEM := "-----BEGIN CERTIFICATE-----\nMIILEACERT\n-----END CERTIFICATE-----"
 	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIILEAKEY\n-----END PRIVATE KEY-----"
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                      "web",
 		"--quiet certs:report web --ssl-enabled": "true",
 		"--quiet letsencrypt:active web":         "true",
 		"--quiet certs:show web crt":             certPEM,
 		"--quiet certs:show web key":             keyPEM,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -654,18 +672,19 @@ func TestExportAppCertSkippedWhenLetsencryptActive(t *testing.T) {
 }
 
 func TestExportAppCertExportedWhenLetsencryptInactive(t *testing.T) {
+	t.Parallel()
 	// A manual (non-letsencrypt) cert is still exported as dokku_certs.
 	certPEM := "-----BEGIN CERTIFICATE-----\nMIIMANUAL\n-----END CERTIFICATE-----"
 	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIIMANUALKEY\n-----END PRIVATE KEY-----"
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                      "web",
 		"--quiet certs:report web --ssl-enabled": "true",
 		"--quiet letsencrypt:active web":         "false",
 		"--quiet certs:show web crt":             certPEM,
 		"--quiet certs:show web key":             keyPEM,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -680,6 +699,7 @@ func TestExportAppCertExportedWhenLetsencryptInactive(t *testing.T) {
 }
 
 func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
+	t.Parallel()
 	// #334: with maintenance:custom-page-export available, the page HTML is read
 	// back and inlined as content instead of lifted into an input, producing a
 	// valid, self-contained task in both file and stdout modes.
@@ -688,14 +708,14 @@ func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildMaintenancePageTarball: %v", err)
 	}
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                          "web",
 		"maintenance:report web --format json":       `{"enabled":"false","custom-page-sha256":"abc123"}`,
 		"--quiet maintenance:custom-page-export web": string(tarBytes),
-	}))()
+	}))
 
 	// The task ExportApp yields a valid task carrying the real content.
-	bodies, err := MaintenanceCustomPageTask{}.ExportApp(testCtx(), "web")
+	bodies, err := MaintenanceCustomPageTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -711,9 +731,9 @@ func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
 	}
 
 	for _, inline := range []bool{false, true} {
-		res, err := ExportRecipe(testCtx(), ExportOptions{Inline: inline})
+		res, err := ExportRecipe(ctx, ExportOptions{Inline: inline})
 		if err != nil {
-			t.Fatalf("ExportRecipe(testCtx(), inline=%v): %v", inline, err)
+			t.Fatalf("ExportRecipe(ctx, inline=%v): %v", inline, err)
 		}
 		if _, ok := res.Vars["web_maintenance_custom_page"]; ok {
 			t.Errorf("inline=%v: content should be inlined, not lifted into a var", inline)
@@ -734,9 +754,10 @@ func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
 // simply ride along, so `export --output - | apply` reproduces the users with
 // nothing supplied by hand.
 func TestExportHttpAuthUserInlineKeepsTheHash(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -764,9 +785,10 @@ func TestExportHttpAuthUserInlineKeepsTheHash(t *testing.T) {
 // input instead, and the caller is told the values still have to be supplied
 // (#334).
 func TestExportHttpAuthUserInlineRedactLiftsAndWarns(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Inline: true, Redact: true})
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true, Redact: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -798,12 +820,13 @@ func TestExportHttpAuthUserInlineRedactLiftsAndWarns(t *testing.T) {
 }
 
 func TestAppCountExcludesGlobalPlay(t *testing.T) {
+	t.Parallel()
 	// #345: the leading global play is not an app, so AppCount excludes it.
 	responses := exportFixture()
 	responses["--quiet plugin:list --format json"] = `[{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"c0ffee","branch":"master"}]`
-	defer subprocess.SetExecRunner(fakeDokku(responses))()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(responses))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -816,11 +839,12 @@ func TestAppCountExcludesGlobalPlay(t *testing.T) {
 }
 
 func TestExportMissingAppsRecorded(t *testing.T) {
+	t.Parallel()
 	// #346: a nonexistent --app is recorded, not silently dropped, and the
 	// existing app still exports.
-	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Apps: []string{"app-one", "nope"}})
+	res, err := ExportRecipe(ctx, ExportOptions{Apps: []string{"app-one", "nope"}})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -833,14 +857,15 @@ func TestExportMissingAppsRecorded(t *testing.T) {
 }
 
 func TestExportGlobalPropertiesReadsGlobalScope(t *testing.T) {
+	t.Parallel()
 	// #327: exportGlobalProperties reads the --global report and emits the global
 	// form of each set property (both global-only and dual-scope keys), skipping
 	// empty values and per-app-only keys.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet git:report --global --format json": `{"global-deploy-branch":"main","global-archive-max-files":"100","global-keep-git-dir":""}`,
-	}))()
+	}))
 
-	bodies, err := exportGlobalProperties(testCtx(), GitPropertyTask{}, func(property, value string) interface{} {
+	bodies, err := exportGlobalProperties(ctx, GitPropertyTask{}, func(property, value string) interface{} {
 		return GitPropertyTask{Global: true, Property: property, Value: value}
 	})
 	if err != nil {
@@ -870,11 +895,12 @@ func TestExportGlobalPropertiesReadsGlobalScope(t *testing.T) {
 // lifted straight out of the report. The app scope also carries the global and
 // computed variants of a key, and only the bare row is the app's own value.
 func TestExportLetsencryptDynamicPropertiesFromAppReport(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider":"namecheap","dns-provider-NAMECHEAP_API_USER":"deploy-bot","global-dns-provider-NAMECHEAP_API_KEY":"globalkey","computed-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
-	}))()
+	}))
 
-	bodies, err := exportProperties(testCtx(), LetsencryptPropertyTask{}, "web", func(app, property, value string) interface{} {
+	bodies, err := exportProperties(ctx, LetsencryptPropertyTask{}, "web", func(app, property, value string) interface{} {
 		return LetsencryptPropertyTask{App: app, Property: property, Value: value}
 	})
 	if err != nil {
@@ -899,11 +925,12 @@ func TestExportLetsencryptDynamicPropertiesFromAppReport(t *testing.T) {
 }
 
 func TestExportGlobalLetsencryptDynamicProperties(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet letsencrypt:report --global --format json": `{"global-email":"","global-dns-provider":"namecheap","global-dns-provider-NAMECHEAP_API_KEY":"globalkey"}`,
-	}))()
+	}))
 
-	bodies, err := exportGlobalProperties(testCtx(), LetsencryptPropertyTask{}, func(property, value string) interface{} {
+	bodies, err := exportGlobalProperties(ctx, LetsencryptPropertyTask{}, func(property, value string) interface{} {
 		return LetsencryptPropertyTask{Global: true, Property: property, Value: value}
 	})
 	if err != nil {
@@ -932,12 +959,13 @@ func TestExportGlobalLetsencryptDynamicProperties(t *testing.T) {
 // an exported recipe still describes the letsencrypt configuration and only asks
 // the operator for the credential.
 func TestExportGlobalLetsencryptCredentialLiftedAsSensitiveInput(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "",
 		"--quiet letsencrypt:report --global --format json": `{"global-email":"admin@example.com","global-dns-provider":"namecheap","global-dns-provider-NAMECHEAP_API_KEY":"s3cr3tkey"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -970,12 +998,13 @@ func TestExportGlobalLetsencryptCredentialLiftedAsSensitiveInput(t *testing.T) {
 // the credential family is a secret, so a plain property must not turn into a
 // required input the operator has to re-supply on every apply (#451).
 func TestExportLetsencryptBenignPropertyNotLifted(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                            "web",
 		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"tok3n"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -994,14 +1023,15 @@ func TestExportLetsencryptBenignPropertyNotLifted(t *testing.T) {
 }
 
 func TestExportGlobalK3sTokenLiftedAsSensitiveInput(t *testing.T) {
+	t.Parallel()
 	// #327: the scheduler-k3s global token is core bootstrap state and must be
 	// exported - but as a secret, lifted into a sensitive input, never inline.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "",
 		"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken","global-ingress-class":"nginx-ingress"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -1028,14 +1058,15 @@ func TestExportGlobalK3sTokenLiftedAsSensitiveInput(t *testing.T) {
 }
 
 func TestExportGlobalTraefikPasswordLiftedAsSensitiveInput(t *testing.T) {
+	t.Parallel()
 	// #327: the traefik global basic-auth password is also a secret and must be
 	// lifted rather than emitted in cleartext.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "",
 		"--quiet traefik:report --global --format json": `{"global-basic-auth-password":"hunter2"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -1059,12 +1090,13 @@ func TestExportGlobalTraefikPasswordLiftedAsSensitiveInput(t *testing.T) {
 }
 
 func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "",
 		"--quiet global-cert:report --global --global-cert-enabled": "false",
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -1079,13 +1111,14 @@ func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
 }
 
 func TestExportPortsUsesStateSet(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet ports:report web --ports-map": "https:443:5000 http:80:5000",
-	}))()
+	}))
 
 	// state:set replaces the whole mapping list, so re-applying an export
 	// converges an app that has extra mappings rather than adding to them.
-	bodies, err := PortsTask{}.ExportApp(testCtx(), "web")
+	bodies, err := PortsTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -1111,11 +1144,12 @@ func TestExportPortsUsesStateSet(t *testing.T) {
 }
 
 func TestExportPortsEmitsNoTaskWithoutMappings(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet ports:report web --ports-map": "",
-	}))()
+	}))
 
-	bodies, err := PortsTask{}.ExportApp(testCtx(), "web")
+	bodies, err := PortsTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}

--- a/tasks/git_sync_task_test.go
+++ b/tasks/git_sync_task_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGitSyncTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := GitSyncTask{
 		App:    "test-app",
 		Remote: "https://example.com/repo",
@@ -19,14 +20,15 @@ func TestGitSyncTaskInvalidState(t *testing.T) {
 }
 
 func TestGitSyncInSyncOnRemoteAndDeployBranch(t *testing.T) {
+	t.Parallel()
 	// The stored metadata SHA differs from the pinned ref, but the remote and
 	// the persisted deploy-branch match, so the app is in sync.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123def456"}`,
 		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
-	}))()
+	}))
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", Build: true, State: StatePresent}.Plan(testCtx())
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", Build: true, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -36,12 +38,13 @@ func TestGitSyncInSyncOnRemoteAndDeployBranch(t *testing.T) {
 }
 
 func TestGitSyncDriftOnRefChange(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
 		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
-	}))()
+	}))
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "develop", Build: true, State: StatePresent}.Plan(testCtx())
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "develop", Build: true, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -51,22 +54,24 @@ func TestGitSyncDriftOnRefChange(t *testing.T) {
 }
 
 func TestGitSyncDriftOnRemoteChange(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/other.git#abc123"}`,
-	}))()
+	}))
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan(testCtx())
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan(ctx)
 	if plan.InSync {
 		t.Fatal("expected drift when the remote differs")
 	}
 }
 
 func TestGitSyncInSyncWithoutRef(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
-	}))()
+	}))
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", State: StatePresent}.Plan(testCtx())
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -76,13 +81,14 @@ func TestGitSyncInSyncWithoutRef(t *testing.T) {
 }
 
 func TestGitSyncSkipDeployBranchMatchesOnRemote(t *testing.T) {
+	t.Parallel()
 	// With skip_deploy_branch the ref is not persisted, so a matching remote is
 	// treated as in sync rather than re-syncing forever.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
-	}))()
+	}))
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", SkipDeployBranch: true, State: StatePresent}.Plan(testCtx())
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", SkipDeployBranch: true, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -92,23 +98,25 @@ func TestGitSyncSkipDeployBranchMatchesOnRemote(t *testing.T) {
 }
 
 func TestGitSyncDriftWhenNotGitSyncSource(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"apps:report test-app --format json": `{"app-deploy-source":"","app-deploy-source-metadata":""}`,
-	}))()
+	}))
 
-	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan(testCtx())
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan(ctx)
 	if plan.InSync {
 		t.Fatal("expected drift when the app has no git-sync deploy source")
 	}
 }
 
 func TestGitSyncExportUsesDeployBranchAsRef(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123def"}`,
 		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
-	}))()
+	}))
 
-	bodies, err := GitSyncTask{}.ExportApp(testCtx(), "test-app")
+	bodies, err := GitSyncTask{}.ExportApp(ctx, "test-app")
 	if err != nil {
 		t.Fatalf("ExportApp error: %v", err)
 	}

--- a/tasks/http_auth_task_test.go
+++ b/tasks/http_auth_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestHttpAuthTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthTask{App: "test-app", Username: "admin", Password: "secret", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -17,6 +18,7 @@ func TestHttpAuthTaskInvalidState(t *testing.T) {
 }
 
 func TestHttpAuthTaskPresentWithoutUsername(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthTask{App: "test-app", Password: "secret", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -28,6 +30,7 @@ func TestHttpAuthTaskPresentWithoutUsername(t *testing.T) {
 }
 
 func TestHttpAuthTaskPresentWithoutPassword(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthTask{App: "test-app", Username: "admin", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -44,6 +47,7 @@ func TestHttpAuthTaskPresentWithoutPassword(t *testing.T) {
 // what lets the exporter emit an app's auth state without duplicating the
 // password input dokku_http_auth_user already lifts (#428).
 func TestHttpAuthTaskPresentWithoutCredentialsIsValid(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthTask{App: "test-app", State: StatePresent}
 	if err := task.Validate(); err != nil {
 		t.Errorf("credential-free present state should validate, got: %v", err)
@@ -51,11 +55,12 @@ func TestHttpAuthTaskPresentWithoutCredentialsIsValid(t *testing.T) {
 }
 
 func TestHttpAuthTaskEnableOmitsEmptyCredentials(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"http-auth:report test-app --format json": `{"enabled":"false"}`,
-	}))()
+	}))
 
-	plan := HttpAuthTask{App: "test-app", State: StatePresent}.Plan(testCtx())
+	plan := HttpAuthTask{App: "test-app", State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("Plan: %v", plan.Error)
 	}
@@ -70,6 +75,7 @@ func TestHttpAuthTaskEnableOmitsEmptyCredentials(t *testing.T) {
 }
 
 func TestGetTasksHttpAuthTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: enable http auth

--- a/tasks/http_auth_user_task_test.go
+++ b/tasks/http_auth_user_task_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestHttpAuthUserTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin", Password: "secret"}}, State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -22,6 +23,7 @@ func TestHttpAuthUserTaskInvalidState(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskPresentMissingApp(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{Users: []HttpAuthUser{{Username: "admin", Password: "secret"}}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -33,6 +35,7 @@ func TestHttpAuthUserTaskPresentMissingApp(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskAbsentMissingApp(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{State: StateAbsent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -44,6 +47,7 @@ func TestHttpAuthUserTaskAbsentMissingApp(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskPresentEmptyUsers(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{App: "test-app", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -55,6 +59,7 @@ func TestHttpAuthUserTaskPresentEmptyUsers(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskPresentWithoutCredential(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin"}}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -66,6 +71,7 @@ func TestHttpAuthUserTaskPresentWithoutCredential(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskSetWithoutCredential(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin"}}, State: StateSet}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -77,6 +83,7 @@ func TestHttpAuthUserTaskSetWithoutCredential(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskSetEmptyUsers(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{App: "test-app", State: StateSet}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -91,6 +98,7 @@ func TestHttpAuthUserTaskSetEmptyUsers(t *testing.T) {
 // generated parameter table cannot express: the two credential forms dispatch
 // to different dokku commands, so a user carrying both has no defined meaning.
 func TestHttpAuthUserTaskPasswordAndHashAreExclusive(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "admin", Password: "secret", Hash: "$6$abc$def"}},
@@ -105,6 +113,7 @@ func TestHttpAuthUserTaskPasswordAndHashAreExclusive(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskDuplicateUsernameRejected(t *testing.T) {
+	t.Parallel()
 	// Once the credential forms split across import-users and add-user, the
 	// winner for a repeated username would depend on nothing but list order.
 	task := HttpAuthUserTask{
@@ -127,6 +136,7 @@ func TestHttpAuthUserTaskDuplicateUsernameRejected(t *testing.T) {
 // docket frames itself: a colon in the username or a newline in either half
 // would write a corrupt htpasswd through http-auth:import-users.
 func TestHttpAuthUserTaskHashFramingRejected(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		user HttpAuthUser
@@ -165,6 +175,7 @@ func TestHttpAuthUserTaskHashFramingRejected(t *testing.T) {
 // is scoped to the hash form. A password goes on argv, never into the htpasswd
 // stream docket writes, so no recipe that validates today starts failing.
 func TestHttpAuthUserTaskPasswordUsernameColonAllowed(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "ad:min", Password: "secret"}}}
 	if err := task.Validate(); err != nil {
 		t.Errorf("password users should not be subject to the stdin framing guard, got: %v", err)
@@ -172,6 +183,7 @@ func TestHttpAuthUserTaskPasswordUsernameColonAllowed(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskMissingUsername(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Password: "secret"}}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -183,6 +195,7 @@ func TestHttpAuthUserTaskMissingUsername(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskSensitiveValues(t *testing.T) {
+	t.Parallel()
 	task := HttpAuthUserTask{
 		App: "test-app",
 		Users: []HttpAuthUser{
@@ -221,14 +234,15 @@ const (
 // have: because http-auth:export-users reads the stored hash back, a task that
 // already matches the server plans nothing.
 func TestHttpAuthUserTaskHashInSync(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
-		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))
 
 	plan := HttpAuthUserTask{
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -244,15 +258,16 @@ func TestHttpAuthUserTaskHashInSync(t *testing.T) {
 // stored-hash comparison has to win over the update_password arm, or a matching
 // hash user would be re-imported on every run and Changed would never be false.
 func TestHttpAuthUserTaskHashIgnoresUpdatePassword(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
-		"alice:"+aliceHash+"\n", "alice")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\n", "alice")))
 
 	plan := HttpAuthUserTask{
 		App:            "test-app",
 		Users:          []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		UpdatePassword: boolPtr(true),
 		State:          StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -262,14 +277,15 @@ func TestHttpAuthUserTaskHashIgnoresUpdatePassword(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskHashDriftPlansImport(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
-		"alice:"+aliceHash+"\n", "alice")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\n", "alice")))
 
 	plan := HttpAuthUserTask{
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: "$6$rotated$ROTATED"}},
 		State: StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -295,7 +311,8 @@ func TestHttpAuthUserTaskHashDriftPlansImport(t *testing.T) {
 // validates its whole stream before writing, so it runs before any add-user
 // that could otherwise land first and leave a partial apply behind.
 func TestHttpAuthUserTaskMixedPlansImportFirst(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture("", "")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture("", "")))
 
 	plan := HttpAuthUserTask{
 		App: "test-app",
@@ -304,7 +321,7 @@ func TestHttpAuthUserTaskMixedPlansImportFirst(t *testing.T) {
 			{Username: "alice", Hash: aliceHash},
 		},
 		State: StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -327,8 +344,9 @@ func TestHttpAuthUserTaskMixedPlansImportFirst(t *testing.T) {
 // replacement for the membership probe, so a password-only recipe still works
 // against a plugin that predates the command.
 func TestHttpAuthUserTaskPasswordOnlySkipsExportUsers(t *testing.T) {
+	t.Parallel()
 	asked := false
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		joined := strings.Join(in.Args, " ")
 		if strings.Contains(joined, "export-users") {
 			asked = true
@@ -337,13 +355,13 @@ func TestHttpAuthUserTaskPasswordOnlySkipsExportUsers(t *testing.T) {
 			return subprocess.ExecCommandResponse{Stdout: `{"enabled":"true","users":"alice","allowed-ips":"","domains":""}`}, nil
 		}
 		return subprocess.ExecCommandResponse{}, nil
-	})()
+	})
 
 	HttpAuthUserTask{
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Password: "secret"}},
 		State: StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if asked {
 		t.Error("a password-only task must not probe http-auth:export-users")
 	}
@@ -353,8 +371,9 @@ func TestHttpAuthUserTaskPasswordOnlySkipsExportUsers(t *testing.T) {
 // appears in plan output: resolveCommands ignores Stdin, so the only way to see
 // what import-users receives is to read the reader off the exec input.
 func TestHttpAuthUserTaskExecuteStreamsEntries(t *testing.T) {
+	t.Parallel()
 	var payload string
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		joined := strings.Join(in.Args, " ")
 		if strings.Contains(joined, "http-auth:report") {
 			return subprocess.ExecCommandResponse{Stdout: `{"enabled":"true","users":"alice bob","allowed-ips":"","domains":""}`}, nil
@@ -372,7 +391,7 @@ func TestHttpAuthUserTaskExecuteStreamsEntries(t *testing.T) {
 			payload = string(b)
 		}
 		return subprocess.ExecCommandResponse{}, nil
-	})()
+	})
 
 	result := HttpAuthUserTask{
 		App: "test-app",
@@ -382,7 +401,7 @@ func TestHttpAuthUserTaskExecuteStreamsEntries(t *testing.T) {
 			{Username: "carol", Hash: "$6$cccc$CCCC"},
 		},
 		State: StatePresent,
-	}.Execute(testCtx())
+	}.Execute(ctx)
 	if result.Error != nil {
 		t.Fatalf("Execute: %v", result.Error)
 	}
@@ -394,14 +413,15 @@ func TestHttpAuthUserTaskExecuteStreamsEntries(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskSetAllHashesUsesReplace(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
-		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))
 
 	plan := HttpAuthUserTask{
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StateSet,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -425,8 +445,9 @@ func TestHttpAuthUserTaskSetAllHashesUsesReplace(t *testing.T) {
 // cleartext password cannot be written into the htpasswd stream, so the exact
 // set is reached by removing the strays and upserting instead.
 func TestHttpAuthUserTaskSetWithPasswordAvoidsReplace(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
-		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))
 
 	plan := HttpAuthUserTask{
 		App: "test-app",
@@ -435,7 +456,7 @@ func TestHttpAuthUserTaskSetWithPasswordAvoidsReplace(t *testing.T) {
 			{Username: "carol", Password: "secret"},
 		},
 		State: StateSet,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -456,14 +477,15 @@ func TestHttpAuthUserTaskSetWithPasswordAvoidsReplace(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskSetInSync(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
-		"alice:"+aliceHash+"\n", "alice")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\n", "alice")))
 
 	plan := HttpAuthUserTask{
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StateSet,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -473,13 +495,14 @@ func TestHttpAuthUserTaskSetInSync(t *testing.T) {
 }
 
 func TestHttpAuthUserTaskSetReportsSetState(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture("", "")))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(httpAuthUserFixture("", "")))
 
 	result := HttpAuthUserTask{
 		App:   "test-app",
 		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
 		State: StateSet,
-	}.Execute(testCtx())
+	}.Execute(ctx)
 	if result.Error != nil {
 		t.Fatalf("Execute: %v", result.Error)
 	}
@@ -497,11 +520,12 @@ func TestHttpAuthUserTaskSetReportsSetState(t *testing.T) {
 // this parser lets through lands in a recipe, and a credential-less user would
 // make `docket export` emit a body its own Validate rejects.
 func TestGetHttpAuthUserHashesSkipsMalformedLines(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet http-auth:export-users test-app": "# a comment\n\nalice:" + aliceHash + "\ntruncated:\nnoseparator\nbob:$6$b:b$BB\n",
-	}))()
+	}))
 
-	got, err := getHttpAuthUserHashes(testCtx(), "test-app")
+	got, err := getHttpAuthUserHashes(ctx, "test-app")
 	if err != nil {
 		t.Fatalf("getHttpAuthUserHashes: %v", err)
 	}
@@ -513,6 +537,7 @@ func TestGetHttpAuthUserHashesSkipsMalformedLines(t *testing.T) {
 }
 
 func TestGetTasksHttpAuthUserTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: add http auth users

--- a/tasks/maintenance_custom_page_task_test.go
+++ b/tasks/maintenance_custom_page_task_test.go
@@ -21,17 +21,18 @@ var _ appExportReporter = MaintenanceCustomPageTask{}
 // the dropped-assets notice through the warn callback the engine wires to
 // ExportReport.Warnings, and still captures the maintenance.html content.
 func TestMaintenanceCustomPageExportReportWarnsOnExtraAssets(t *testing.T) {
+	t.Parallel()
 	tarball := tarFromEntries(t, map[string]string{
 		"maintenance.html": maintenanceTestPage,
 		"assets/logo.png":  "PNGDATA",
 	})
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"maintenance:report myapp --format json":       `{"custom-page-sha256":"abc123"}`,
 		"--quiet maintenance:custom-page-export myapp": string(tarball),
-	}))()
+	}))
 
 	var warnings []string
-	bodies, err := MaintenanceCustomPageTask{}.ExportAppReport(testCtx(), "myapp", func(msg string) {
+	bodies, err := MaintenanceCustomPageTask{}.ExportAppReport(ctx, "myapp", func(msg string) {
 		warnings = append(warnings, msg)
 	})
 	if err != nil {
@@ -58,16 +59,17 @@ func TestMaintenanceCustomPageExportReportWarnsOnExtraAssets(t *testing.T) {
 // TestMaintenanceCustomPageExportReportNoExtraAssets pins that a single
 // maintenance.html produces no warning.
 func TestMaintenanceCustomPageExportReportNoExtraAssets(t *testing.T) {
+	t.Parallel()
 	tarball := tarFromEntries(t, map[string]string{
 		"maintenance.html": maintenanceTestPage,
 	})
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"maintenance:report myapp --format json":       `{"custom-page-sha256":"abc123"}`,
 		"--quiet maintenance:custom-page-export myapp": string(tarball),
-	}))()
+	}))
 
 	var warnings []string
-	if _, err := (MaintenanceCustomPageTask{}).ExportAppReport(testCtx(), "myapp", func(msg string) {
+	if _, err := (MaintenanceCustomPageTask{}).ExportAppReport(ctx, "myapp", func(msg string) {
 		warnings = append(warnings, msg)
 	}); err != nil {
 		t.Fatalf("ExportAppReport error: %v", err)
@@ -116,6 +118,7 @@ const (
 )
 
 func TestMaintenanceCustomPageTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -124,6 +127,7 @@ func TestMaintenanceCustomPageTaskInvalidState(t *testing.T) {
 }
 
 func TestMaintenanceCustomPageTaskMissingApp(t *testing.T) {
+	t.Parallel()
 	task := MaintenanceCustomPageTask{Content: maintenanceTestPage, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -135,6 +139,7 @@ func TestMaintenanceCustomPageTaskMissingApp(t *testing.T) {
 }
 
 func TestMaintenanceCustomPageTaskPresentMissingSource(t *testing.T) {
+	t.Parallel()
 	task := MaintenanceCustomPageTask{App: "test-app", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -146,6 +151,7 @@ func TestMaintenanceCustomPageTaskPresentMissingSource(t *testing.T) {
 }
 
 func TestMaintenanceCustomPageTaskPresentBothSources(t *testing.T) {
+	t.Parallel()
 	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, Tarball: "/tmp/page.tar", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -157,6 +163,7 @@ func TestMaintenanceCustomPageTaskPresentBothSources(t *testing.T) {
 }
 
 func TestMaintenanceCustomPageTaskAbsentWithContent(t *testing.T) {
+	t.Parallel()
 	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, State: StateAbsent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -168,6 +175,7 @@ func TestMaintenanceCustomPageTaskAbsentWithContent(t *testing.T) {
 }
 
 func TestMaintenanceCustomPageTaskAbsentWithTarball(t *testing.T) {
+	t.Parallel()
 	task := MaintenanceCustomPageTask{App: "test-app", Tarball: "/tmp/page.tar", State: StateAbsent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -179,6 +187,7 @@ func TestMaintenanceCustomPageTaskAbsentWithTarball(t *testing.T) {
 }
 
 func TestBuildMaintenancePageTarball(t *testing.T) {
+	t.Parallel()
 	out, err := buildMaintenancePageTarball(maintenanceTestPage)
 	if err != nil {
 		t.Fatalf("buildMaintenancePageTarball failed: %v", err)
@@ -209,6 +218,7 @@ func TestBuildMaintenancePageTarball(t *testing.T) {
 }
 
 func TestMaintenanceTarballChecksumSingleFile(t *testing.T) {
+	t.Parallel()
 	tarBytes, err := buildMaintenancePageTarball(maintenanceTestPage)
 	if err != nil {
 		t.Fatalf("buildMaintenancePageTarball failed: %v", err)
@@ -223,6 +233,7 @@ func TestMaintenanceTarballChecksumSingleFile(t *testing.T) {
 }
 
 func TestMaintenanceTarballChecksumMultiFile(t *testing.T) {
+	t.Parallel()
 	tarBytes := tarFromEntries(t, map[string]string{
 		"maintenance.html": maintenanceTestPage,
 		"assets/style.css": maintenanceTestCSS,
@@ -237,6 +248,7 @@ func TestMaintenanceTarballChecksumMultiFile(t *testing.T) {
 }
 
 func TestMaintenanceTarballChecksumDeterministicAndSensitive(t *testing.T) {
+	t.Parallel()
 	a := tarFromEntries(t, map[string]string{"maintenance.html": maintenanceTestPage})
 	b := tarFromEntries(t, map[string]string{"maintenance.html": maintenanceTestPage + "<!-- changed -->"})
 
@@ -264,6 +276,7 @@ func TestMaintenanceTarballChecksumDeterministicAndSensitive(t *testing.T) {
 }
 
 func TestMaintenanceTarballChecksumMissingIndex(t *testing.T) {
+	t.Parallel()
 	tarBytes := tarFromEntries(t, map[string]string{"index.html": maintenanceTestPage})
 	if _, err := maintenanceTarballChecksum(tarBytes); err == nil {
 		t.Fatal("expected error when maintenance.html is absent")
@@ -273,12 +286,14 @@ func TestMaintenanceTarballChecksumMissingIndex(t *testing.T) {
 }
 
 func TestMaintenanceTarballChecksumMalformed(t *testing.T) {
+	t.Parallel()
 	if _, err := maintenanceTarballChecksum([]byte("not a tar archive at all")); err == nil {
 		t.Fatal("expected error for malformed tar bytes")
 	}
 }
 
 func TestGetTasksMaintenanceCustomPageInlineParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set page
@@ -318,6 +333,7 @@ func TestGetTasksMaintenanceCustomPageInlineParsedCorrectly(t *testing.T) {
 }
 
 func TestGetTasksMaintenanceCustomPageTarballParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set page

--- a/tasks/maintenance_task_test.go
+++ b/tasks/maintenance_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestMaintenanceTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := MaintenanceTask{App: "test-app", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -20,14 +21,15 @@ func TestMaintenanceTaskInvalidState(t *testing.T) {
 // forwards an SSH transport failure so planToggle reports it as a plan error
 // rather than spurious drift (#357).
 func TestMaintenanceTaskPlanSurfacesSSHError(t *testing.T) {
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
 			Host:   "dokku@unreachable",
 			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
 		}
-	})()
+	})
 
-	plan := MaintenanceTask{App: "web", State: StatePresent}.Plan(testCtx())
+	plan := MaintenanceTask{App: "web", State: StatePresent}.Plan(ctx)
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}

--- a/tasks/network_task_test.go
+++ b/tasks/network_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNetworkTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := NetworkTask{Name: "test-network", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -17,6 +18,7 @@ func TestNetworkTaskInvalidState(t *testing.T) {
 }
 
 func TestGetTasksNetworkTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: create test network
@@ -65,11 +67,12 @@ const networkListFixture = `[
 ]`
 
 func TestNetworkExportGlobalOnlyDokkuManaged(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet network:list --format json": networkListFixture,
-	}))()
+	}))
 
-	bodies, err := NetworkTask{}.ExportGlobal(testCtx())
+	bodies, err := NetworkTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -95,11 +98,12 @@ func TestNetworkExportGlobalOnlyDokkuManaged(t *testing.T) {
 }
 
 func TestExportNetworksBecomeTasks(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet network:list --format json": networkListFixture,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/ports_task_test.go
+++ b/tasks/ports_task_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestPortsTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := PortsTask{
 		App:          "test-app",
 		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}},
@@ -22,6 +23,7 @@ func TestPortsTaskInvalidState(t *testing.T) {
 }
 
 func TestPortsTaskEmptyPortMappings(t *testing.T) {
+	t.Parallel()
 	task := PortsTask{App: "test-app", PortMappings: []PortMapping{}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -30,6 +32,7 @@ func TestPortsTaskEmptyPortMappings(t *testing.T) {
 }
 
 func TestPortsTaskValidatePerItem(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		task    PortsTask
@@ -149,15 +152,16 @@ func TestPortsTaskValidatePerItem(t *testing.T) {
 const portsReportKey = "--quiet ports:report web --ports-map"
 
 func TestPortsSetPlansFullReplacement(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "http:80:5000 https:443:5000",
-	}))()
+	}))
 
 	plan := PortsTask{
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "http", Host: 8080, Container: 5000}},
 		State:        StateSet,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -181,15 +185,16 @@ func TestPortsSetPlansFullReplacement(t *testing.T) {
 }
 
 func TestPortsSetOnAppWithNoMappingsIsACreate(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "",
-	}))()
+	}))
 
 	plan := PortsTask{
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}},
 		State:        StateSet,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -199,9 +204,10 @@ func TestPortsSetOnAppWithNoMappingsIsACreate(t *testing.T) {
 }
 
 func TestPortsSetConvergesWhenReportMatches(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "https:443:5000 http:80:5000",
-	}))()
+	}))
 
 	plan := PortsTask{
 		App: "web",
@@ -210,7 +216,7 @@ func TestPortsSetConvergesWhenReportMatches(t *testing.T) {
 			{Scheme: "https", Host: 443, Container: 5000},
 		},
 		State: StateSet,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -223,11 +229,12 @@ func TestPortsSetConvergesWhenReportMatches(t *testing.T) {
 }
 
 func TestPortsClearPlansEveryMapping(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "http:80:5000 https:443:5000",
-	}))()
+	}))
 
-	plan := PortsTask{App: "web", State: StateClear}.Plan(testCtx())
+	plan := PortsTask{App: "web", State: StateClear}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -251,11 +258,12 @@ func TestPortsClearPlansEveryMapping(t *testing.T) {
 }
 
 func TestPortsClearIsInSyncWithoutMappings(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "",
-	}))()
+	}))
 
-	plan := PortsTask{App: "web", State: StateClear}.Plan(testCtx())
+	plan := PortsTask{App: "web", State: StateClear}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -268,9 +276,10 @@ func TestPortsClearIsInSyncWithoutMappings(t *testing.T) {
 }
 
 func TestPortsPresentPlansOnlyTheMissingMappings(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "http:80:5000",
-	}))()
+	}))
 
 	plan := PortsTask{
 		App: "web",
@@ -279,7 +288,7 @@ func TestPortsPresentPlansOnlyTheMissingMappings(t *testing.T) {
 			{Scheme: "https", Host: 443, Container: 5000},
 		},
 		State: StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -299,15 +308,16 @@ func TestPortsPresentPlansOnlyTheMissingMappings(t *testing.T) {
 }
 
 func TestPortsPresentRejectsCollisionWithAnExistingMapping(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "http:80:5000",
-	}))()
+	}))
 
 	plan := PortsTask{
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 6000}},
 		State:        StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error == nil {
 		t.Fatal("expected an error when the scheme:host pair is already bound to another container port")
 	}
@@ -320,15 +330,16 @@ func TestPortsPresentRejectsCollisionWithAnExistingMapping(t *testing.T) {
 }
 
 func TestPortsPresentAllowsTheSameHostPortUnderAnotherScheme(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "http:80:5000",
-	}))()
+	}))
 
 	plan := PortsTask{
 		App:          "web",
 		PortMappings: []PortMapping{{Scheme: "https", Host: 80, Container: 5000}},
 		State:        StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -341,9 +352,10 @@ func TestPortsPresentAllowsTheSameHostPortUnderAnotherScheme(t *testing.T) {
 }
 
 func TestPortsAbsentPlansOnlyThePresentMappings(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		portsReportKey: "http:80:5000",
-	}))()
+	}))
 
 	plan := PortsTask{
 		App: "web",
@@ -352,7 +364,7 @@ func TestPortsAbsentPlansOnlyThePresentMappings(t *testing.T) {
 			{Scheme: "https", Host: 443, Container: 5000},
 		},
 		State: StateAbsent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -368,6 +380,7 @@ func TestPortsAbsentPlansOnlyThePresentMappings(t *testing.T) {
 }
 
 func TestPortMappingString(t *testing.T) {
+	t.Parallel()
 	pm := PortMapping{Scheme: "http", Host: 80, Container: 5000}
 	expected := "http:80:5000"
 	if pm.String() != expected {
@@ -376,6 +389,7 @@ func TestPortMappingString(t *testing.T) {
 }
 
 func TestPortMappingStringVariousValues(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		pm   PortMapping
@@ -397,6 +411,7 @@ func TestPortMappingStringVariousValues(t *testing.T) {
 }
 
 func TestGetTasksPortsTaskWithMappings(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set ports
@@ -444,6 +459,7 @@ func TestGetTasksPortsTaskWithMappings(t *testing.T) {
 }
 
 func TestGetTasksPortsTaskClearWithoutMappings(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: clear ports

--- a/tasks/proxy_toggle_task_test.go
+++ b/tasks/proxy_toggle_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestProxyToggleTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := ProxyToggleTask{App: "test-app", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -20,14 +21,15 @@ func TestProxyToggleTaskInvalidState(t *testing.T) {
 // forwards an SSH transport failure so planToggle reports it as a plan error
 // rather than spurious drift (#357).
 func TestProxyToggleTaskPlanSurfacesSSHError(t *testing.T) {
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
 			Host:   "dokku@unreachable",
 			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
 		}
-	})()
+	})
 
-	plan := ProxyToggleTask{App: "web", State: StateAbsent}.Plan(testCtx())
+	plan := ProxyToggleTask{App: "web", State: StateAbsent}.Plan(ctx)
 	if plan.Status != PlanStatusError {
 		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
 	}

--- a/tasks/ps_scale_task_test.go
+++ b/tasks/ps_scale_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestPsScaleTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := PsScaleTask{App: "test-app", Scale: map[string]int{"web": 1}, State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -17,6 +18,7 @@ func TestPsScaleTaskInvalidState(t *testing.T) {
 }
 
 func TestPsScaleTaskEmptyScale(t *testing.T) {
+	t.Parallel()
 	task := PsScaleTask{App: "test-app", Scale: map[string]int{}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -25,6 +27,7 @@ func TestPsScaleTaskEmptyScale(t *testing.T) {
 }
 
 func TestPsScaleTaskNilScale(t *testing.T) {
+	t.Parallel()
 	task := PsScaleTask{App: "test-app", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -33,12 +36,13 @@ func TestPsScaleTaskNilScale(t *testing.T) {
 }
 
 func TestPsScaleCommandDeterministicOrder(t *testing.T) {
+	t.Parallel()
 	// web and worker both drift, so the ps:scale command lists both (appended
 	// after the app) and both mutations are reported. Sorting the process types
 	// must yield byte-identical output on every run (issue #341).
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet ps:scale test-app": "web: 1\nworker: 1",
-	}))()
+	}))
 
 	task := PsScaleTask{
 		App:   "test-app",
@@ -52,7 +56,7 @@ func TestPsScaleCommandDeterministicOrder(t *testing.T) {
 	// Repeat so a reintroduced map-order bug is caught reliably rather than
 	// passing by chance on a lucky iteration.
 	for i := 0; i < 20; i++ {
-		plan := task.Plan(testCtx())
+		plan := task.Plan(ctx)
 		if plan.Error != nil {
 			t.Fatalf("iteration %d: unexpected plan error: %v", i, plan.Error)
 		}
@@ -66,6 +70,7 @@ func TestPsScaleCommandDeterministicOrder(t *testing.T) {
 }
 
 func TestGetTasksPsScaleTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: scale processes

--- a/tasks/resource_limit_task_test.go
+++ b/tasks/resource_limit_task_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestResourceLimitTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := ResourceLimitTask{
 		App:       "test-app",
 		Resources: map[string]string{"cpu": "100"},
@@ -22,6 +23,7 @@ func TestResourceLimitTaskInvalidState(t *testing.T) {
 }
 
 func TestResourceLimitTaskEmptyResources(t *testing.T) {
+	t.Parallel()
 	task := ResourceLimitTask{App: "test-app", Resources: map[string]string{}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -30,6 +32,7 @@ func TestResourceLimitTaskEmptyResources(t *testing.T) {
 }
 
 func TestResourceLimitTaskNilResources(t *testing.T) {
+	t.Parallel()
 	task := ResourceLimitTask{App: "test-app", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -38,16 +41,17 @@ func TestResourceLimitTaskNilResources(t *testing.T) {
 }
 
 func TestResourceLimitClearBeforeConvergesWhenMatched(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet resource:limit test-app": "cpu: 100",
-	}))()
+	}))
 
 	plan := ResourceLimitTask{
 		App:         "test-app",
 		Resources:   map[string]string{"cpu": "100"},
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -57,17 +61,18 @@ func TestResourceLimitClearBeforeConvergesWhenMatched(t *testing.T) {
 }
 
 func TestResourceLimitClearBeforeIgnoresEmptyExtraResource(t *testing.T) {
+	t.Parallel()
 	// memory reads as "0" (unset), so clearing before setting cpu changes nothing.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet resource:limit test-app": "cpu: 100\nmemory: 0",
-	}))()
+	}))
 
 	plan := ResourceLimitTask{
 		App:         "test-app",
 		Resources:   map[string]string{"cpu": "100"},
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -77,17 +82,18 @@ func TestResourceLimitClearBeforeIgnoresEmptyExtraResource(t *testing.T) {
 }
 
 func TestResourceLimitClearBeforeClearsNonDesiredResource(t *testing.T) {
+	t.Parallel()
 	// memory holds a real value outside the desired map, so the clear must run.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet resource:limit test-app": "cpu: 100\nmemory: 256",
-	}))()
+	}))
 
 	plan := ResourceLimitTask{
 		App:         "test-app",
 		Resources:   map[string]string{"cpu": "100"},
 		ClearBefore: boolPtr(true),
 		State:       StatePresent,
-	}.Plan(testCtx())
+	}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -115,12 +121,13 @@ func TestResourceLimitClearBeforeClearsNonDesiredResource(t *testing.T) {
 }
 
 func TestResourceLimitSetCommandDeterministicOrder(t *testing.T) {
+	t.Parallel()
 	// Both cpu and memory drift, so the set command carries both flags and both
 	// mutations are reported. Sorting the resource keys must yield byte-identical,
 	// alphabetical output on every run so plan and apply agree (issue #341).
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet resource:limit test-app": "cpu: 50\nmemory: 256",
-	}))()
+	}))
 
 	task := ResourceLimitTask{
 		App:       "test-app",
@@ -134,7 +141,7 @@ func TestResourceLimitSetCommandDeterministicOrder(t *testing.T) {
 	// Repeat so a reintroduced map-order bug is caught reliably rather than
 	// passing by chance on a lucky iteration.
 	for i := 0; i < 20; i++ {
-		plan := task.Plan(testCtx())
+		plan := task.Plan(ctx)
 		if plan.Error != nil {
 			t.Fatalf("iteration %d: unexpected plan error: %v", i, plan.Error)
 		}
@@ -148,6 +155,7 @@ func TestResourceLimitSetCommandDeterministicOrder(t *testing.T) {
 }
 
 func TestGetTasksResourceLimitTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set resource limits

--- a/tasks/resource_reserve_task_test.go
+++ b/tasks/resource_reserve_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestResourceReserveTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := ResourceReserveTask{
 		App:       "test-app",
 		Resources: map[string]string{"cpu": "100"},
@@ -21,6 +22,7 @@ func TestResourceReserveTaskInvalidState(t *testing.T) {
 }
 
 func TestResourceReserveTaskEmptyResources(t *testing.T) {
+	t.Parallel()
 	task := ResourceReserveTask{App: "test-app", Resources: map[string]string{}, State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -29,6 +31,7 @@ func TestResourceReserveTaskEmptyResources(t *testing.T) {
 }
 
 func TestResourceReserveTaskNilResources(t *testing.T) {
+	t.Parallel()
 	task := ResourceReserveTask{App: "test-app", State: StatePresent}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -37,12 +40,13 @@ func TestResourceReserveTaskNilResources(t *testing.T) {
 }
 
 func TestResourceReserveSetCommandDeterministicOrder(t *testing.T) {
+	t.Parallel()
 	// Both cpu and memory drift, so the set command carries both flags and both
 	// mutations are reported. Sorting the resource keys must yield byte-identical,
 	// alphabetical output on every run so plan and apply agree (issue #341).
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet resource:reserve test-app": "cpu: 50\nmemory: 256",
-	}))()
+	}))
 
 	task := ResourceReserveTask{
 		App:       "test-app",
@@ -56,7 +60,7 @@ func TestResourceReserveSetCommandDeterministicOrder(t *testing.T) {
 	// Repeat so a reintroduced map-order bug is caught reliably rather than
 	// passing by chance on a lucky iteration.
 	for i := 0; i < 20; i++ {
-		plan := task.Plan(testCtx())
+		plan := task.Plan(ctx)
 		if plan.Error != nil {
 			t.Fatalf("iteration %d: unexpected plan error: %v", i, plan.Error)
 		}
@@ -70,6 +74,7 @@ func TestResourceReserveSetCommandDeterministicOrder(t *testing.T) {
 }
 
 func TestGetTasksResourceReserveTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: set resource reservations

--- a/tasks/scheduler_k3s_export_test.go
+++ b/tasks/scheduler_k3s_export_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParseSchedulerK3sAutoscalingAuthReport(t *testing.T) {
+	t.Parallel()
 	t.Run("dot format grouped by trigger", func(t *testing.T) {
 		raw := []byte(`{"datadog.apiKey":"secret-1","datadog.appKey":"secret-2"}`)
 		md, err := parseSchedulerK3sAutoscalingAuthReport(raw, "datadog")
@@ -76,15 +77,16 @@ func annotationScope(bodies []interface{}, processType, resourceType string) *Sc
 }
 
 func TestSchedulerK3sAnnotationsExportApp(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet scheduler-k3s:annotations:report myapp --format json": `{
 			"global.deployment.prometheus.io/scrape":"true",
 			"global.deployment.prometheus.io/port":"9090",
 			"web.ingress.nginx.ingress.kubernetes.io/rewrite-target":"/"
 		}`,
-	}))()
+	}))
 
-	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(testCtx(), "myapp")
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(ctx, "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -122,11 +124,12 @@ func TestSchedulerK3sAnnotationsExportApp(t *testing.T) {
 }
 
 func TestSchedulerK3sAnnotationsExportGlobal(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet scheduler-k3s:annotations:report --global --format json": `{"global.deployment.managed-by":"docket"}`,
-	}))()
+	}))
 
-	bodies, err := SchedulerK3sAnnotationsTask{}.ExportGlobal(testCtx())
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -143,11 +146,12 @@ func TestSchedulerK3sAnnotationsExportGlobal(t *testing.T) {
 }
 
 func TestSchedulerK3sLabelsExportApp(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet scheduler-k3s:labels:report myapp --format json": `{"web.deployment.tier":"edge","web.deployment.app.kubernetes.io/component":"api"}`,
-	}))()
+	}))
 
-	bodies, err := SchedulerK3sLabelsTask{}.ExportApp(testCtx(), "myapp")
+	bodies, err := SchedulerK3sLabelsTask{}.ExportApp(ctx, "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -164,15 +168,16 @@ func TestSchedulerK3sLabelsExportApp(t *testing.T) {
 }
 
 func TestSchedulerK3sAutoscalingAuthExportApp(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet scheduler-k3s:autoscaling-auth:report myapp --format json": `{
 			"datadog.apiKey":"secret-1",
 			"aws-secret-manager.awsRegion":"us-east-1",
 			"aws-secret-manager.secretName":"my-secret"
 		}`,
-	}))()
+	}))
 
-	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp(testCtx(), "myapp")
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp(ctx, "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -199,11 +204,12 @@ func TestSchedulerK3sAutoscalingAuthExportApp(t *testing.T) {
 }
 
 func TestSchedulerK3sAutoscalingAuthExportGlobal(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet scheduler-k3s:autoscaling-auth:report --global --format json": `{"datadog.apiKey":"global-secret"}`,
-	}))()
+	}))
 
-	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportGlobal(testCtx())
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -220,12 +226,13 @@ func TestSchedulerK3sAutoscalingAuthExportGlobal(t *testing.T) {
 }
 
 func TestSchedulerK3sScopedPairsExportEmpty(t *testing.T) {
+	t.Parallel()
 	// An app with no annotations returns "{}"; the exporter yields no bodies.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet scheduler-k3s:annotations:report myapp --format json": `{}`,
-	}))()
+	}))
 
-	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(testCtx(), "myapp")
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(ctx, "myapp")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -238,14 +245,15 @@ func TestSchedulerK3sScopedPairsExportEmpty(t *testing.T) {
 // and labels are emitted inline, while trigger-auth metadata (a secret) is
 // lifted into the vars map and never leaks into the recipe body.
 func TestExportSchedulerK3sScopedAndAuthRecipe(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "web",
 		"--quiet scheduler-k3s:annotations:report web --format json":      `{"global.deployment.prometheus.io/scrape":"true"}`,
 		"--quiet scheduler-k3s:labels:report web --format json":           `{"web.deployment.tier":"edge"}`,
 		"--quiet scheduler-k3s:autoscaling-auth:report web --format json": `{"datadog.apiKey":"s3cr3t-key"}`,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -309,10 +317,11 @@ func schedulerK3sProfileExportFixture() map[string]string {
 // out, and the profiles that survive carry an explicit state so the body is
 // plannable straight out of the exporter.
 func TestSchedulerK3sProfileExportReportLeavesOutUnappliableProfiles(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(schedulerK3sProfileExportFixture()))
 
 	var warnings []string
-	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(testCtx(), func(msg string) {
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobalReport(ctx, func(msg string) {
 		warnings = append(warnings, msg)
 	})
 	if err != nil {
@@ -360,9 +369,10 @@ func TestSchedulerK3sProfileExportReportLeavesOutUnappliableProfiles(t *testing.
 // plain GlobalExporter form leaves out the same profiles; it only discards the
 // explanation, which is why the engine prefers ExportGlobalReport.
 func TestSchedulerK3sProfileExportGlobalDropsWithoutDiagnostics(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(schedulerK3sProfileExportFixture()))
 
-	bodies, err := SchedulerK3sProfileTask{}.ExportGlobal(testCtx())
+	bodies, err := SchedulerK3sProfileTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -378,9 +388,10 @@ func TestSchedulerK3sProfileExportGlobalDropsWithoutDiagnostics(t *testing.T) {
 // engine: the warnings reach ExportReport.Warnings under the global prefix, and
 // the recipe that comes back carries only the profile that can be applied.
 func TestExportSchedulerK3sProfileRecipeOmitsUnappliableProfiles(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(schedulerK3sProfileExportFixture()))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -420,13 +431,14 @@ func TestExportSchedulerK3sProfileRecipeOmitsUnappliableProfiles(t *testing.T) {
 // so export reports it as missing and the command exits non-zero. The warning
 // printed above it is what says the profile is on the server but unexportable.
 func TestExportSchedulerK3sProfileResourceAddressReportsAMissingProfile(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(schedulerK3sProfileExportFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(schedulerK3sProfileExportFixture()))
 
 	selectors, err := ParseResourceSelectors([]string{"dokku_scheduler_k3s_profile[name=EdgePool]"})
 	if err != nil {
 		t.Fatalf("ParseResourceSelectors: %v", err)
 	}
-	res, err := ExportRecipe(testCtx(), ExportOptions{Resources: selectors})
+	res, err := ExportRecipe(ctx, ExportOptions{Resources: selectors})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/service_export_test.go
+++ b/tasks/service_export_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 func TestListServicesParsesTypeAndName(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		// well-formed lines, plus blank/malformed ones that must be dropped
 		"--quiet plugin:trigger service-list": "redis:cache\npostgres:my-db\npostgres:analytics\n\nmalformed-line\n:bad\nbad:",
-	}))()
+	}))
 
-	services, err := listServices(testCtx())
+	services, err := listServices(ctx)
 	if err != nil {
 		t.Fatalf("listServices: %v", err)
 	}
@@ -31,13 +32,14 @@ func TestListServicesParsesTypeAndName(t *testing.T) {
 }
 
 func TestExportServiceCreateEnumeratesInstances(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet plugin:trigger service-list":   "postgres:my-db\nredis:cache",
 		"--quiet postgres:info my-db --version": "postgis/postgis:13-master",
 		"--quiet redis:info cache --version":    "redis:7.2.5",
-	}))()
+	}))
 
-	bodies, err := ServiceCreateTask{}.ExportGlobal(testCtx())
+	bodies, err := ServiceCreateTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -69,11 +71,12 @@ func TestExportServiceCreateEnumeratesInstances(t *testing.T) {
 // is gone: dokku prints nothing for --version, and the export must leave both
 // image fields empty rather than emitting a half-formed pin.
 func TestExportServiceCreateOmitsUnreadableImage(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet plugin:trigger service-list": "redis:cache",
-	}))()
+	}))
 
-	bodies, err := ServiceCreateTask{}.ExportGlobal(testCtx())
+	bodies, err := ServiceCreateTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -87,6 +90,7 @@ func TestExportServiceCreateOmitsUnreadableImage(t *testing.T) {
 }
 
 func TestSplitImageRef(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		ref         string
 		wantImage   string
@@ -117,6 +121,7 @@ func TestSplitImageRef(t *testing.T) {
 }
 
 func TestServiceExposedPortListParsesHostSide(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		stdout string
@@ -131,10 +136,10 @@ func TestServiceExposedPortListParsesHostSide(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+			ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 				"--quiet postgres:info svc --exposed-ports": tc.stdout,
-			}))()
-			got, err := serviceExposedPortList(testCtx(), "postgres", "svc")
+			}))
+			got, err := serviceExposedPortList(ctx, "postgres", "svc")
 			if err != nil {
 				t.Fatalf("serviceExposedPortList: %v", err)
 			}
@@ -146,13 +151,14 @@ func TestServiceExposedPortListParsesHostSide(t *testing.T) {
 }
 
 func TestExportServiceExposeReadsHostPorts(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet plugin:trigger service-list":         "postgres:my-db\nredis:cache",
 		"--quiet postgres:info my-db --exposed-ports": "5432->5433",
 		"--quiet redis:info cache --exposed-ports":    "-",
-	}))()
+	}))
 
-	bodies, err := ServiceExposeTask{}.ExportGlobal(testCtx())
+	bodies, err := ServiceExposeTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -169,6 +175,7 @@ func TestExportServiceExposeReadsHostPorts(t *testing.T) {
 }
 
 func TestParseBackupSchedule(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		content  string
@@ -196,13 +203,14 @@ func TestParseBackupSchedule(t *testing.T) {
 }
 
 func TestExportServiceBackupParsesSchedule(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet plugin:trigger service-list":        "postgres:my-db\nredis:cache",
 		"--quiet postgres:backup-schedule-cat my-db": "0 3 * * * dokku /usr/bin/dokku postgres:backup my-db my-bucket --use-iam",
 		// redis has no schedule: unmapped -> empty content -> parse fails -> skipped
-	}))()
+	}))
 
-	bodies, err := ServiceBackupTask{}.ExportGlobal(testCtx())
+	bodies, err := ServiceBackupTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -223,13 +231,14 @@ func TestExportServiceBackupParsesSchedule(t *testing.T) {
 }
 
 func TestExportServiceLinkEnumeratesForApp(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet plugin:trigger service-list": "postgres:my-db\nredis:cache",
 		"--quiet postgres:links my-db":        "web\nworker",
 		"--quiet redis:links cache":           "worker",
-	}))()
+	}))
 
-	bodies, err := ServiceLinkTask{}.ExportApp(testCtx(), "web")
+	bodies, err := ServiceLinkTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -241,7 +250,7 @@ func TestExportServiceLinkEnumeratesForApp(t *testing.T) {
 		t.Errorf("unexpected link task: %+v", l)
 	}
 
-	bodies, err = ServiceLinkTask{}.ExportApp(testCtx(), "worker")
+	bodies, err = ServiceLinkTask{}.ExportApp(ctx, "worker")
 	if err != nil {
 		t.Fatalf("ExportApp worker: %v", err)
 	}
@@ -251,6 +260,7 @@ func TestExportServiceLinkEnumeratesForApp(t *testing.T) {
 }
 
 func TestExportAclServiceReadsUsers(t *testing.T) {
+	t.Parallel()
 	responses := map[string]string{
 		"--quiet plugin:trigger service-list": "postgres:my-db\nredis:cache",
 	}
@@ -259,12 +269,12 @@ func TestExportAclServiceReadsUsers(t *testing.T) {
 		"--quiet acl:list-service postgres my-db": "bob\nalice",
 		"--quiet acl:list-service redis cache":    "",
 	}
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		key := strings.Join(in.Args, " ")
 		return subprocess.ExecCommandResponse{Stdout: responses[key], Stderr: stderr[key]}, nil
-	})()
+	})
 
-	bodies, err := AclServiceTask{}.ExportGlobal(testCtx())
+	bodies, err := AclServiceTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal: %v", err)
 	}
@@ -283,16 +293,17 @@ func TestExportAclServiceReadsUsers(t *testing.T) {
 }
 
 func TestExportConfigExcludesLinkedServiceDSNs(t *testing.T) {
+	t.Parallel()
 	dsn := "postgres://postgres:pw@dokku-postgres-my-db:5432/my_db"
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                       "web",
 		"--quiet config:export --format json web": `{"DATABASE_URL":"` + dsn + `","SECRET_KEY":"s3cr3t"}`,
 		"--quiet plugin:trigger service-list":     "postgres:my-db",
 		"--quiet postgres:links my-db":            "web",
 		"--quiet postgres:info my-db --dsn":       dsn,
-	}))()
+	}))
 
-	bodies, err := ConfigTask{}.ExportApp(testCtx(), "web")
+	bodies, err := ConfigTask{}.ExportApp(ctx, "web")
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -309,7 +320,8 @@ func TestExportConfigExcludesLinkedServiceDSNs(t *testing.T) {
 }
 
 func TestExportRecipeIncludesServiceTasks(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list":                           "web",
 		"--quiet config:export --format json web":     `{}`,
 		"domains:report web --domains-app-vhosts":     "",
@@ -318,9 +330,9 @@ func TestExportRecipeIncludesServiceTasks(t *testing.T) {
 		"--quiet postgres:links my-db":                "web",
 		"--quiet postgres:info my-db --dsn":           "postgres://postgres:pw@dokku-postgres-my-db:5432/my_db",
 		"--quiet postgres:info my-db --version":       "postgres:17.2",
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{})
+	res, err := ExportRecipe(ctx, ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}

--- a/tasks/service_expose_task_test.go
+++ b/tasks/service_expose_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestServiceExposeTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := ServiceExposeTask{Service: "redis", Name: "test-service", Ports: []string{"6379"}, State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -17,6 +18,7 @@ func TestServiceExposeTaskInvalidState(t *testing.T) {
 }
 
 func TestServiceExposeTaskPresentRequiresPorts(t *testing.T) {
+	t.Parallel()
 	task := ServiceExposeTask{Service: "redis", Name: "test-service"}
 	result := task.Plan(testCtx())
 	if result.Error == nil {
@@ -25,6 +27,7 @@ func TestServiceExposeTaskPresentRequiresPorts(t *testing.T) {
 }
 
 func TestGetTasksServiceExposeTaskParsedCorrectly(t *testing.T) {
+	t.Parallel()
 	data := []byte(`---
 - tasks:
     - name: expose postgres service
@@ -70,11 +73,12 @@ func TestGetTasksServiceExposeTaskParsedCorrectly(t *testing.T) {
 }
 
 func TestServiceExposeSameOrderInSync(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet redis:info my-svc --exposed-ports": "1111->1111 2222->2222",
-	}))()
+	}))
 
-	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan(testCtx())
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -84,11 +88,12 @@ func TestServiceExposeSameOrderInSync(t *testing.T) {
 }
 
 func TestServiceExposeReorderReportsDrift(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet redis:info my-svc --exposed-ports": "1111->1111 2222->2222",
-	}))()
+	}))
 
-	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"2222", "1111"}, State: StatePresent}.Plan(testCtx())
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"2222", "1111"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -117,11 +122,12 @@ func TestServiceExposeReorderReportsDrift(t *testing.T) {
 }
 
 func TestServiceExposeCreatesWhenNotExposed(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet redis:info my-svc --exposed-ports": "",
-	}))()
+	}))
 
-	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan(testCtx())
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}

--- a/tasks/storage_entry_task_test.go
+++ b/tasks/storage_entry_task_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestStorageEntryTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := StorageEntryTask{Name: "test-entry", State: "invalid"}
 	result := task.Execute(testCtx())
 	if result.Error == nil {
@@ -17,6 +18,7 @@ func TestStorageEntryTaskInvalidState(t *testing.T) {
 }
 
 func TestStorageEntryAbsentStateAllowed(t *testing.T) {
+	t.Parallel()
 	// Absent is a valid state, unlike storage_ensure. The task will fail
 	// because dokku isn't reachable, but the failure must not be the
 	// "absent state is not supported" sentinel.
@@ -28,12 +30,14 @@ func TestStorageEntryAbsentStateAllowed(t *testing.T) {
 }
 
 func TestStorageEntryRegistered(t *testing.T) {
+	t.Parallel()
 	if _, ok := RegisteredTasks["dokku_storage_entry"]; !ok {
 		t.Fatal("expected dokku_storage_entry to be registered")
 	}
 }
 
 func TestStorageEntryCreateArgsMinimal(t *testing.T) {
+	t.Parallel()
 	// An omitted scheduler leaves the flag off entirely so dokku applies
 	// its own default rather than docket restating it.
 	task := StorageEntryTask{Name: "app-data", State: StatePresent}
@@ -44,6 +48,7 @@ func TestStorageEntryCreateArgsMinimal(t *testing.T) {
 }
 
 func TestStorageEntryCreateArgsPathIsTrailingPositional(t *testing.T) {
+	t.Parallel()
 	task := StorageEntryTask{
 		Name:      "app-data",
 		Path:      "/mnt/app-data",
@@ -63,6 +68,7 @@ func TestStorageEntryCreateArgsPathIsTrailingPositional(t *testing.T) {
 }
 
 func TestStorageEntryCreateArgsEveryFlag(t *testing.T) {
+	t.Parallel()
 	// The full k3s surface, asserting the fixed flag order plan and apply
 	// both build from.
 	task := StorageEntryTask{
@@ -97,6 +103,7 @@ func TestStorageEntryCreateArgsEveryFlag(t *testing.T) {
 }
 
 func TestStorageEntryCreateArgsRepeatsMapFlagsInSortedOrder(t *testing.T) {
+	t.Parallel()
 	// dokku collects the flag into a map, so docket sorts the keys to keep
 	// plan and apply byte-identical across runs.
 	task := StorageEntryTask{
@@ -124,6 +131,7 @@ func TestStorageEntryCreateArgsRepeatsMapFlagsInSortedOrder(t *testing.T) {
 }
 
 func TestStorageEntryCreateArgsCarriesMode(t *testing.T) {
+	t.Parallel()
 	// --mode sits between --chown and --reclaim-policy, matching dokku's own
 	// flag order, and is rendered in the 4 digit form the registry records so
 	// the create command reads the same as the storage:set a later converge
@@ -146,6 +154,7 @@ func TestStorageEntryCreateArgsCarriesMode(t *testing.T) {
 }
 
 func TestStorageEntryCreateArgsKeepsAFourDigitMode(t *testing.T) {
+	t.Parallel()
 	task := StorageEntryTask{Name: "app-data", Mode: "0777", State: StatePresent}
 	want := []string{"--quiet", "storage:create", "--mode", "0777", "app-data"}
 	if got := task.createArgs(); !equalStrings(got, want) {
@@ -154,6 +163,7 @@ func TestStorageEntryCreateArgsKeepsAFourDigitMode(t *testing.T) {
 }
 
 func TestStorageEntryValidModeValues(t *testing.T) {
+	t.Parallel()
 	// The same shape dokku's directoryModeRegexp accepts: 3 or 4 octal digits.
 	for _, mode := range []string{"000", "755", "777", "0000", "0755", "0777", "2775", "7777"} {
 		task := StorageEntryTask{Name: "app-data", Mode: mode, State: StatePresent}
@@ -164,6 +174,7 @@ func TestStorageEntryValidModeValues(t *testing.T) {
 }
 
 func TestStorageEntryInvalidModeValue(t *testing.T) {
+	t.Parallel()
 	for _, mode := range []string{"8", "99", "12345", "0888", "0o755", "-755", "+755", "07 5", "abc", "0x1ff", "u+rwx"} {
 		task := StorageEntryTask{Name: "app-data", Mode: mode, State: StatePresent}
 		err := task.Validate()
@@ -178,6 +189,7 @@ func TestStorageEntryInvalidModeValue(t *testing.T) {
 }
 
 func TestStorageEntryOmittedModeAllowed(t *testing.T) {
+	t.Parallel()
 	task := StorageEntryTask{Name: "app-data", State: StatePresent}
 	if err := task.Validate(); err != nil {
 		t.Errorf("an omitted mode should be valid, got: %v", err)
@@ -185,6 +197,7 @@ func TestStorageEntryOmittedModeAllowed(t *testing.T) {
 }
 
 func TestStorageEntryValidChownValues(t *testing.T) {
+	t.Parallel()
 	// The same value set dokku_storage_ensure accepts: the entry task now
 	// shares validChown rather than forwarding anything at all.
 	for _, chown := range []string{"heroku", "herokuish", "paketo", "root", "false", "0", "1000", "32767", "65535"} {
@@ -196,6 +209,7 @@ func TestStorageEntryValidChownValues(t *testing.T) {
 }
 
 func TestStorageEntryInvalidChownValue(t *testing.T) {
+	t.Parallel()
 	for _, chown := range []string{"packeto", "65536", "70000", "-1", "+5", "1000:1000", "root:root", "0x10", "1_000", "abc"} {
 		task := StorageEntryTask{Name: "app-data", Chown: chown, State: StatePresent}
 		err := task.Validate()
@@ -210,6 +224,7 @@ func TestStorageEntryInvalidChownValue(t *testing.T) {
 }
 
 func TestStorageEntryOmittedChownAllowed(t *testing.T) {
+	t.Parallel()
 	task := StorageEntryTask{Name: "app-data", State: StatePresent}
 	if err := task.Validate(); err != nil {
 		t.Errorf("an omitted chown should be valid, got: %v", err)
@@ -217,6 +232,7 @@ func TestStorageEntryOmittedChownAllowed(t *testing.T) {
 }
 
 func TestStorageEntryValidateSchedulerRules(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		task    StorageEntryTask
@@ -319,6 +335,7 @@ func TestStorageEntryValidateSchedulerRules(t *testing.T) {
 }
 
 func TestStorageEntryValidateRejectsCreateOptionsWhenAbsent(t *testing.T) {
+	t.Parallel()
 	// storage:destroy takes only the entry name, so a create-time option
 	// alongside state 'absent' would be silently dropped.
 	tests := []struct {
@@ -353,6 +370,7 @@ func TestStorageEntryValidateRejectsCreateOptionsWhenAbsent(t *testing.T) {
 }
 
 func TestStorageEntryValidateAbsentWithOnlyNameIsValid(t *testing.T) {
+	t.Parallel()
 	// The scheduler default must not count as a supplied create-time
 	// option, or every destroy would fail validation.
 	task := StorageEntryTask{Name: "app-data", Scheduler: "docker-local", State: StateAbsent}
@@ -362,6 +380,7 @@ func TestStorageEntryValidateAbsentWithOnlyNameIsValid(t *testing.T) {
 }
 
 func TestStorageEntryValidateRejectsDestroyHostDirWhenPresent(t *testing.T) {
+	t.Parallel()
 	// storage:destroy is the only command that takes the flag, so asking for
 	// it under 'present' asks for a removal that will never happen.
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StatePresent}
@@ -375,6 +394,7 @@ func TestStorageEntryValidateRejectsDestroyHostDirWhenPresent(t *testing.T) {
 }
 
 func TestStorageEntryValidateAcceptsDestroyHostDirWhenAbsent(t *testing.T) {
+	t.Parallel()
 	// It is the one field state 'absent' wants rather than refuses, so it must
 	// not be swept up by the create-time option guard.
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
@@ -384,6 +404,7 @@ func TestStorageEntryValidateAcceptsDestroyHostDirWhenAbsent(t *testing.T) {
 }
 
 func TestStorageEntryValidateMapKeysAndValues(t *testing.T) {
+	t.Parallel()
 	// dokku splits each pair on its first '=' and the flag is comma-split
 	// through a CSV reader before dokku sees it, so neither delimiter can
 	// survive inside a key or value.
@@ -468,6 +489,7 @@ func TestStorageEntryValidateMapKeysAndValues(t *testing.T) {
 }
 
 func TestStorageEntryPlanReportsValidationError(t *testing.T) {
+	t.Parallel()
 	// Validate runs before the probe, so an invalid input never reaches
 	// the server.
 	task := StorageEntryTask{Name: "app-data", Chown: "packeto", State: StatePresent}
@@ -481,9 +503,10 @@ func TestStorageEntryPlanReportsValidationError(t *testing.T) {
 }
 
 func TestStorageEntryPlanCreateCarriesEveryFlag(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet storage:list-entries --format json": `[]`,
-	}))()
+	}))
 
 	task := StorageEntryTask{
 		Name:        "app-data",
@@ -491,7 +514,7 @@ func TestStorageEntryPlanCreateCarriesEveryFlag(t *testing.T) {
 		Annotations: map[string]string{"team": "platform"},
 		State:       StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusCreate {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusCreate, plan.Status)
 	}
@@ -542,9 +565,10 @@ func storageEntriesFixture() map[string]string {
 }
 
 func TestStorageEntryExportGlobal(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(storageEntriesFixture()))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(storageEntriesFixture()))
 
-	exported, err := StorageEntryTask{}.ExportGlobal(testCtx())
+	exported, err := StorageEntryTask{}.ExportGlobal(ctx)
 	if err != nil {
 		t.Fatalf("ExportGlobal returned an error: %v", err)
 	}
@@ -610,7 +634,8 @@ const dockerLocalEntryJSON = `{
 }`
 
 func TestStorageEntryPlanInSyncWhenEveryDeclaredFieldMatches(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))
 
 	task := StorageEntryTask{
 		Name:      "app-data",
@@ -619,7 +644,7 @@ func TestStorageEntryPlanInSyncWhenEveryDeclaredFieldMatches(t *testing.T) {
 		Chown:     "herokuish",
 		State:     StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q reason %q", plan.Status, plan.Reason)
 	}
@@ -629,11 +654,12 @@ func TestStorageEntryPlanInSyncWhenEveryDeclaredFieldMatches(t *testing.T) {
 }
 
 func TestStorageEntryPlanLeavesUndeclaredAttributesAlone(t *testing.T) {
+	t.Parallel()
 	// The recipe names only the fields it manages. A size, namespace and
 	// annotation it never mentions are neither compared nor cleared, which
 	// is what stops a partially-declared recipe from destroying attributes
 	// set elsewhere.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(`{
 		"name": "app-data",
 		"scheduler": "k3s",
 		"size": "2Gi",
@@ -642,7 +668,7 @@ func TestStorageEntryPlanLeavesUndeclaredAttributesAlone(t *testing.T) {
 		"annotations": {"team": "platform"},
 		"labels": {"tier": "data"},
 		"schema_version": 1
-	}`)))()
+	}`)))
 
 	task := StorageEntryTask{
 		Name:      "app-data",
@@ -651,17 +677,18 @@ func TestStorageEntryPlanLeavesUndeclaredAttributesAlone(t *testing.T) {
 		Chown:     "herokuish",
 		State:     StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q reason %q mutations %v", plan.Status, plan.Reason, plan.Mutations)
 	}
 }
 
 func TestStorageEntryPlanConvergesChown(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))
 
 	task := StorageEntryTask{Name: "app-data", Chown: "root", State: StatePresent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusModify, plan.Status)
 	}
@@ -693,10 +720,11 @@ const dockerLocalEntryWithModeJSON = `{
 }`
 
 func TestStorageEntryPlanConvergesMode(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))
 
 	task := StorageEntryTask{Name: "app-data", Mode: "0777", State: StatePresent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
 	}
@@ -711,25 +739,27 @@ func TestStorageEntryPlanConvergesMode(t *testing.T) {
 }
 
 func TestStorageEntryPlanReadsAThreeDigitModeAsItsFourDigitForm(t *testing.T) {
+	t.Parallel()
 	// dokku records 0755 whether the caller wrote 755 or 0755. Comparing the
 	// raw recipe value against the recorded one would report drift on every
 	// run and re-apply a mode that was already correct.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))
 
 	task := StorageEntryTask{Name: "app-data", Mode: "755", State: StatePresent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q mutations %v", plan.Status, plan.Mutations)
 	}
 }
 
 func TestStorageEntryPlanNormalizesAThreeDigitModeItSets(t *testing.T) {
+	t.Parallel()
 	// The other half of the same rule: a drifted three digit mode converges to
 	// the four digit form, so the next run settles rather than looping.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))
 
 	task := StorageEntryTask{Name: "app-data", Mode: "700", State: StatePresent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	want := []string{"dokku --quiet storage:set app-data mode 0700"}
 	if !equalStrings(plan.Commands, want) {
 		t.Errorf("expected commands %v, got %v", want, plan.Commands)
@@ -737,13 +767,14 @@ func TestStorageEntryPlanNormalizesAThreeDigitModeItSets(t *testing.T) {
 }
 
 func TestStorageEntryPlanConvergesChownBeforeMode(t *testing.T) {
+	t.Parallel()
 	// Struct field order, so plan and apply build byte-identical argv across
 	// runs. The k3s ordering test below cannot cover this pair: k3s rejects
 	// mode outright.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryWithModeJSON)))
 
 	task := StorageEntryTask{Name: "app-data", Chown: "root", Mode: "0777", State: StatePresent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	want := []string{
 		"dokku --quiet storage:set app-data chown root",
 		"dokku --quiet storage:set app-data mode 0777",
@@ -757,9 +788,10 @@ func TestStorageEntryPlanConvergesChownBeforeMode(t *testing.T) {
 }
 
 func TestStorageEntryPlanConvergesEveryMutableAttributeInFieldOrder(t *testing.T) {
+	t.Parallel()
 	// One command per drifted field, in struct field order with sorted map
 	// keys, so plan and apply build byte-identical argv across runs.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(`{
 		"name": "app-data",
 		"scheduler": "k3s",
 		"size": "2Gi",
@@ -768,7 +800,7 @@ func TestStorageEntryPlanConvergesEveryMutableAttributeInFieldOrder(t *testing.T
 		"reclaim_policy": "Retain",
 		"annotations": {"team": "infra"},
 		"schema_version": 1
-	}`)))()
+	}`)))
 
 	task := StorageEntryTask{
 		Name:          "app-data",
@@ -781,7 +813,7 @@ func TestStorageEntryPlanConvergesEveryMutableAttributeInFieldOrder(t *testing.T
 		Labels:        map[string]string{"tier": "data"},
 		State:         StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusModify {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusModify, plan.Status, plan.Error)
 	}
@@ -815,23 +847,24 @@ func TestStorageEntryPlanConvergesEveryMutableAttributeInFieldOrder(t *testing.T
 }
 
 func TestStorageEntryPlanConvergesMapKeysWithoutDisturbingSiblings(t *testing.T) {
+	t.Parallel()
 	// The per-key subcommands are what make an omitted key unmanaged; the
 	// wholesale --annotation flag would replace the entire map and drop the
 	// key the recipe does not name.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(`{
 		"name": "app-data",
 		"scheduler": "docker-local",
 		"host_path": "/var/lib/dokku/data/storage/app-data",
 		"annotations": {"team": "platform", "owner": "sre"},
 		"schema_version": 1
-	}`)))()
+	}`)))
 
 	task := StorageEntryTask{
 		Name:        "app-data",
 		Annotations: map[string]string{"team": "data"},
 		State:       StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	want := []string{"dokku --quiet storage:annotations:set app-data team data"}
 	if !equalStrings(plan.Commands, want) {
 		t.Errorf("expected commands %v, got %v", want, plan.Commands)
@@ -844,6 +877,7 @@ func TestStorageEntryPlanConvergesMapKeysWithoutDisturbingSiblings(t *testing.T)
 }
 
 func TestStorageEntryPlanRejectsImmutableDrift(t *testing.T) {
+	t.Parallel()
 	// dokku refuses an access-mode or storage-class swap in place, and has
 	// no command at all for the scheduler or the host path, so the plan
 	// errors rather than reporting a change it could never apply.
@@ -881,10 +915,10 @@ func TestStorageEntryPlanRejectsImmutableDrift(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(test.entry)))()
+			ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(test.entry)))
 
 			test.task.State = StatePresent
-			plan := test.task.Plan(testCtx())
+			plan := test.task.Plan(ctx)
 			if plan.Status != PlanStatusError {
 				t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 			}
@@ -899,15 +933,16 @@ func TestStorageEntryPlanRejectsImmutableDrift(t *testing.T) {
 }
 
 func TestStorageEntryPlanReadsAnOmittedSchedulerAsDockerLocal(t *testing.T) {
+	t.Parallel()
 	// createArgs drops the flag when the scheduler is empty and dokku
 	// applies docker-local, so the comparison has to read it the same way
 	// rather than treating an empty scheduler as unmanaged.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(
 		`{"name": "app-data", "scheduler": "k3s", "size": "2Gi", "schema_version": 1}`,
-	)))()
+	)))
 
 	task := StorageEntryTask{Name: "app-data", State: StatePresent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusError {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 	}
@@ -917,12 +952,13 @@ func TestStorageEntryPlanReadsAnOmittedSchedulerAsDockerLocal(t *testing.T) {
 }
 
 func TestStorageEntryPlanAbsentIgnoresAttributes(t *testing.T) {
+	t.Parallel()
 	// Attributes are rejected by Validate under state 'absent', so the
 	// destroy branch never compares them - it plans on presence alone.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))
 
 	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusDestroy {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusDestroy, plan.Status)
 	}
@@ -933,10 +969,11 @@ func TestStorageEntryPlanAbsentIgnoresAttributes(t *testing.T) {
 }
 
 func TestStorageEntryPlanAbsentDestroysTheHostDirectoryOnRequest(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))
 
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusDestroy {
 		t.Fatalf("expected plan status %q, got %q (error %v)", PlanStatusDestroy, plan.Status, plan.Error)
 	}
@@ -952,19 +989,20 @@ func TestStorageEntryPlanAbsentDestroysTheHostDirectoryOnRequest(t *testing.T) {
 }
 
 func TestStorageEntryPlanAbsentReportsAReclaimDeleteRemoval(t *testing.T) {
+	t.Parallel()
 	// dokku removes the host directory for a Delete entry with no flag at all,
 	// so a plan reporting only what the recipe asked for would stay silent
 	// about a directory that is about to go.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(`{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(`{
 		"name": "app-data",
 		"scheduler": "docker-local",
 		"host_path": "/var/lib/dokku/data/storage/app-data",
 		"reclaim_policy": "Delete",
 		"schema_version": 1
-	}`)))()
+	}`)))
 
 	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	want := []string{"dokku --quiet storage:destroy --force app-data"}
 	if !equalStrings(plan.Commands, want) {
 		t.Errorf("expected commands %v, got %v", want, plan.Commands)
@@ -976,10 +1014,11 @@ func TestStorageEntryPlanAbsentReportsAReclaimDeleteRemoval(t *testing.T) {
 }
 
 func TestStorageEntryPlanAbsentLeavesTheHostDirectoryAloneByDefault(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))()
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(dockerLocalEntryJSON)))
 
 	task := StorageEntryTask{Name: "app-data", State: StateAbsent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	wantMutations := []string{"destroy storage entry app-data"}
 	if !equalStrings(plan.Mutations, wantMutations) {
 		t.Errorf("expected mutations %v, got %v", wantMutations, plan.Mutations)
@@ -987,14 +1026,15 @@ func TestStorageEntryPlanAbsentLeavesTheHostDirectoryAloneByDefault(t *testing.T
 }
 
 func TestStorageEntryPlanAbsentRejectsDestroyHostDirOnANonDockerLocalEntry(t *testing.T) {
+	t.Parallel()
 	// dokku refuses the flag outright there, so the plan says so rather than
 	// letting the apply fail part way through.
-	defer subprocess.SetExecRunner(fakeDokku(singleStorageEntryFixture(
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(singleStorageEntryFixture(
 		`{"name": "app-data", "scheduler": "k3s", "size": "2Gi", "reclaim_policy": "Delete", "schema_version": 1}`,
-	)))()
+	)))
 
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Status != PlanStatusError {
 		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
 	}
@@ -1007,29 +1047,31 @@ func TestStorageEntryPlanAbsentRejectsDestroyHostDirOnANonDockerLocalEntry(t *te
 }
 
 func TestStorageEntryPlanAbsentIgnoresDestroyHostDirWhenTheEntryIsGone(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet storage:list-entries --format json": `[]`,
-	}))()
+	}))
 
 	task := StorageEntryTask{Name: "app-data", DestroyHostDir: true, State: StateAbsent}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if !plan.InSync || plan.Status != PlanStatusOK {
 		t.Fatalf("expected an in-sync plan, got status %q (error %v)", plan.Status, plan.Error)
 	}
 }
 
 func TestStorageEntryExecuteAppliesAttributeDrift(t *testing.T) {
+	t.Parallel()
 	// The apply path runs what the plan rendered, and reports the entry as
 	// still present afterwards rather than newly created.
 	responses := singleStorageEntryFixture(dockerLocalEntryJSON)
 	var dispatched [][]string
-	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		dispatched = append(dispatched, in.Args)
 		return subprocess.ExecCommandResponse{Stdout: responses[strings.Join(in.Args, " ")]}, nil
-	})()
+	})
 
 	task := StorageEntryTask{Name: "app-data", Chown: "root", State: StatePresent}
-	result := task.Execute(testCtx())
+	result := task.Execute(ctx)
 	if result.Error != nil {
 		t.Fatalf("expected the apply to succeed, got: %v", result.Error)
 	}

--- a/tasks/storage_mount_task_test.go
+++ b/tasks/storage_mount_task_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestStorageMountTaskInvalidState(t *testing.T) {
+	t.Parallel()
 	task := StorageMountTask{
 		App:          "test-app",
 		HostDir:      "/host",
@@ -21,6 +22,7 @@ func TestStorageMountTaskInvalidState(t *testing.T) {
 }
 
 func TestStorageMountRequiresExactlyOneSource(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		task StorageMountTask
@@ -51,6 +53,7 @@ func TestStorageMountRequiresExactlyOneSource(t *testing.T) {
 }
 
 func TestStorageMountRejectsInvalidPhase(t *testing.T) {
+	t.Parallel()
 	task := StorageMountTask{
 		App:          "test-app",
 		EntryName:    "data",
@@ -68,6 +71,7 @@ func TestStorageMountRejectsInvalidPhase(t *testing.T) {
 }
 
 func TestStorageMountNamedEntryCommandShape(t *testing.T) {
+	t.Parallel()
 	task := StorageMountTask{
 		App:           "test-app",
 		EntryName:     "data",
@@ -96,6 +100,7 @@ func TestStorageMountNamedEntryCommandShape(t *testing.T) {
 }
 
 func TestStorageMountLegacyFirstMountCommandShape(t *testing.T) {
+	t.Parallel()
 	task := StorageMountTask{
 		App:          "test-app",
 		HostDir:      "/var/data",
@@ -109,6 +114,7 @@ func TestStorageMountLegacyFirstMountCommandShape(t *testing.T) {
 }
 
 func TestStorageMountLegacyFirstMountWithVolumeOptions(t *testing.T) {
+	t.Parallel()
 	task := StorageMountTask{
 		App:           "test-app",
 		HostDir:       "/var/data",
@@ -128,6 +134,7 @@ func TestStorageMountLegacyFirstMountWithVolumeOptions(t *testing.T) {
 }
 
 func TestStorageMountNamedRemediationFromLegacy(t *testing.T) {
+	t.Parallel()
 	// Recipe uses host_dir; storage:report discovered the auto-named
 	// entry. Drift remediation must upsert via the named-entry CLI.
 	task := StorageMountTask{
@@ -148,6 +155,7 @@ func TestStorageMountNamedRemediationFromLegacy(t *testing.T) {
 }
 
 func TestStorageMountNamedRemediationWithOptions(t *testing.T) {
+	t.Parallel()
 	task := StorageMountTask{
 		App:           "test-app",
 		HostDir:       "/var/data",
@@ -166,6 +174,7 @@ func TestStorageMountNamedRemediationWithOptions(t *testing.T) {
 }
 
 func TestStorageMountNamedUnmount(t *testing.T) {
+	t.Parallel()
 	task := StorageMountTask{
 		App:          "test-app",
 		HostDir:      "/var/data",
@@ -183,11 +192,11 @@ func TestStorageMountNamedUnmount(t *testing.T) {
 // without a live server.
 func exportMounts(t *testing.T, app, report string) []StorageMountTask {
 	t.Helper()
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet storage:report " + app + " --format json": report,
-	}))()
+	}))
 
-	bodies, err := StorageMountTask{}.ExportApp(testCtx(), app)
+	bodies, err := StorageMountTask{}.ExportApp(ctx, app)
 	if err != nil {
 		t.Fatalf("ExportApp: %v", err)
 	}
@@ -203,6 +212,7 @@ func exportMounts(t *testing.T, app, report string) []StorageMountTask {
 }
 
 func TestStorageMountExportNamedEntryFullFidelity(t *testing.T) {
+	t.Parallel()
 	report := `{
 		"attachment.1.entry-name": "data",
 		"attachment.1.host-path": "/var/lib/dokku/data/storage/data",
@@ -248,6 +258,7 @@ func TestStorageMountExportNamedEntryFullFidelity(t *testing.T) {
 }
 
 func TestStorageMountExportSinglePhaseAndDefaultProcessType(t *testing.T) {
+	t.Parallel()
 	report := `{
 		"attachment.1.entry-name": "logs",
 		"attachment.1.host-path": "/var/lib/dokku/data/storage/logs",
@@ -276,6 +287,7 @@ func TestStorageMountExportSinglePhaseAndDefaultProcessType(t *testing.T) {
 }
 
 func TestStorageMountExportLegacyEntryUsesHostDir(t *testing.T) {
+	t.Parallel()
 	report := `{
 		"attachment.1.entry-name": "legacy-abc123def4",
 		"attachment.1.host-path": "/var/data",
@@ -296,6 +308,7 @@ func TestStorageMountExportLegacyEntryUsesHostDir(t *testing.T) {
 }
 
 func TestStorageMountExportSortsByContainerPath(t *testing.T) {
+	t.Parallel()
 	// Indices are intentionally out of container-path order to prove the
 	// exporter sorts deterministically rather than trusting report order.
 	report := `{
@@ -319,6 +332,7 @@ func TestStorageMountExportSortsByContainerPath(t *testing.T) {
 }
 
 func TestStorageMountExportRecipeEmitsFields(t *testing.T) {
+	t.Parallel()
 	// End-to-end through ExportRecipe: the reconstructed fields must survive
 	// YAML marshaling in the user-facing recipe (bool readonly, single-phase
 	// list, process_type).
@@ -330,12 +344,12 @@ func TestStorageMountExportRecipeEmitsFields(t *testing.T) {
 		"attachment.1.process-type": "web",
 		"attachment.1.readonly": "true"
 	}`
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet apps:list": "node-js-app",
 		"--quiet storage:report node-js-app --format json": report,
-	}))()
+	}))
 
-	res, err := ExportRecipe(testCtx(), ExportOptions{Apps: []string{"node-js-app"}})
+	res, err := ExportRecipe(ctx, ExportOptions{Apps: []string{"node-js-app"}})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
@@ -362,6 +376,7 @@ func TestStorageMountExportRecipeEmitsFields(t *testing.T) {
 }
 
 func TestStorageMountPlanFindsRunOnlyMount(t *testing.T) {
+	t.Parallel()
 	// storage:list hides run-only mounts (it reports the deploy phase only);
 	// findMount now reads storage:report, so a run-only mount is discovered and
 	// the recipe reports InSync instead of a perpetual create.
@@ -372,9 +387,9 @@ func TestStorageMountPlanFindsRunOnlyMount(t *testing.T) {
 		"attachment.1.phases": "run",
 		"attachment.1.readonly": "false"
 	}`
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet storage:report node-js-app --format json": report,
-	}))()
+	}))
 
 	task := StorageMountTask{
 		App:          "node-js-app",
@@ -383,7 +398,7 @@ func TestStorageMountPlanFindsRunOnlyMount(t *testing.T) {
 		Phases:       []string{"run"},
 		State:        StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("Plan returned error: %v", plan.Error)
 	}
@@ -393,6 +408,7 @@ func TestStorageMountPlanFindsRunOnlyMount(t *testing.T) {
 }
 
 func TestStorageMountPlanVolumeOptionsDriftReportsModify(t *testing.T) {
+	t.Parallel()
 	// An attachment already exists and only volume_options drifted: the plan
 	// remediates it in place, so it must render the modify marker (~), not the
 	// create marker (+). Regression guard for the hardcoded PlanStatusCreate.
@@ -404,9 +420,9 @@ func TestStorageMountPlanVolumeOptionsDriftReportsModify(t *testing.T) {
 		"attachment.1.volume-options": "Z",
 		"attachment.1.readonly": "false"
 	}`
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet storage:report node-js-app --format json": report,
-	}))()
+	}))
 
 	task := StorageMountTask{
 		App:           "node-js-app",
@@ -415,7 +431,7 @@ func TestStorageMountPlanVolumeOptionsDriftReportsModify(t *testing.T) {
 		VolumeOptions: "noexec,nosuid",
 		State:         StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("Plan returned error: %v", plan.Error)
 	}
@@ -431,11 +447,12 @@ func TestStorageMountPlanVolumeOptionsDriftReportsModify(t *testing.T) {
 }
 
 func TestStorageMountPlanMissingReportsCreate(t *testing.T) {
+	t.Parallel()
 	// No attachment matches the recipe, so the mount is brand new and must
 	// render the create marker (+). Pins the default create branch.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
 		"--quiet storage:report node-js-app --format json": "{}",
-	}))()
+	}))
 
 	task := StorageMountTask{
 		App:          "node-js-app",
@@ -443,7 +460,7 @@ func TestStorageMountPlanMissingReportsCreate(t *testing.T) {
 		ContainerDir: "/app/storage",
 		State:        StatePresent,
 	}
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("Plan returned error: %v", plan.Error)
 	}


### PR DESCRIPTION
Twenty-six of the twenty-nine `tasks` unit test files installed their fake executor by swapping a package variable, which is why nothing in this repo could call `t.Parallel()`. They now build the fake into the context they already pass to `Plan` and `Execute`, through `subprocess.ContextWithRunner`, and every test in those files runs in parallel - 149 call sites, 280 tests.

This buys no wall-clock time: the suite is mocked end to end and finishes in about a second either way. What it buys is the `-race` step actually exercising concurrency. Until now every test ran alone, so the detector was watching a serial program and the mutex the package runner grew when the seam moved onto the context was never exercised by anything. It is now, along with the concurrent readers of the mask registry.

The three files left behind are the ones that set the mask registry directly - `properties_test.go`, `service_create_task_test.go` and `scheduler_k3s_autoscaling_auth_task_test.go`. Isolating the registry per test is #501; they keep `SetExecRunner` until then, which is also what keeps that seam alive for the `commands` package.

Two tests needed more than the mechanical change. `exportResource` performs the `ExportRecipe` call for its callers, so it takes their context rather than building its own. And the two context-propagation tests build a context that carries a sentinel or a cancellation, so the runner goes onto that context instead of a fresh one - which is the more honest shape anyway, since the point of both is that the caller's context is the one that reaches the probe.

Verified with `-shuffle=on` across seeds and at `-parallel 32`, both under `-race`.

First of the two passes in #502. The `commands` half needs #501, #505 and #506 first.
