### PR TITLE
feat: let a play target its own host

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -292,12 +292,15 @@ func (c *ApplyCommand) Run(args []string) int {
 			userSet:       userSet,
 			context:       inputCtx,
 			jsonOut:       c.json,
+			target:        target,
 		})
 	}
 
-	if target.Host != "" {
-		defer subprocess.CloseSshControlMaster(target.Host)
-	}
+	// Every distinct host the run will touch, so a recipe whose plays span
+	// servers tears down one ControlMaster per server rather than only the
+	// run-wide one. controlPath already keys on the host, so the sockets do
+	// not collide; nothing was closing the extra ones.
+	defer closeControlMasters(target, plays)
 
 	emitter := c.newEmitter()
 	start := time.Now()
@@ -349,12 +352,19 @@ playLoop:
 			}
 		}
 
-		emitter.PlayStart(play.Name, target.Host)
+		// A play may send its tasks somewhere other than the run-wide
+		// target. Resolving here and deriving a child context is the whole
+		// of the per-play routing: the tasks below read the target off the
+		// context they are handed and need to know nothing about plays.
+		playTarget := play.ResolveTarget(target)
+		playCtx := subprocess.ContextWithTarget(ctx, playTarget)
+
+		emitter.PlayStart(play.Name, playTarget.Host)
 
 		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(inputCtx, play.Inputs, userSet))
 
 		ac := &applyContext{
-			ctx:         ctx,
+			ctx:         playCtx,
 			play:        play,
 			playExprCtx: playExprCtx,
 			registered:  registered,

--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -22,6 +22,11 @@ type listTasksOptions struct {
 	userSet       map[string]bool
 	context       map[string]interface{}
 	jsonOut       bool
+	// target is the run-wide target the plays resolve against, so the
+	// rendered plan can say which server each play would talk to. The JSON
+	// stream is deliberately left alone: it has no play_start event to hang a
+	// host on, and its schema forbids extra properties.
+	target subprocess.Target
 }
 
 // renderListTasks walks the resolved task plan and prints one line per
@@ -109,7 +114,11 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 		}
 
 		if !opts.jsonOut {
-			ui.Output(fmt.Sprintf("==> Play: %s", playName))
+			header := fmt.Sprintf("==> Play: %s", playName)
+			if host := play.ResolveTarget(opts.target).Host; host != "" {
+				header += fmt.Sprintf("  (host: %s)", host)
+			}
+			ui.Output(header)
 		}
 
 		rc := listRenderContext{

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -270,12 +270,15 @@ func (c *PlanCommand) Run(args []string) int {
 			userSet:       userSet,
 			context:       inputCtx,
 			jsonOut:       c.json,
+			target:        target,
 		})
 	}
 
-	if target.Host != "" {
-		defer subprocess.CloseSshControlMaster(target.Host)
-	}
+	// Every distinct host the run will touch, so a recipe whose plays span
+	// servers tears down one ControlMaster per server rather than only the
+	// run-wide one. controlPath already keys on the host, so the sockets do
+	// not collide; nothing was closing the extra ones.
+	defer closeControlMasters(target, plays)
 
 	emitter := c.newEmitter()
 	start := time.Now()
@@ -319,12 +322,19 @@ playLoop:
 			}
 		}
 
-		emitter.PlayStart(play.Name, target.Host)
+		// A play may send its tasks somewhere other than the run-wide
+		// target. Resolving here and deriving a child context is the whole
+		// of the per-play routing: the tasks below read the target off the
+		// context they are handed and need to know nothing about plays.
+		playTarget := play.ResolveTarget(target)
+		playCtx := subprocess.ContextWithTarget(ctx, playTarget)
+
+		emitter.PlayStart(play.Name, playTarget.Host)
 
 		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(inputCtx, play.Inputs, userSet))
 
 		pc := &planContext{
-			ctx:         ctx,
+			ctx:         playCtx,
 			play:        play,
 			playExprCtx: playExprCtx,
 			registered:  registered,

--- a/commands/play_target_test.go
+++ b/commands/play_target_test.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+// runApplyWithTarget drives apply with a recording runner on the context, so
+// the test can see which host each play's tasks were routed to without a
+// server. The stub task does not reach subprocess, so this uses a real task
+// type and lets the runner answer for it.
+func runApplyWithTarget(t *testing.T, path string, args ...string) (map[string][]string, string) {
+	t.Helper()
+	origArgs := os.Args
+	os.Args = []string{"docket-test", "apply", "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	seen := map[string][]string{}
+	ctx := subprocess.ContextWithRunner(context.Background(),
+		func(ctx context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+			host := subprocess.TargetFromContext(ctx).Host
+			seen[host] = append(seen[host], strings.Join(in.Args, " "))
+			return subprocess.ExecCommandResponse{}, nil
+		})
+
+	ui := cli.NewMockUi()
+	c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+	c.Run(append([]string{"--tasks", path}, args...))
+	return seen, ui.OutputWriter.String()
+}
+
+const twoHostRecipe = `---
+- name: local play
+  tasks:
+    - name: first
+      dokku_app: { app: a }
+- name: remote play
+  host: deploy@remote.example.com
+  tasks:
+    - name: second
+      dokku_app: { app: b }
+`
+
+// TestApplyRoutesEachPlayToItsOwnHost is the headline case #500 asks for: one
+// recipe, two servers. Before the target was per-invocation this was not
+// expressible at all.
+func TestApplyRoutesEachPlayToItsOwnHost(t *testing.T) {
+	path := writeTasksFile(t, twoHostRecipe)
+	seen, stdout := runApplyWithTarget(t, path)
+
+	local, remote := seen[""], seen["deploy@remote.example.com"]
+	if len(local) == 0 {
+		t.Error("the play declaring no host should have run against the local target")
+	}
+	if len(remote) == 0 {
+		t.Fatal("the play declaring a host should have run against it")
+	}
+	// The app name is the last argument, so match on that rather than a
+	// substring - "--quiet apps:exists" contains " a" all by itself.
+	for _, args := range local {
+		if strings.HasSuffix(args, " b") {
+			t.Errorf("the remote play's app reached the local target: %q", args)
+		}
+	}
+	for _, args := range remote {
+		if strings.HasSuffix(args, " a") {
+			t.Errorf("the local play's app reached the remote target: %q", args)
+		}
+	}
+	if !strings.Contains(stdout, "(host: deploy@remote.example.com)") {
+		t.Errorf("the play header should name the play's own host; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "local play  (host:") {
+		t.Errorf("a play with no host of its own should not claim one; got:\n%s", stdout)
+	}
+}
+
+// TestApplyPlayHostOverridesTheRunWideFlag pins precedence: the play wins over
+// --host for its own tasks, and the plays that declare nothing still follow
+// the flag.
+func TestApplyPlayHostOverridesTheRunWideFlag(t *testing.T) {
+	path := writeTasksFile(t, twoHostRecipe)
+	seen, _ := runApplyWithTarget(t, path, "--host", "run@cli.example.com")
+
+	if len(seen["run@cli.example.com"]) == 0 {
+		t.Error("the play declaring no host should follow --host")
+	}
+	if len(seen["deploy@remote.example.com"]) == 0 {
+		t.Error("the play declaring a host should override --host")
+	}
+	if _, ok := seen[""]; ok {
+		t.Error("nothing should have run against an empty target")
+	}
+}
+
+// TestApplyPlaySudoInheritsAndDeclines pins the inheritance rule: a play
+// overrides only the keys it names, so --sudo follows a play to its own host
+// unless the play says otherwise. The alternative - a play's `host:` meaning
+// "ignore everything the run was given" - would make a two-server migration
+// restate the run's flags on every play.
+func TestApplyPlaySudoInheritsAndDeclines(t *testing.T) {
+	path := writeTasksFile(t, `---
+- name: inherits
+  host: deploy@one.example.com
+  tasks:
+    - name: a
+      dokku_app: { app: a }
+- name: declines
+  host: deploy@two.example.com
+  sudo: false
+  tasks:
+    - name: b
+      dokku_app: { app: b }
+`)
+
+	origArgs := os.Args
+	os.Args = []string{"docket-test", "apply", "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	sudoByHost := map[string]bool{}
+	ctx := subprocess.ContextWithRunner(context.Background(),
+		func(ctx context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+			target := subprocess.TargetFromContext(ctx)
+			sudoByHost[target.Host] = target.Sudo
+			return subprocess.ExecCommandResponse{}, nil
+		})
+
+	c := &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Ctx: ctx}
+	c.Run([]string{"--tasks", path, "--sudo"})
+
+	if !sudoByHost["deploy@one.example.com"] {
+		t.Error("a play that redirects but says nothing about sudo should keep the run's --sudo")
+	}
+	if sudoByHost["deploy@two.example.com"] {
+		t.Error("`sudo: false` should decline the run's --sudo for that play")
+	}
+}
+
+// TestPlanRoutesEachPlayToItsOwnHost mirrors the apply case: plan probes the
+// server for every task, so it needs the same per-play routing or it would
+// report drift read off the wrong machine.
+func TestPlanRoutesEachPlayToItsOwnHost(t *testing.T) {
+	path := writeTasksFile(t, twoHostRecipe)
+
+	origArgs := os.Args
+	os.Args = []string{"docket-test", "plan", "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	seen := map[string]bool{}
+	ctx := subprocess.ContextWithRunner(context.Background(),
+		func(ctx context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+			seen[subprocess.TargetFromContext(ctx).Host] = true
+			return subprocess.ExecCommandResponse{}, nil
+		})
+
+	ui := cli.NewMockUi()
+	c := &PlanCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+	c.Run([]string{"--tasks", path})
+
+	if !seen[""] || !seen["deploy@remote.example.com"] {
+		t.Errorf("plan should probe both targets; saw %v", seen)
+	}
+	if !strings.Contains(ui.OutputWriter.String(), "(host: deploy@remote.example.com)") {
+		t.Errorf("the plan play header should name the play's host; got:\n%s", ui.OutputWriter.String())
+	}
+}

--- a/commands/ssh_flags.go
+++ b/commands/ssh_flags.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/dokku/docket/subprocess"
+	"github.com/dokku/docket/tasks"
 )
 
 // resolveSshFlags merges the SSH-related CLI flags with their env-var
@@ -49,4 +50,34 @@ func runContext(ctx context.Context) context.Context {
 		return context.Background()
 	}
 	return ctx
+}
+
+// closeControlMasters tears down the multiplexed SSH connection for every host
+// the run could have opened one against: the run-wide target, plus whatever
+// the plays declared for themselves.
+//
+// One per host rather than one per run, because a recipe whose plays span
+// servers opens a master per server. Best-effort, like the underlying call -
+// a host that was never reached has no socket and is skipped there.
+func closeControlMasters(base subprocess.Target, plays []*tasks.Play) {
+	seen := map[string]bool{}
+	for _, host := range append([]string{base.Host}, playHosts(base, plays)...) {
+		if host == "" || seen[host] {
+			continue
+		}
+		seen[host] = true
+		_ = subprocess.CloseSshControlMaster(host)
+	}
+}
+
+// playHosts returns the host each play resolves to against base.
+func playHosts(base subprocess.Target, plays []*tasks.Play) []string {
+	hosts := make([]string, 0, len(plays))
+	for _, play := range plays {
+		if play == nil {
+			continue
+		}
+		hosts = append(hosts, play.ResolveTarget(base).Host)
+	}
+	return hosts
 }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -144,6 +144,7 @@ reworded:
 | `unknown_task_type` | The task-type key is not registered. `hint` carries a did-you-mean. |
 | `unknown_key` | An unrecognized envelope key sits alongside the task-type key. |
 | `envelope_key_type` | An envelope key has the wrong type (for example `tags:` as a string). |
+| `play_key_type` | A play's targeting key has the wrong type or an unusable value (for example `sudo: yes`, which YAML 1.2 reads as a string, or a `host:` that is not `[user@]host[:port]`). |
 | `duplicate_task_name` | Two tasks in one play share a `name`. |
 | `block_shape` | A `block` / `rescue` / `always` clause is not a list of task entries. |
 | `block_empty` | A `block:` clause contains no child tasks. |

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -105,6 +105,9 @@ A play can carry these keys:
 | `name` | A human label for the play, shown in the output. Defaults to `play #N`, except a single-play recipe uses the legacy `tasks` header. |
 | `tags` | A tag list inherited by every task in the play. Combines with per-task `tags`. See [task envelope](task-envelope.md#tags). |
 | `when` | A condition. When it is false, the whole play is skipped. |
+| `host` | The server this play's tasks run against, as `[user@]host[:port]`. Overrides `--host` / `DOKKU_HOST` for this play. See [remote execution](remote-execution.md#a-recipe-that-spans-hosts). |
+| `sudo` | Run this play's `dokku` calls as root. Overrides `--sudo`. |
+| `accept_new_host_keys` | Trust an unknown SSH host key on first connect for this play. Overrides `--accept-new-host-keys`. |
 | `inputs` | Variable defaults for this play. See [inputs](inputs.md). |
 | `tasks` | The play's list of tasks. |
 
@@ -132,6 +135,44 @@ writing more than one play. docket runs the plays top to bottom:
 ```
 
 Single-play recipes keep working unchanged, because a single play is just a one-element list.
+
+### Plays on different servers
+
+A play can name its own `host:`, which is what makes a migration or a fan-out deploy expressible as
+one recipe:
+
+```yaml
+---
+- name: drain the old server
+  host: deploy@old.example.com
+  tasks:
+    - dokku_maintenance: { app: api }
+
+- name: install on the new one
+  host: deploy@new.example.com
+  sudo: true
+  tasks:
+    - dokku_app: { app: api }
+```
+
+A play that names no `host:` runs against `--host` / `DOKKU_HOST` as before, so every recipe written
+without these keys behaves exactly as it did.
+
+The three keys override **individually**, not as a group. A play that sets `host:` and nothing else
+still gets the run's `--sudo` and `--accept-new-host-keys`, which is what lets the example above
+send both plays to servers that need root without repeating the flag. A play that wants the opposite
+says so explicitly:
+
+```yaml
+- name: a server where dokku runs unprivileged
+  host: deploy@other.example.com
+  sudo: false
+  tasks: ...
+```
+
+`docket validate` checks each `host:` offline, so a typo is caught before anything connects rather
+than surfacing as an `ssh:` failure partway through the run. `docket plan --list-tasks` and the play
+headers in `plan` and `apply` all name the host each play resolved to.
 
 ### Running one play with `--play`
 

--- a/docs/remote-execution.md
+++ b/docs/remote-execution.md
@@ -39,6 +39,29 @@ the key yourself:
 ssh-keyscan dokku.example.com >> ~/.ssh/known_hosts
 ```
 
+## A recipe that spans hosts
+
+The flags above set one target for the whole run. A play can name its own instead, which is how a
+migration or a fan-out deploy is written as a single recipe:
+
+```yaml
+---
+- name: drain the old server
+  host: deploy@old.example.com
+  tasks:
+    - dokku_maintenance: { app: api }
+
+- name: install on the new one
+  host: deploy@new.example.com
+  tasks:
+    - dokku_app: { app: api }
+```
+
+Each play opens its own multiplexed SSH connection and docket closes all of them at the end of the
+run. A play that names no `host:` uses the run-wide target, and `sudo` / `accept_new_host_keys`
+carry over to a play that redirects unless it overrides them. See
+[recipes](recipes.md#plays-on-different-servers) for the full rules.
+
 ## Argument quoting
 
 OpenSSH joins the words of a remote command into a single string that the remote login shell

--- a/docs/schemas/events-v1.schema.json
+++ b/docs/schemas/events-v1.schema.json
@@ -59,7 +59,7 @@
         "ts": { "$ref": "#/$defs/timestamp" },
         "host": {
           "type": "string",
-          "description": "Remote target, present only when --host or DOKKU_HOST is in effect."
+          "description": "Remote target this play runs against, present when the play declares host: or when --host / DOKKU_HOST is in effect."
         }
       }
     },

--- a/docs/schemas/validate-v1.schema.json
+++ b/docs/schemas/validate-v1.schema.json
@@ -26,6 +26,7 @@
         "duplicate_task_name",
         "empty_task_body",
         "envelope_key_type",
+        "play_key_type",
         "envelope_key_unsupported",
         "expr_compile",
         "input_missing",

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -90,7 +90,7 @@ func (e *SSHError) Unwrap() error {
 	return e.Err
 }
 
-// sshTarget is the parsed form of DOKKU_HOST.
+// sshTarget is the parsed form of a target host.
 type sshTarget struct {
 	User string
 	Host string
@@ -105,22 +105,30 @@ func (t sshTarget) UserHost() string {
 	return t.User + "@" + t.Host
 }
 
-// parseDokkuHost parses a DOKKU_HOST value of the form `[user@]host[:port]`.
+// parseDokkuHost parses a target host of the form `[user@]host[:port]`, as
+// supplied by DOKKU_HOST, --host, or a play's own `host:` key.
 // We prepend `ssh://` and use net/url so port and IPv6 hosts get parsed
 // correctly. An empty user defaults to $USER (then $LOGNAME, then
 // user.Current); an empty port defaults to "22".
 func parseDokkuHost(raw string) (sshTarget, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return sshTarget{}, errors.New("DOKKU_HOST is empty")
+		return sshTarget{}, errors.New("host is empty")
+	}
+	// A scheme is rejected rather than parsed. The value is joined onto
+	// "ssh://" below, so `ssh://example.com` would become
+	// `ssh://ssh://example.com` and yield the hostname "ssh" - connecting
+	// somewhere the user plainly did not mean, with no error to say so.
+	if strings.Contains(raw, "://") {
+		return sshTarget{}, fmt.Errorf("invalid host %q: remove the scheme, the form is [user@]host[:port]", raw)
 	}
 	u, err := url.Parse("ssh://" + raw)
 	if err != nil {
-		return sshTarget{}, fmt.Errorf("invalid DOKKU_HOST %q: %w", raw, err)
+		return sshTarget{}, fmt.Errorf("invalid host %q: %w", raw, err)
 	}
 	host := u.Hostname()
 	if host == "" {
-		return sshTarget{}, fmt.Errorf("invalid DOKKU_HOST %q: no host", raw)
+		return sshTarget{}, fmt.Errorf("invalid host %q: no hostname", raw)
 	}
 	target := sshTarget{
 		Host: host,
@@ -136,6 +144,15 @@ func parseDokkuHost(raw string) (sshTarget, error) {
 		target.Port = "22"
 	}
 	return target, nil
+}
+
+// ValidateHost reports whether raw is a usable `[user@]host[:port]` target,
+// without contacting anything. It exists so `docket validate` can reject a
+// typo in a play's `host:` offline rather than leaving it to surface as an
+// `ssh:` failure partway through a run.
+func ValidateHost(raw string) error {
+	_, err := parseDokkuHost(raw)
+	return err
 }
 
 func defaultSshUser() string {

--- a/subprocess/target_test.go
+++ b/subprocess/target_test.go
@@ -163,3 +163,35 @@ func TestContextRunnerBeatsThePackageRunner(t *testing.T) {
 		t.Errorf("stdout = %q, want the package runner as the fallback", resp.Stdout)
 	}
 }
+
+func TestValidateHost(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"example.com",
+		"deploy@example.com",
+		"deploy@example.com:2222",
+		"[2001:db8::1]:2222",
+	}
+	for _, raw := range valid {
+		t.Run("valid/"+raw, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateHost(raw); err != nil {
+				t.Errorf("ValidateHost(%q) = %v, want nil", raw, err)
+			}
+		})
+	}
+
+	// An empty host is rejected rather than treated as "run locally": reaching
+	// this function at all means something named a host, and `host: ""` in a
+	// recipe is a mistake rather than a way to opt out.
+	invalid := []string{"", "   ", "deploy@", "ssh://example.com"}
+	for _, raw := range invalid {
+		t.Run("invalid/"+raw, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateHost(raw); err == nil {
+				t.Errorf("ValidateHost(%q) = nil, want an error", raw)
+			}
+		})
+	}
+}

--- a/tasks/format.go
+++ b/tasks/format.go
@@ -12,7 +12,7 @@ import (
 // canonicalPlayKeys is the canonical key order inside a play mapping.
 // Keys not in this list keep their relative order, appended after the
 // canonical keys.
-var canonicalPlayKeys = []string{"name", "tags", "when", "inputs", "tasks"}
+var canonicalPlayKeys = []string{"name", "tags", "when", "host", "sudo", "accept_new_host_keys", "inputs", "tasks"}
 
 // canonicalEnvelopeKeys is the canonical key order inside a task entry's
 // envelope. The task-type key (e.g. dokku_app) sorts after every envelope

--- a/tasks/format_test.go
+++ b/tasks/format_test.go
@@ -390,3 +390,55 @@ func mustParse(t *testing.T, in string) *yaml.Node {
 	}
 	return &n
 }
+
+// TestFormatOrdersTargetingPlayKeys pins where the targeting keys sort. They
+// belong with the play's other metadata rather than trailing after tasks:,
+// which is where fmt left them while they were unknown keys it merely
+// preserved.
+func TestFormatOrdersTargetingPlayKeys(t *testing.T) {
+	input := []byte(`---
+- tasks:
+    - dokku_app: {app: api}
+  accept_new_host_keys: true
+  sudo: true
+  host: deploy@example.com
+  name: remote
+`)
+	out, err := Format(input)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	got := string(out)
+
+	order := []string{"name:", "host:", "sudo:", "accept_new_host_keys:", "tasks:"}
+	for i := 1; i < len(order); i++ {
+		prev, cur := strings.Index(got, order[i-1]), strings.Index(got, order[i])
+		if prev < 0 || cur < 0 {
+			t.Fatalf("expected both %q and %q in output:\n%s", order[i-1], order[i], got)
+		}
+		if prev > cur {
+			t.Errorf("%q should sort before %q:\n%s", order[i-1], order[i], got)
+		}
+	}
+}
+
+// TestFormatTargetingKeysStayValidatable is the tripwire for adding a key to
+// canonicalPlayKeys without adding it to allowedPlayKeys: fmt would reorder a
+// recipe that validate then rejects.
+func TestFormatTargetingKeysStayValidatable(t *testing.T) {
+	input := []byte(`---
+- name: remote
+  host: deploy@example.com
+  sudo: false
+  accept_new_host_keys: true
+  tasks:
+    - dokku_app: {app: api}
+`)
+	out, err := Format(input)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if problems := Validate(out, ValidateOptions{}); len(problems) != 0 {
+		t.Errorf("formatted output should still validate; got %+v", problems)
+	}
+}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -106,6 +106,17 @@ type RecipeEntry struct {
 	// happens in GetPlays).
 	Inputs []Input `yaml:"inputs,omitempty" json:"inputs,omitempty"`
 
+	// Host sends this play's tasks to a server other than the run-wide
+	// --host / DOKKU_HOST target. `[user@]host[:port]`, same spelling as the
+	// flag.
+	Host string `yaml:"host,omitempty" json:"host,omitempty"`
+
+	// Sudo and AcceptNewHostKeys override the run-wide flags of the same
+	// name for this play. Pointers so an omitted key inherits the run's
+	// setting and an explicit false declines it.
+	Sudo              *bool `yaml:"sudo,omitempty" json:"sudo,omitempty"`
+	AcceptNewHostKeys *bool `yaml:"accept_new_host_keys,omitempty" json:"accept_new_host_keys,omitempty"`
+
 	// Tasks is the raw per-play task list, decoded into envelopes by
 	// GetPlays via buildEnvelopesForEntry.
 	Tasks []map[string]interface{} `yaml:"tasks,omitempty" json:"tasks,omitempty"`
@@ -634,9 +645,12 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 		}
 
 		play := &Play{
-			Name:   meta.Name,
-			When:   meta.When,
-			Inputs: meta.Inputs,
+			Name:              meta.Name,
+			When:              meta.When,
+			Inputs:            meta.Inputs,
+			Host:              meta.Host,
+			Sudo:              meta.Sudo,
+			AcceptNewHostKeys: meta.AcceptNewHostKeys,
 		}
 		if play.Name == "" {
 			// Single-play recipes without a name keep the legacy
@@ -753,10 +767,13 @@ func parseRecipeForLoader(data []byte, format string) (*parsedRecipe, error) {
 // play's mapping node. Task entries are parsed separately through the
 // shared structural parser, so this struct deliberately omits `tasks:`.
 type playMeta struct {
-	Name   string      `yaml:"name"`
-	Tags   interface{} `yaml:"tags"`
-	When   string      `yaml:"when"`
-	Inputs []Input     `yaml:"inputs"`
+	Name              string      `yaml:"name"`
+	Tags              interface{} `yaml:"tags"`
+	When              string      `yaml:"when"`
+	Inputs            []Input     `yaml:"inputs"`
+	Host              string      `yaml:"host"`
+	Sudo              *bool       `yaml:"sudo"`
+	AcceptNewHostKeys *bool       `yaml:"accept_new_host_keys"`
 }
 
 // decodePlayMeta decodes a play mapping node's metadata fields.

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/dokku/docket/subprocess"
 	defaults "github.com/mcuadros/go-defaults"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -213,16 +214,19 @@ func parsePlay(play *yaml.Node, index int) *parsedPlay {
 	pp.Name = scalarChild(play, "name")
 
 	for i := 0; i < len(play.Content); i += 2 {
-		key := play.Content[i].Value
+		keyNode, valueNode := play.Content[i], play.Content[i+1]
+		key := keyNode.Value
 		if !allowedPlayKeys[key] {
 			pp.Problems = append(pp.Problems, Problem{
 				Code:    "recipe_shape",
 				Play:    pp.Label,
-				Line:    play.Content[i].Line,
-				Column:  play.Content[i].Column,
+				Line:    keyNode.Line,
+				Column:  keyNode.Column,
 				Message: fmt.Sprintf("unexpected play key %q (expected: %s)", key, allowedPlayKeysList),
 			})
+			continue
 		}
+		pp.Problems = append(pp.Problems, checkPlayKeyValue(pp.Label, key, valueNode)...)
 	}
 
 	flagReservedInputNames(pp, play)
@@ -292,6 +296,50 @@ func flagDuplicateTaskNames(pp *parsedPlay) {
 // collides with a built-in CLI flag (see ReservedInputNames). Such a name
 // used to make pflag panic before flag parsing began; both the loader and
 // the validator now reject it offline (#302).
+// checkPlayKeyValue type-checks the play keys whose value shape the loader
+// would otherwise reject with an opaque `play parse error` from the yaml
+// decoder, with no line or column to point at.
+//
+// Only the targeting keys are checked. `name`, `tags`, `when` and `inputs`
+// predate this and are left as they were rather than changed underneath
+// existing recipes.
+//
+// The bool check is narrower than it looks: yaml.v3 already accepts `yes`,
+// `on` and even a quoted `"yes"` as true, so what it actually catches is
+// `sudo: 1` and the collection forms. The host check is the one that earns
+// its place - a typo there is otherwise a run that fails partway through
+// with an `ssh:` error against a server that was never going to answer.
+func checkPlayKeyValue(label, key string, valueNode *yaml.Node) []Problem {
+	problem := func(msg string) []Problem {
+		return []Problem{{
+			Code:    "play_key_type",
+			Play:    label,
+			Line:    valueNode.Line,
+			Column:  valueNode.Column,
+			Message: msg,
+		}}
+	}
+
+	switch key {
+	case "host":
+		host, ok, typeName := scalarString(valueNode)
+		if !ok {
+			return problem(fmt.Sprintf("host must be a string, got %s", typeName))
+		}
+		// Checked offline so a typo costs a diagnostic rather than a run that
+		// fails partway through with an `ssh:` error.
+		if err := subprocess.ValidateHost(host); err != nil {
+			return problem(fmt.Sprintf("host is not usable: %v", err))
+		}
+	case "sudo", "accept_new_host_keys":
+		var b bool
+		if err := valueNode.Decode(&b); err != nil {
+			return problem(fmt.Sprintf("%s must be a bool, got %s", key, scalarTypeName(valueNode)))
+		}
+	}
+	return nil
+}
+
 func flagReservedInputNames(pp *parsedPlay, play *yaml.Node) {
 	inputsNode := mappingValue(play, "inputs")
 	if inputsNode == nil || inputsNode.Kind != yaml.SequenceNode {

--- a/tasks/play.go
+++ b/tasks/play.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"github.com/dokku/docket/subprocess"
 	"github.com/expr-lang/expr/vm"
 )
 
@@ -37,6 +38,20 @@ type Play struct {
 	// file-level defaults but below --vars-file / CLI overrides.
 	Inputs []Input
 
+	// Host is the server this play's tasks run against, as
+	// [user@]host[:port]. Empty means the play inherits the run-wide target
+	// from --host / DOKKU_HOST, which is what every recipe written before
+	// multi-host plays existed does.
+	Host string
+
+	// Sudo and AcceptNewHostKeys override the run-wide --sudo and
+	// --accept-new-host-keys for this play. They are pointers because unset
+	// and false mean different things here: an omitted key inherits whatever
+	// the run was given, while `sudo: false` actively declines it for this
+	// play alone. See ResolveTarget.
+	Sudo              *bool
+	AcceptNewHostKeys *bool
+
 	// Tasks is the per-play envelope map populated by GetPlays. Insertion
 	// order mirrors the play's tasks: source order.
 	Tasks OrderedStringEnvelopeMap
@@ -44,6 +59,28 @@ type Play struct {
 	// whenProgram is the pre-compiled expr program for When. Set by
 	// GetPlays so the executor does not re-compile per evaluation.
 	whenProgram *vm.Program
+}
+
+// ResolveTarget returns the target this play's tasks run against: base, with
+// each key the play declared overriding it.
+//
+// The override is per key rather than wholesale, so a run given --sudo keeps
+// sudo when a play sends its tasks to a different host. That is the reading
+// that matches the rest of the recipe format - a play's `inputs:` layer over
+// the file's rather than replacing them - and it means a two-server migration
+// does not have to restate the run's flags on every play. A play that wants
+// the opposite says so: `sudo: false` declines it.
+func (p *Play) ResolveTarget(base subprocess.Target) subprocess.Target {
+	if p == nil {
+		return base
+	}
+	out := base
+	if p.Host != "" {
+		out.Host = p.Host
+	}
+	out.Sudo = boolValue(p.Sudo, base.Sudo)
+	out.AcceptNewHostKeys = boolValue(p.AcceptNewHostKeys, base.AcceptNewHostKeys)
+	return out
 }
 
 // HasWhen reports whether the play carries a non-empty `when:` predicate

--- a/tasks/play_test.go
+++ b/tasks/play_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
 
@@ -390,5 +391,109 @@ func TestMergePlayTagsEmptyPlay(t *testing.T) {
 	got := mergePlayTags(in, nil)
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Errorf("got %v, want %v unchanged", got, in)
+	}
+}
+
+// TestGetPlaysTargetingKeysDecode pins that the three targeting keys reach the
+// Play. They are decoded through playMeta rather than RecipeEntry, which is
+// the shape that actually runs, so a field added to one and not the other
+// would silently never arrive.
+func TestGetPlaysTargetingKeysDecode(t *testing.T) {
+	t.Parallel()
+	data := []byte(`---
+- name: remote
+  host: deploy@example.com:2222
+  sudo: true
+  accept_new_host_keys: false
+  tasks:
+    - dokku_app: { app: api }
+`)
+	plays, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	if len(plays) != 1 {
+		t.Fatalf("got %d plays, want 1", len(plays))
+	}
+	play := plays[0]
+	if play.Host != "deploy@example.com:2222" {
+		t.Errorf("Host = %q, want %q", play.Host, "deploy@example.com:2222")
+	}
+	if play.Sudo == nil || !*play.Sudo {
+		t.Errorf("Sudo = %v, want a pointer to true", play.Sudo)
+	}
+	if play.AcceptNewHostKeys == nil || *play.AcceptNewHostKeys {
+		t.Errorf("AcceptNewHostKeys = %v, want a pointer to false", play.AcceptNewHostKeys)
+	}
+}
+
+// TestGetPlaysOmittedTargetingKeysAreNil pins the distinction the pointers
+// exist for: an omitted key is nil, not false, so ResolveTarget can tell
+// "inherit the run's setting" from "decline it".
+func TestGetPlaysOmittedTargetingKeysAreNil(t *testing.T) {
+	t.Parallel()
+	plays, err := GetPlays([]byte("---\n- tasks:\n    - dokku_app: { app: api }\n"), map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	if plays[0].Host != "" || plays[0].Sudo != nil || plays[0].AcceptNewHostKeys != nil {
+		t.Errorf("a play declaring no targeting keys should leave them unset; got %+v", plays[0])
+	}
+}
+
+func TestPlayResolveTarget(t *testing.T) {
+	t.Parallel()
+
+	base := subprocess.Target{Host: "run@base", Sudo: true, AcceptNewHostKeys: true}
+	tests := []struct {
+		name string
+		play *Play
+		want subprocess.Target
+	}{
+		{
+			name: "a play declaring nothing inherits the run's target",
+			play: &Play{},
+			want: base,
+		},
+		{
+			name: "host alone redirects but keeps the run's flags",
+			play: &Play{Host: "play@other"},
+			want: subprocess.Target{Host: "play@other", Sudo: true, AcceptNewHostKeys: true},
+		},
+		{
+			name: "an explicit false declines a flag the run was given",
+			play: &Play{Host: "play@other", Sudo: boolPtr(false)},
+			want: subprocess.Target{Host: "play@other", Sudo: false, AcceptNewHostKeys: true},
+		},
+		{
+			name: "a flag can be asked for without redirecting",
+			play: &Play{Sudo: boolPtr(true)},
+			want: base,
+		},
+		{
+			name: "a nil play is the run's target",
+			play: nil,
+			want: base,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.play.ResolveTarget(base); got != tc.want {
+				t.Errorf("ResolveTarget() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPlayResolveTargetOffALocalRun pins the common case: no --host at all,
+// and a play that names one. The run-wide zero target must not turn the
+// play's own host back off.
+func TestPlayResolveTargetOffALocalRun(t *testing.T) {
+	t.Parallel()
+	got := (&Play{Host: "play@other", Sudo: boolPtr(true)}).ResolveTarget(subprocess.Target{})
+	want := subprocess.Target{Host: "play@other", Sudo: true}
+	if got != want {
+		t.Errorf("ResolveTarget() = %+v, want %+v", got, want)
 	}
 }

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -108,16 +108,19 @@ var groupClauseKeys = []string{"block", "rescue", "always"}
 // admits without flagging as unexpected. #208 extends the legacy
 // inputs/tasks pair with name/tags/when at the play envelope.
 var allowedPlayKeys = map[string]bool{
-	"name":   true,
-	"tags":   true,
-	"when":   true,
-	"inputs": true,
-	"tasks":  true,
+	"name":                 true,
+	"tags":                 true,
+	"when":                 true,
+	"inputs":               true,
+	"host":                 true,
+	"sudo":                 true,
+	"accept_new_host_keys": true,
+	"tasks":                true,
 }
 
 // allowedPlayKeysList is the comma-separated form rendered into the
 // "unexpected play key" diagnostic so users see the full allowlist.
-const allowedPlayKeysList = "name, tags, when, inputs, tasks"
+const allowedPlayKeysList = "name, tags, when, inputs, host, sudo, accept_new_host_keys, tasks"
 
 // Validate parses data as a docket recipe and returns every problem it finds.
 // It is offline by contract: the implementation must never invoke

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -1576,3 +1576,91 @@ func TestBuildSigilContextKeepsUnparseableDefaultText(t *testing.T) {
 		t.Errorf("debug = %#v, want the raw text %q", context["debug"], "mabye")
 	}
 }
+
+// TestValidateAcceptsTargetingPlayKeys pins that the three keys are on the
+// play allowlist. Adding them to canonicalPlayKeys without this would make
+// fmt reorder a recipe validate then rejects.
+func TestValidateAcceptsTargetingPlayKeys(t *testing.T) {
+	data := []byte(`---
+- name: remote
+  host: deploy@example.com:2222
+  sudo: true
+  accept_new_host_keys: true
+  tasks:
+    - dokku_app: { app: api }
+`)
+	problems := Validate(data, ValidateOptions{})
+	if len(problems) != 0 {
+		t.Errorf("targeting keys should validate cleanly; got %+v", problems)
+	}
+}
+
+// TestValidateRejectsUnusableHost pins the offline host check. A typo here
+// otherwise costs a run: it surfaces as an `ssh:` failure partway through,
+// against a server that was never going to answer.
+func TestValidateRejectsUnusableHost(t *testing.T) {
+	cases := map[string]string{
+		"scheme":     "ssh://example.com",
+		"empty":      "",
+		"whitespace": "   ",
+	}
+	for name, host := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := []byte("---\n- host: \"" + host + "\"\n  tasks:\n    - dokku_app: { app: api }\n")
+			problems := Validate(data, ValidateOptions{})
+			p := findProblem(problems, "play_key_type")
+			if p == nil {
+				t.Fatalf("expected a play_key_type problem; got %+v", problems)
+			}
+			if !strings.Contains(p.Message, "host is not usable") {
+				t.Errorf("message = %q, want it to name the host", p.Message)
+			}
+			if p.Line == 0 {
+				t.Error("problem should carry the line the host was declared on")
+			}
+		})
+	}
+}
+
+// TestValidateRejectsNonBoolTargetingFlags pins that the bool keys report a
+// positioned diagnostic rather than the opaque decode error the loader would
+// otherwise produce. yaml.v3 already accepts yes/on/"yes" as true, so what
+// this actually catches is a number or a collection.
+func TestValidateRejectsNonBoolTargetingFlags(t *testing.T) {
+	data := []byte(`---
+- sudo: 1
+  accept_new_host_keys: [a]
+  tasks:
+    - dokku_app: { app: api }
+`)
+	problems := Validate(data, ValidateOptions{})
+	var got []string
+	for _, p := range problems {
+		if p.Code == "play_key_type" {
+			got = append(got, p.Message)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected both bool keys flagged; got %+v", problems)
+	}
+	for _, msg := range got {
+		if !strings.Contains(msg, "must be a bool") {
+			t.Errorf("message = %q, want it to say the key must be a bool", msg)
+		}
+	}
+}
+
+// TestValidateAcceptsYamlBoolSpellings guards the other direction: the check
+// must not reject spellings yaml.v3 itself accepts, or a recipe that used to
+// load would start failing validation.
+func TestValidateAcceptsYamlBoolSpellings(t *testing.T) {
+	for _, spelling := range []string{"true", "yes", "on", `"yes"`} {
+		t.Run(spelling, func(t *testing.T) {
+			data := []byte("---\n- sudo: " + spelling + "\n  tasks:\n    - dokku_app: { app: api }\n")
+			problems := Validate(data, ValidateOptions{})
+			if p := findProblem(problems, "play_key_type"); p != nil {
+				t.Errorf("sudo: %s should be accepted; got %q", spelling, p.Message)
+			}
+		})
+	}
+}

--- a/tests/bats/plays.bats
+++ b/tests/bats/plays.bats
@@ -552,3 +552,112 @@ EOF
   assert_success
   refute_output --partial "[skipped]"
 }
+
+# Per-play targeting tests drive `apply --list-tasks` and `validate`, both of
+# which resolve the play's host and return before contacting anything. That
+# keeps them runnable without a Dokku server, the same reason the when: tests
+# above use --list-tasks.
+
+@test "plays: a play's host: is shown in the resolved plan" {
+  write_tasks_file <<EOF
+---
+- name: local play
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+- name: remote play
+  host: deploy@remote.example.com
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "==> Play: remote play  (host: deploy@remote.example.com)"
+  # The play that names no host of its own must not claim one.
+  assert_output --partial "==> Play: local play"
+  refute_output --partial "local play  (host:"
+}
+
+@test "plays: a play's host: overrides --host" {
+  write_tasks_file <<EOF
+---
+- name: follows the flag
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+- name: names its own
+  host: deploy@remote.example.com
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --host run@cli.example.com
+  assert_success
+  assert_output --partial "==> Play: follows the flag  (host: run@cli.example.com)"
+  assert_output --partial "==> Play: names its own  (host: deploy@remote.example.com)"
+}
+
+@test "plays: targeting keys validate cleanly" {
+  write_tasks_file <<EOF
+---
+- name: remote
+  host: deploy@remote.example.com:2222
+  sudo: true
+  accept_new_host_keys: false
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+}
+
+@test "plays: an unusable host: is rejected offline" {
+  write_tasks_file <<EOF
+---
+- name: typo
+  host: "ssh://remote.example.com"
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  # Caught by validate rather than surfacing as an ssh: failure partway
+  # through a run, which is the point of checking the host offline.
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "host is not usable"
+  assert_output --partial "remove the scheme"
+}
+
+@test "plays: a non-bool sudo: is rejected with a position" {
+  write_tasks_file <<EOF
+---
+- name: bad
+  sudo: 1
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "sudo must be a bool"
+}
+
+@test "plays: fmt sorts the targeting keys with the play metadata" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-noop
+  host: deploy@remote.example.com
+  name: remote
+EOF
+  run "$(docket_bin)" fmt "$TASKS_FILE"
+  assert_success
+  run cat "$TASKS_FILE"
+  assert_success
+  # name, then host, then tasks - not the order they were written in.
+  assert_line --index 1 "- name: remote"
+  assert_line --index 2 "  host: deploy@remote.example.com"
+}


### PR DESCRIPTION
A recipe could not span servers, so a migration or a fan-out deploy - the two things that most obviously want it - had no way to say where each step runs. `--host`, `--sudo` and `--accept-new-host-keys` resolved to one target for the whole run. A play can now declare `host:`, `sudo:` and `accept_new_host_keys:` of its own; the executor resolves each play against the run-wide target and derives a child context, so the tasks below read their target off the context they are handed and know nothing about plays.

The three keys override individually rather than as a group. A play that redirects with `host:` and says nothing else keeps the run's `--sudo`, which is what lets a two-server migration avoid restating the run's flags on every play, and matches how a play's `inputs:` layer over the file's rather than replacing them. A play that wants the opposite writes `sudo: false`. `sudo` and `accept_new_host_keys` are `*bool` for exactly that reason: unset has to mean "inherit" and false has to mean "decline".

`docket validate` checks a play's `host:` offline through the new `subprocess.ValidateHost`, so a typo costs a diagnostic with a line and column rather than a run that fails partway through against a server that was never going to answer. Plays gained no type checking at all before this, so `host: [a, b]` or `sudo: 1` produced an opaque decode error from the loader; both now report `play_key_type` with a position. The bool check is narrower than it looks - yaml.v3 already accepts `yes`, `on` and a quoted `"yes"` as true - so what it catches is a number or a collection.

While adding that check, `parseDokkuHost` turned out to accept `ssh://example.com` and silently resolve it to a host named `ssh`, because the value is joined onto `ssh://` before parsing. That misroutes `DOKKU_HOST` and `--host` today, not just the new key, and a validator that rubber-stamped it would be worse than none, so a scheme is now rejected with a message naming the expected form. Its sibling errors no longer say "DOKKU_HOST" either, since the value now reaches them from three places.

ControlMaster teardown follows: a run closes one master per distinct host rather than only the run-wide one. `controlPath` already keyed on the host, so the extra sockets existed and nothing was closing them.

The `--json` stream needs no schema change - `play_start` already carried an optional `host`, which now names the play's own. `--list-tasks` gained the host on its play header; its JSON stream is deliberately left alone, having no play event to hang one on and a schema that forbids extra properties.

Fixes #500.
