### PR TITLE
fix: make the masking registry per-invocation

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -235,12 +235,15 @@ func (c *ApplyCommand) Run(args []string) int {
 	// parsed and rendered, so a template or parse error that interpolated one
 	// of them is masked. Task-declared sensitive values are added once the
 	// recipe parses (below).
-	subprocess.SetGlobalSensitive(sensitiveValues)
-	defer subprocess.SetGlobalSensitive(nil)
+	// The masker belongs to this run and goes out of scope with it, so there
+	// is no teardown: the deferred clear this replaces is exactly what made a
+	// second run in the same process lose its secrets.
+	masker := subprocess.NewMasker(sensitiveValues...)
+	ctx = subprocess.ContextWithMasker(ctx, masker)
 
 	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, inputCtx, userSet)
 	if err != nil {
-		c.Ui.Error(subprocess.MaskString(fmt.Sprintf("task error: %v", err)))
+		c.Ui.Error(masker.String(fmt.Sprintf("task error: %v", err)))
 		return 1
 	}
 
@@ -249,14 +252,14 @@ func (c *ApplyCommand) Run(args []string) int {
 	// declared inputs the surviving play's when: depends on.
 	fileLevelKeys := tasks.FileLevelInputNames(plays)
 
-	selected, err := filterPlaysByName(plays, c.play)
+	selected, err := filterPlaysByName(masker, plays, c.play)
 	if err != nil {
 		// The hint names every play in the file, so a value any of their tasks
 		// declares sensitive is in scope for this message - unlike the filtered
 		// collection below, which deliberately leaves out a play --play
 		// excluded. Registering the whole file costs nothing here: this branch
 		// prints one line and returns.
-		subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
+		masker.Add(tasks.CollectPlaySensitiveValues(plays)...)
 		c.Ui.Error(err.Error())
 		return 1
 	}
@@ -271,13 +274,13 @@ func (c *ApplyCommand) Run(args []string) int {
 	// play --play excluded from masking output it never appears in. The
 	// unmatched --play branch above is the one place that collects from the
 	// whole file, and says why.
-	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
+	masker.Add(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if c.startAtTask != "" {
 		if !startAtTaskMatches(plays, c.startAtTask) {
-			c.Ui.Error(subprocess.MaskString(fmt.Sprintf(
+			c.Ui.Error(masker.String(fmt.Sprintf(
 				"--start-at-task %q: no task matched name; available names: %s",
-				c.startAtTask, formatStartAtTaskNames(plays),
+				c.startAtTask, formatStartAtTaskNames(masker, plays),
 			)))
 			return 1
 		}
@@ -292,6 +295,7 @@ func (c *ApplyCommand) Run(args []string) int {
 			userSet:       userSet,
 			context:       inputCtx,
 			jsonOut:       c.json,
+			masker:        masker,
 			target:        target,
 		})
 	}
@@ -302,7 +306,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	// not collide; nothing was closing the extra ones.
 	defer closeControlMasters(target, plays)
 
-	emitter := c.newEmitter()
+	emitter := c.newEmitter(masker)
 	start := time.Now()
 	counts := ApplyCounts{}
 	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(inputCtx, fileLevelKeys, userSet))
@@ -942,7 +946,7 @@ func startAtTaskMatches(plays []*tasks.Play, target string) bool {
 // text that carries the secret escaped twice over - and would miss it (#475).
 // Deduplication still keys on the real name: two tasks that mask alike are two
 // tasks.
-func formatStartAtTaskNames(plays []*tasks.Play) string {
+func formatStartAtTaskNames(masker *subprocess.Masker, plays []*tasks.Play) string {
 	seen := map[string]bool{}
 	var quoted []string
 	for _, play := range plays {
@@ -952,7 +956,7 @@ func formatStartAtTaskNames(plays []*tasks.Play) string {
 		for _, name := range play.Tasks.Keys() {
 			if !seen[name] {
 				seen[name] = true
-				quoted = append(quoted, fmt.Sprintf("%q", subprocess.MaskString(name)))
+				quoted = append(quoted, fmt.Sprintf("%q", masker.String(name)))
 			}
 			env := play.Tasks.GetEnvelope(name)
 			for _, descendant := range tasks.CollectEnvelopeNames([]*tasks.TaskEnvelope{env}) {
@@ -961,7 +965,7 @@ func formatStartAtTaskNames(plays []*tasks.Play) string {
 				}
 				if !seen[descendant] {
 					seen[descendant] = true
-					quoted = append(quoted, fmt.Sprintf("%q", subprocess.MaskString(descendant)))
+					quoted = append(quoted, fmt.Sprintf("%q", masker.String(descendant)))
 				}
 			}
 		}
@@ -980,13 +984,13 @@ func formatStartAtTaskNames(plays []*tasks.Play) string {
 // formatStartAtTaskNames gives: `%q` escapes what it wraps, so masking the
 // finished message would be matching a registered literal against text that
 // carries the secret escaped (#477).
-func formatAvailablePlayNames(plays []*tasks.Play) string {
+func formatAvailablePlayNames(masker *subprocess.Masker, plays []*tasks.Play) string {
 	quoted := make([]string, 0, len(plays))
 	for _, play := range plays {
 		if play == nil {
 			continue
 		}
-		quoted = append(quoted, fmt.Sprintf("%q", subprocess.MaskString(play.Name)))
+		quoted = append(quoted, fmt.Sprintf("%q", masker.String(play.Name)))
 	}
 	if len(quoted) == 0 {
 		return "(none)"
@@ -1002,18 +1006,22 @@ func formatAvailablePlayNames(plays []*tasks.Play) string {
 type unknownPlayError struct {
 	target string
 	plays  []*tasks.Play
+	// masker is carried on the error because Error() is called from places
+	// that have neither a context nor an emitter, and the message names both
+	// the requested play and every available one.
+	masker *subprocess.Masker
 }
 
 func (e *unknownPlayError) Error() string {
 	return fmt.Sprintf("--play %q: no play with that name; available plays: %s",
-		subprocess.MaskString(e.target), formatAvailablePlayNames(e.plays))
+		e.masker.String(e.target), formatAvailablePlayNames(e.masker, e.plays))
 }
 
 // filterPlaysByName narrows plays to the single play whose Name matches
 // target. An empty target returns plays unchanged. An unmatched target
 // returns an error so the user sees a clear "no such play" diagnostic
 // rather than silently doing nothing.
-func filterPlaysByName(plays []*tasks.Play, target string) ([]*tasks.Play, error) {
+func filterPlaysByName(masker *subprocess.Masker, plays []*tasks.Play, target string) ([]*tasks.Play, error) {
 	if target == "" {
 		return plays, nil
 	}
@@ -1022,16 +1030,16 @@ func filterPlaysByName(plays []*tasks.Play, target string) ([]*tasks.Play, error
 			return []*tasks.Play{play}, nil
 		}
 	}
-	return nil, &unknownPlayError{target: target, plays: plays}
+	return nil, &unknownPlayError{target: target, plays: plays, masker: masker}
 }
 
 // newEmitter constructs the EventEmitter for this run. --json builds a
 // JSONEmitter; otherwise the human Formatter is used. The verbose flag is
 // only meaningful for the human path - JSON output already includes the
 // resolved commands in each task event's `commands` array.
-func (c *ApplyCommand) newEmitter() EventEmitter {
+func (c *ApplyCommand) newEmitter(masker *subprocess.Masker) EventEmitter {
 	if c.json {
-		return NewJSONEmitter(c.Ui)
+		return NewJSONEmitter(c.Ui, masker)
 	}
-	return NewFormatter(c.Ui, c.verbose)
+	return NewFormatter(c.Ui, c.verbose, masker)
 }

--- a/commands/apply_test.go
+++ b/commands/apply_test.go
@@ -117,17 +117,17 @@ func TestFilterPlaysByName(t *testing.T) {
 		{Name: "worker"},
 	}
 
-	out, err := filterPlaysByName(plays, "")
+	out, err := filterPlaysByName(nil, plays, "")
 	if err != nil || len(out) != 2 {
 		t.Errorf("empty target should pass through; got len=%d err=%v", len(out), err)
 	}
 
-	out, err = filterPlaysByName(plays, "api")
+	out, err = filterPlaysByName(nil, plays, "api")
 	if err != nil || len(out) != 1 || out[0].Name != "api" {
 		t.Errorf(`--play "api" got len=%d names=%v err=%v`, len(out), playNames(out), err)
 	}
 
-	_, err = filterPlaysByName(plays, "missing")
+	_, err = filterPlaysByName(nil, plays, "missing")
 	if err == nil {
 		t.Fatal("expected error for unknown play")
 	}
@@ -139,7 +139,7 @@ func TestFilterPlaysByName(t *testing.T) {
 
 	// An empty recipe has no name to suggest, so the hint says so rather
 	// than trailing off after the colon.
-	_, err = filterPlaysByName(nil, "missing")
+	_, err = filterPlaysByName(nil, nil, "missing")
 	if err == nil {
 		t.Fatal("expected error for unknown play in an empty list")
 	}

--- a/commands/export.go
+++ b/commands/export.go
@@ -219,15 +219,14 @@ func (c *ExportCommand) Run(args []string) int {
 	// arguments - the --app names and --resource addresses reported missing,
 	// and the output paths - because a name masked down to *** would hide the
 	// typo the message exists to report.
-	subprocess.SetGlobalSensitive(res.SensitiveValues())
-	defer subprocess.SetGlobalSensitive(nil)
+	masker := subprocess.NewMasker(res.SensitiveValues()...)
 
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("export failed: %v", subprocess.MaskString(err.Error())))
+		c.Ui.Error(fmt.Sprintf("export failed: %v", masker.String(err.Error())))
 		return 1
 	}
 	for _, w := range res.Report.Warnings {
-		c.Ui.Warn(fmt.Sprintf("warning: %s", subprocess.MaskString(w)))
+		c.Ui.Warn(fmt.Sprintf("warning: %s", masker.String(w)))
 	}
 
 	// A nonexistent --app must not silently produce an empty recipe (which the
@@ -249,7 +248,7 @@ func (c *ExportCommand) Run(args []string) int {
 
 	recipeBytes, err := res.MarshalRecipe(recipeFormat)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("marshal recipe: %v", subprocess.MaskString(err.Error())))
+		c.Ui.Error(fmt.Sprintf("marshal recipe: %v", masker.String(err.Error())))
 		return 1
 	}
 
@@ -310,7 +309,7 @@ func (c *ExportCommand) Run(args []string) int {
 	if writeVars {
 		varsBytes, err := res.MarshalVars(varsFormat)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("marshal vars: %v", subprocess.MaskString(err.Error())))
+			c.Ui.Error(fmt.Sprintf("marshal vars: %v", masker.String(err.Error())))
 			return 1
 		}
 		if err := c.writeVarsFile(varsOutput, varsBytes); err != nil {

--- a/commands/export_masking_test.go
+++ b/commands/export_masking_test.go
@@ -33,7 +33,6 @@ func failingExecRunner(responses map[string]string, failing string, err error) f
 // deliberate: it pins that masking happens when the warning is printed, after
 // the whole read, rather than when it is appended.
 func TestExportCommandWarningMasksAConfigValue(t *testing.T) {
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 	defer subprocess.SetExecRunner(failingExecRunner(
 		exportCommandFixture(),
 		"--quiet apps:locked web",
@@ -70,7 +69,6 @@ func TestExportCommandWarningMasksAConfigValue(t *testing.T) {
 // placeholder there, so the vars map holds nothing to mask with - while the
 // real value was still read off the server and is still in the warning.
 func TestExportCommandRedactWarningMasksAConfigValue(t *testing.T) {
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 	defer subprocess.SetExecRunner(failingExecRunner(
 		exportCommandFixture(),
 		"--quiet apps:locked web",
@@ -101,7 +99,6 @@ func TestExportCommandRedactWarningMasksAConfigValue(t *testing.T) {
 // exported before apps:list runs, so by the time the failure is printed the
 // export is already holding the cluster token it read.
 func TestExportCommandFailureMasksASecretReadBeforeTheAppList(t *testing.T) {
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 	defer subprocess.SetExecRunner(failingExecRunner(
 		map[string]string{
 			"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken"}`,
@@ -134,7 +131,6 @@ func TestExportCommandFailureMasksASecretReadBeforeTheAppList(t *testing.T) {
 // masked Ui, so an export whose every config value is registered still writes
 // a vars-file the operator can apply.
 func TestExportCommandMaskingLeavesTheVarsFileInTheClear(t *testing.T) {
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -161,7 +157,6 @@ func TestExportCommandMaskingLeavesTheVarsFileInTheClear(t *testing.T) {
 // point at the typo - which "*** not found on server" would not do. It stays
 // unmasked even when it collides with a value the export registered.
 func TestExportCommandMissingAppNameStaysReadable(t *testing.T) {
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 	responses := exportCommandFixture()
 	responses["--quiet config:export --format json web"] = `{"API_KEY":"nope-app"}`
 	defer subprocess.SetExecRunner(fakeExecRunner(responses))()

--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -22,6 +22,9 @@ type listTasksOptions struct {
 	userSet       map[string]bool
 	context       map[string]interface{}
 	jsonOut       bool
+	// masker holds the run's sensitive values; the rendered plan echoes task
+	// and play names, which are exactly where a secret reaches output.
+	masker *subprocess.Masker
 	// target is the run-wide target the plays resolve against, so the
 	// rendered plan can say which server each play would talk to. The JSON
 	// stream is deliberately left alone: it has no play_start event to hang a
@@ -75,9 +78,9 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 		// per value rather than per output site is what keeps the two paths
 		// from drifting apart, and it leaves docket's own decorations - the
 		// `==> Play: ` prefix, the markers, `(group)` - untouched.
-		playName := subprocess.MaskString(play.Name)
+		playName := opts.masker.String(play.Name)
 		if play.HasWhen() {
-			whenSrc := subprocess.MaskString(play.When)
+			whenSrc := opts.masker.String(play.When)
 			playCtx := buildEnvelopeExprContext(buildPlayWhenContext(opts.context, opts.fileLevelKeys, opts.userSet))
 			ok, err := tasks.EvalBool(play.WhenProgram(), playCtx)
 			if err != nil {
@@ -85,7 +88,7 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 				// An expr runtime error quotes the predicate's own source
 				// back in its snippet, so the formatted error - not just the
 				// play name - carries whatever the predicate interpolated.
-				reason := subprocess.MaskString(fmt.Sprintf("when error: %v", err))
+				reason := opts.masker.String(fmt.Sprintf("when error: %v", err))
 				if opts.jsonOut {
 					emitListJSON(ui, map[string]interface{}{
 						"type":   "play_skipped",
@@ -122,6 +125,7 @@ func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
 		}
 
 		rc := listRenderContext{
+			masker:      opts.masker,
 			ui:          ui,
 			playName:    playName,
 			playExprCtx: buildEnvelopeExprContext(tasks.BuildPerPlayContext(opts.context, play.Inputs, opts.userSet)),
@@ -151,6 +155,7 @@ type listRenderContext struct {
 	playName    string
 	playExprCtx map[string]interface{}
 	jsonOut     bool
+	masker      *subprocess.Masker
 }
 
 // renderListEnvelope renders one envelope's line and, for a group,
@@ -189,16 +194,16 @@ func renderListEnvelope(
 	// `phase` are deliberately absent - they are docket's own vocabulary,
 	// pinned as enums in docs/schemas/list-tasks-v1.schema.json, and masking
 	// one would emit a stream that fails its own schema.
-	display := subprocess.MaskString(env.Name)
-	whenSrc := subprocess.MaskString(env.When)
-	tags := maskedStrings(env.Tags)
+	display := rc.masker.String(env.Name)
+	whenSrc := rc.masker.String(env.When)
+	tags := maskedStrings(rc.masker, env.Tags)
 	deprecation := ""
 	caveat := ""
 	var probe tasks.ProbeSupport
 	if env != nil && env.Task != nil {
-		deprecation = subprocess.MaskString(tasks.TaskDeprecation(env.Task))
+		deprecation = rc.masker.String(tasks.TaskDeprecation(env.Task))
 		probe, _ = tasks.TaskProbeSupport(env.Task)
-		caveat = subprocess.MaskString(probe.Caveat)
+		caveat = rc.masker.String(probe.Caveat)
 	}
 
 	if rc.jsonOut {
@@ -239,7 +244,7 @@ func renderListEnvelope(
 		if env.IsLoopExpansion {
 			ev["loop_index"] = env.LoopIndex
 			if env.LoopItem != nil {
-				ev["loop_item"] = subprocess.MaskValue(env.LoopItem)
+				ev["loop_item"] = rc.masker.Value(env.LoopItem)
 			}
 		}
 		emitListJSON(rc.ui, ev)

--- a/commands/masking_command_test.go
+++ b/commands/masking_command_test.go
@@ -52,11 +52,10 @@ func TestPlanMasksSensitiveInputInParseError(t *testing.T) {
 }
 
 func TestValidateMasksSensitiveInJSONProblem(t *testing.T) {
-	subprocess.SetGlobalSensitive([]string{"tok_secret"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	masker := subprocess.NewMasker("tok_secret")
 
 	ui := cli.NewMockUi()
-	c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+	c := &ValidateCommand{Meta: command.Meta{Ui: ui}, masker: masker}
 	c.emitJSONProblem(tasks.Problem{
 		Code:    "template_error",
 		Message: `cannot render "tok_secret"`,
@@ -74,11 +73,10 @@ func TestValidateMasksSensitiveInJSONProblem(t *testing.T) {
 }
 
 func TestValidateMasksSensitiveInHumanProblem(t *testing.T) {
-	subprocess.SetGlobalSensitive([]string{"tok_secret"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+	masker := subprocess.NewMasker("tok_secret")
 
 	ui := cli.NewMockUi()
-	c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+	c := &ValidateCommand{Meta: command.Meta{Ui: ui}, masker: masker}
 	c.renderHumanProblems([]tasks.Problem{{
 		Play:    "play tok_secret",
 		Task:    "task tok_secret",

--- a/commands/output.go
+++ b/commands/output.go
@@ -188,17 +188,23 @@ type Formatter struct {
 	verbose bool
 	color   bool
 	paint   map[Marker]*color.Color
+	// masker holds the run's sensitive values. An emitter renders text at
+	// points that have no context to carry one, so it is handed the run's
+	// masker at construction instead. A nil masker masks nothing, which is
+	// what a caller that registered no secrets wants.
+	masker  *subprocess.Masker
 }
 
 // NewFormatter constructs a Formatter bound to the given Ui. verbose
 // controls whether `→`-prefixed continuation lines are emitted under
 // each task line in apply mode.
-func NewFormatter(ui cli.Ui, verbose bool) *Formatter {
+func NewFormatter(ui cli.Ui, verbose bool, masker *subprocess.Masker) *Formatter {
 	useColor := !noColorDefault()
 	return &Formatter{
 		ui:      ui,
 		verbose: verbose,
 		color:   useColor,
+		masker:  masker,
 		paint: map[Marker]*color.Color{
 			MarkerOK:         color.New(color.FgGreen),
 			MarkerChanged:    color.New(color.FgYellow),
@@ -238,7 +244,7 @@ func (f *Formatter) Verbose() bool { return f.verbose }
 // listing. Used once per play; until #208 lands, callers emit one
 // header per run.
 func (f *Formatter) PlayHeader(name string) {
-	f.ui.Output(fmt.Sprintf("==> Play: %s", subprocess.MaskString(name)))
+	f.ui.Output(fmt.Sprintf("==> Play: %s", f.masker.String(name)))
 }
 
 // PlayHeaderWithHost is like PlayHeader but appends a `(host: <name>)`
@@ -250,7 +256,7 @@ func (f *Formatter) PlayHeaderWithHost(name, host string) {
 		f.PlayHeader(name)
 		return
 	}
-	f.ui.Output(fmt.Sprintf("==> Play: %s  (host: %s)", subprocess.MaskString(name), host))
+	f.ui.Output(fmt.Sprintf("==> Play: %s  (host: %s)", f.masker.String(name), host))
 }
 
 // PlayStart satisfies EventEmitter; delegates to PlayHeaderWithHost.
@@ -267,12 +273,12 @@ func (f *Formatter) PlayStart(name, host string) {
 // wrapped with an eval error by apply/plan) may contain the literal
 // secret.
 func (f *Formatter) PlaySkipped(name, whenSrc string) {
-	name = subprocess.MaskString(name)
+	name = f.masker.String(name)
 	if whenSrc == "" {
 		f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped)", name))
 		return
 	}
-	f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", name, subprocess.MaskString(whenSrc)))
+	f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", name, f.masker.String(whenSrc)))
 }
 
 // ApplyTask renders one apply task line plus optional continuations,
@@ -414,9 +420,9 @@ func PrefixErrorMessage(err error) string {
 // suffix can carry a secret via a plan reason or stderr context.
 func (f *Formatter) TaskLine(m Marker, name, suffix string) {
 	marker := f.paintMarker(m)
-	line := marker + subprocess.MaskString(name)
+	line := marker + f.masker.String(name)
 	if suffix != "" {
-		line = line + "  " + subprocess.MaskString(suffix)
+		line = line + "  " + f.masker.String(suffix)
 	}
 	if m == MarkerError || m == MarkerProbeError {
 		f.ui.Error(line)
@@ -435,7 +441,7 @@ func (f *Formatter) Continuation(prefix rune, body string) {
 	if body == "" {
 		return
 	}
-	body = subprocess.MaskString(body)
+	body = f.masker.String(body)
 	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
 		out := fmt.Sprintf("%s%c %s", continuationIndent, prefix, line)
 		f.ui.Output(out)

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -16,15 +16,20 @@ const jsonSchemaVersion = 1
 
 // JSONEmitter writes one JSON-lines event per call to the underlying Ui's
 // stdout (Output) sink. Sensitive values registered via
-// subprocess.SetGlobalSensitive are masked before any string field that
+// the run's masker are masked before any string field that
 // could carry them is serialised.
 type JSONEmitter struct {
 	ui cli.Ui
+	// masker holds the run's sensitive values. An emitter renders text at
+	// points that have no context to carry one, so it is handed the run's
+	// masker at construction instead. A nil masker masks nothing, which is
+	// what a caller that registered no secrets wants.
+	masker *subprocess.Masker
 }
 
 // NewJSONEmitter constructs a JSONEmitter bound to the given Ui.
-func NewJSONEmitter(ui cli.Ui) *JSONEmitter {
-	return &JSONEmitter{ui: ui}
+func NewJSONEmitter(ui cli.Ui, masker *subprocess.Masker) *JSONEmitter {
+	return &JSONEmitter{ui: ui, masker: masker}
 }
 
 // PlayStart emits a `play_start` event.
@@ -32,7 +37,7 @@ func (e *JSONEmitter) PlayStart(name, host string) {
 	ev := map[string]interface{}{
 		"version": jsonSchemaVersion,
 		"type":    "play_start",
-		"name":    subprocess.MaskString(name),
+		"name":    e.masker.String(name),
 		"ts":      nowRFC3339(),
 	}
 	if host != "" {
@@ -52,11 +57,11 @@ func (e *JSONEmitter) PlaySkipped(name, whenSrc string) {
 	ev := map[string]interface{}{
 		"version": jsonSchemaVersion,
 		"type":    "play_skipped",
-		"name":    subprocess.MaskString(name),
+		"name":    e.masker.String(name),
 		"ts":      nowRFC3339(),
 	}
 	if whenSrc != "" {
-		masked := subprocess.MaskString(whenSrc)
+		masked := e.masker.String(whenSrc)
 		ev["when"] = masked
 		ev["reason"] = "when: " + masked
 	}
@@ -69,8 +74,8 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 	out := map[string]interface{}{
 		"version":       jsonSchemaVersion,
 		"type":          "task",
-		"play":          subprocess.MaskString(ev.Play),
-		"name":          subprocess.MaskString(ev.Name),
+		"play":          e.masker.String(ev.Play),
+		"name":          e.masker.String(ev.Name),
 		"changed":       ev.State.Changed,
 		"state":         string(ev.State.State),
 		"desired_state": string(ev.State.DesiredState),
@@ -80,20 +85,20 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 	switch {
 	case ev.WhenError != nil:
 		out["status"] = "error"
-		out["error"] = subprocess.MaskString(ev.WhenError.Error())
+		out["error"] = e.masker.String(ev.WhenError.Error())
 	case ev.Skipped:
 		out["status"] = "skipped"
 		if ev.SkipReason != "" {
-			out["skip_reason"] = subprocess.MaskString(ev.SkipReason)
+			out["skip_reason"] = e.masker.String(ev.SkipReason)
 		}
 	case ev.State.Error != nil:
 		out["status"] = "error"
-		out["error"] = subprocess.MaskString(PrefixErrorMessage(ev.State.Error))
+		out["error"] = e.masker.String(PrefixErrorMessage(ev.State.Error))
 		if ev.State.Stderr != "" {
-			out["stderr"] = subprocess.MaskString(ev.State.Stderr)
+			out["stderr"] = e.masker.String(ev.State.Stderr)
 		}
 		if ev.State.Stdout != "" {
-			out["stdout"] = subprocess.MaskString(ev.State.Stdout)
+			out["stdout"] = e.masker.String(ev.State.Stdout)
 		}
 		out["exit_code"] = ev.State.ExitCode
 		if ev.Ignored {
@@ -101,7 +106,7 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 		}
 	case ev.InvalidState:
 		out["status"] = "error"
-		out["error"] = subprocess.MaskString(invalidStateMessage(ev.State))
+		out["error"] = e.masker.String(invalidStateMessage(ev.State))
 		if ev.Ignored {
 			out["ignored"] = true
 		}
@@ -110,7 +115,7 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 	default:
 		out["status"] = "ok"
 	}
-	if cmds := maskedStrings(ev.State.Commands); len(cmds) > 0 {
+	if cmds := maskedStrings(e.masker, ev.State.Commands); len(cmds) > 0 {
 		out["commands"] = cmds
 	}
 	if ev.Phase != "" {
@@ -128,8 +133,8 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 	out := map[string]interface{}{
 		"version":       jsonSchemaVersion,
 		"type":          "task",
-		"play":          subprocess.MaskString(ev.Play),
-		"name":          subprocess.MaskString(ev.Name),
+		"play":          e.masker.String(ev.Play),
+		"name":          e.masker.String(ev.Name),
 		"would_change":  !ev.Result.InSync && ev.Result.Error == nil && !ev.Skipped && ev.WhenError == nil,
 		"state":         string(ev.Result.DesiredState),
 		"desired_state": string(ev.Result.DesiredState),
@@ -140,14 +145,14 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 	case ev.WhenError != nil:
 		out["status"] = "error"
 		out["would_change"] = false
-		out["error"] = subprocess.MaskString(ev.WhenError.Error())
+		out["error"] = e.masker.String(ev.WhenError.Error())
 	case ev.Skipped:
 		out["status"] = "skipped"
 		out["would_change"] = false
 	case ev.Result.Error != nil:
 		out["status"] = "error"
 		out["would_change"] = false
-		out["error"] = subprocess.MaskString(PrefixErrorMessage(ev.Result.Error))
+		out["error"] = e.masker.String(PrefixErrorMessage(ev.Result.Error))
 	case ev.Result.InSync:
 		out["status"] = "ok"
 	default:
@@ -156,12 +161,12 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 			out["status"] = string(tasks.PlanStatusModify)
 		}
 		if ev.Result.Reason != "" {
-			out["reason"] = subprocess.MaskString(ev.Result.Reason)
+			out["reason"] = e.masker.String(ev.Result.Reason)
 		}
 		if len(ev.Result.Mutations) > 0 {
-			out["mutations"] = maskedStrings(ev.Result.Mutations)
+			out["mutations"] = maskedStrings(e.masker, ev.Result.Mutations)
 		}
-		if cmds := maskedStrings(ev.Result.Commands); len(cmds) > 0 {
+		if cmds := maskedStrings(e.masker, ev.Result.Commands); len(cmds) > 0 {
 			out["commands"] = cmds
 		}
 	}
@@ -186,10 +191,10 @@ func (e *JSONEmitter) TaskWarning(play, name, reason, message string) {
 	e.write(map[string]interface{}{
 		"version": jsonSchemaVersion,
 		"type":    "warning",
-		"play":    subprocess.MaskString(play),
-		"name":    subprocess.MaskString(name),
+		"play":    e.masker.String(play),
+		"name":    e.masker.String(name),
 		"reason":  reason,
-		"message": subprocess.MaskString(message),
+		"message": e.masker.String(message),
 		"ts":      nowRFC3339(),
 	})
 }
@@ -237,17 +242,17 @@ func (e *JSONEmitter) write(ev map[string]interface{}) {
 }
 
 // maskedStrings returns a copy of in with each entry passed through
-// subprocess.MaskString. Returns nil for an empty slice so the caller can
+// the run's masker. Returns nil for an empty slice so the caller can
 // detect "nothing here" and omit the JSON field. Serves the run stream's
 // `commands` and `mutations` arrays and the --list-tasks `tags` array, all of
 // which are rendered from the recipe and can carry an interpolated secret.
-func maskedStrings(in []string) []string {
+func maskedStrings(masker *subprocess.Masker, in []string) []string {
 	if len(in) == 0 {
 		return nil
 	}
 	out := make([]string, len(in))
 	for i, v := range in {
-		out[i] = subprocess.MaskString(v)
+		out[i] = masker.String(v)
 	}
 	return out
 }

--- a/commands/output_json_test.go
+++ b/commands/output_json_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 // emitterTestUI returns a fresh MockUi and the emitter under test.
-func emitterTestUI() (*JSONEmitter, *cli.MockUi) {
+func emitterTestUI(sensitive ...string) (*JSONEmitter, *cli.MockUi) {
 	ui := cli.NewMockUi()
-	return NewJSONEmitter(ui), ui
+	return NewJSONEmitter(ui, subprocess.NewMasker(sensitive...)), ui
 }
 
 // decodeOnly parses the captured stdout as a single JSON-lines event and
@@ -366,10 +366,8 @@ func TestJSONEmitterPlanSummary(t *testing.T) {
 }
 
 func TestJSONEmitterMasksSensitiveValues(t *testing.T) {
-	subprocess.SetGlobalSensitive([]string{"topsecret"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	e, ui := emitterTestUI()
+	e, ui := emitterTestUI("topsecret")
 	e.ApplyTask(ApplyTaskEvent{
 		Play: "tasks",
 		Name: "set config",
@@ -392,10 +390,8 @@ func TestJSONEmitterMasksSensitiveValues(t *testing.T) {
 func TestJSONEmitterMasksTaskNameAndPlay(t *testing.T) {
 	// A loop over a sensitive value expands the task name; the name and play
 	// fields must be masked in JSON too (#312).
-	subprocess.SetGlobalSensitive([]string{"hunter2"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	e, ui := emitterTestUI()
+	e, ui := emitterTestUI("hunter2")
 	e.ApplyTask(ApplyTaskEvent{
 		Play: "play-hunter2",
 		Name: "create auth users (item=hunter2)",
@@ -417,10 +413,8 @@ func TestJSONEmitterMasksTaskNameAndPlay(t *testing.T) {
 func TestJSONEmitterPlaySkippedMasksWhen(t *testing.T) {
 	// The play_skipped when/reason fields carry the raw predicate source; a
 	// secret interpolated into it must be masked (#335).
-	subprocess.SetGlobalSensitive([]string{"tok_abc123"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	e, ui := emitterTestUI()
+	e, ui := emitterTestUI("tok_abc123")
 	e.PlaySkipped("deploy", `"tok_abc123" == "expected"`)
 	ev := decodeOnly(t, ui.OutputWriter.String())
 	if got := ev["when"].(string); strings.Contains(got, "tok_abc123") {
@@ -489,10 +483,8 @@ func TestJSONEmitterTaskWarningEmptyIsNoOp(t *testing.T) {
 // TestJSONEmitterTaskWarningProbeReason pins that a non-deprecation warning
 // carries its own reason through the event and that the message is masked. (#353)
 func TestJSONEmitterTaskWarningProbeReason(t *testing.T) {
-	subprocess.SetGlobalSensitive([]string{"s3cr3t"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	e, ui := emitterTestUI()
+	e, ui := emitterTestUI("s3cr3t")
 	e.TaskWarning("tasks", "set token", "probe_rejected", "rejected probe near value s3cr3t")
 	ev := decodeOnly(t, ui.OutputWriter.String())
 

--- a/commands/output_test.go
+++ b/commands/output_test.go
@@ -15,9 +15,9 @@ import (
 // newTestFormatter returns a formatter wired to a fresh MockUi with
 // color forced off. Tests that need colored output set f.color = true
 // explicitly.
-func newTestFormatter(verbose bool) (*Formatter, *cli.MockUi) {
+func newTestFormatter(verbose bool, sensitive ...string) (*Formatter, *cli.MockUi) {
 	ui := cli.NewMockUi()
-	f := NewFormatter(ui, verbose)
+	f := NewFormatter(ui, verbose, subprocess.NewMasker(sensitive...))
 	f.color = false
 	return f, ui
 }
@@ -55,10 +55,8 @@ func TestFormatterPlayHeaderWithHostEmptyDelegates(t *testing.T) {
 func TestFormatterTaskLineMasksSensitiveName(t *testing.T) {
 	// A loop over a sensitive value expands the task name to
 	// `<name> (item=<secret>)`; the name must be masked (#312).
-	subprocess.SetGlobalSensitive([]string{"hunter2"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	f, ui := newTestFormatter(false)
+	f, ui := newTestFormatter(false, "hunter2")
 	f.TaskLine(MarkerChanged, "create auth users (item=hunter2)", "")
 	got := ui.OutputWriter.String()
 	if strings.Contains(got, "hunter2") {
@@ -73,10 +71,8 @@ func TestFormatterPlaySkippedMasksWhenSource(t *testing.T) {
 	// A play predicate that interpolates a sensitive input has the secret
 	// substituted into the recipe text; the echoed when: source must be
 	// masked (#335).
-	subprocess.SetGlobalSensitive([]string{"tok_abc123"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	f, ui := newTestFormatter(false)
+	f, ui := newTestFormatter(false, "tok_abc123")
 	f.PlaySkipped("deploy", `"tok_abc123" == "expected"`)
 	got := ui.OutputWriter.String()
 	if strings.Contains(got, "tok_abc123") {
@@ -90,10 +86,8 @@ func TestFormatterPlaySkippedMasksWhenSource(t *testing.T) {
 func TestFormatterPlaySkippedMasksWhenEvalError(t *testing.T) {
 	// apply/plan route play-level when-eval errors through PlaySkipped as
 	// `<when> (error: <err>)`; the same masking must cover them (#335).
-	subprocess.SetGlobalSensitive([]string{"tok_abc123"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	f, ui := newTestFormatter(false)
+	f, ui := newTestFormatter(false, "tok_abc123")
 	f.PlaySkipped("deploy", `"tok_abc123" == foo (error: unknown name foo)`)
 	got := ui.OutputWriter.String()
 	if strings.Contains(got, "tok_abc123") {
@@ -321,7 +315,7 @@ func TestFormatterColorOnEmitsAnsi(t *testing.T) {
 	t.Cleanup(func() { color.NoColor = prev })
 
 	ui := cli.NewMockUi()
-	f := NewFormatter(ui, false)
+	f := NewFormatter(ui, false, nil)
 	f.color = true
 	f.TaskLine(MarkerChanged, "task", "")
 	got := ui.OutputWriter.String()
@@ -402,10 +396,8 @@ func TestFormatterTaskWarningRendersDeprecatedMarker(t *testing.T) {
 // reason renders the [warning] marker (not [deprecated]) on stdout, and masks
 // the message. (#353)
 func TestFormatterTaskWarningRendersWarningMarker(t *testing.T) {
-	subprocess.SetGlobalSensitive([]string{"s3cr3t"})
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
 
-	f, ui := newTestFormatter(false)
+	f, ui := newTestFormatter(false, "s3cr3t")
 	f.TaskWarning("tasks", "set token", "probe_rejected", "rejected probe near value s3cr3t")
 	got := ui.OutputWriter.String()
 	if !strings.Contains(got, "[warning]") {

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -225,12 +225,15 @@ func (c *PlanCommand) Run(args []string) int {
 	// parsed and rendered, so a template or parse error that interpolated one
 	// of them is masked. Task-declared sensitive values are added once the
 	// recipe parses (below).
-	subprocess.SetGlobalSensitive(sensitiveValues)
-	defer subprocess.SetGlobalSensitive(nil)
+	// The masker belongs to this run and goes out of scope with it, so there
+	// is no teardown: the deferred clear this replaces is exactly what made a
+	// second run in the same process lose its secrets.
+	masker := subprocess.NewMasker(sensitiveValues...)
+	ctx = subprocess.ContextWithMasker(ctx, masker)
 
 	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, inputCtx, userSet)
 	if err != nil {
-		c.Ui.Error(subprocess.MaskString(fmt.Sprintf("task error: %v", err)))
+		c.Ui.Error(masker.String(fmt.Sprintf("task error: %v", err)))
 		return 1
 	}
 
@@ -239,14 +242,14 @@ func (c *PlanCommand) Run(args []string) int {
 	// declared inputs the surviving play's when: depends on.
 	fileLevelKeys := tasks.FileLevelInputNames(plays)
 
-	selected, err := filterPlaysByName(plays, c.play)
+	selected, err := filterPlaysByName(masker, plays, c.play)
 	if err != nil {
 		// The hint names every play in the file, so a value any of their tasks
 		// declares sensitive is in scope for this message - unlike the filtered
 		// collection below, which deliberately leaves out a play --play
 		// excluded. Registering the whole file costs nothing here: this branch
 		// prints one line and returns.
-		subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
+		masker.Add(tasks.CollectPlaySensitiveValues(plays)...)
 		c.Ui.Error(err.Error())
 		return 1
 	}
@@ -259,7 +262,7 @@ func (c *PlanCommand) Run(args []string) int {
 	// that is only secret in a play --play excluded from masking output it
 	// never appears in. The unmatched --play branch above is the one place
 	// that collects from the whole file, and says why.
-	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
+	masker.Add(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if c.listTasks {
 		return renderListTasks(c.Ui, listTasksOptions{
@@ -270,6 +273,7 @@ func (c *PlanCommand) Run(args []string) int {
 			userSet:       userSet,
 			context:       inputCtx,
 			jsonOut:       c.json,
+			masker:        masker,
 			target:        target,
 		})
 	}
@@ -280,7 +284,7 @@ func (c *PlanCommand) Run(args []string) int {
 	// not collide; nothing was closing the extra ones.
 	defer closeControlMasters(target, plays)
 
-	emitter := c.newEmitter()
+	emitter := c.newEmitter(masker)
 	start := time.Now()
 	counts := PlanCounts{}
 	hasError := false
@@ -378,11 +382,11 @@ playLoop:
 
 // newEmitter constructs the EventEmitter for this run. --json builds a
 // JSONEmitter; otherwise the human Formatter is used.
-func (c *PlanCommand) newEmitter() EventEmitter {
+func (c *PlanCommand) newEmitter(masker *subprocess.Masker) EventEmitter {
 	if c.json {
-		return NewJSONEmitter(c.Ui)
+		return NewJSONEmitter(c.Ui, masker)
 	}
-	return NewFormatter(c.Ui, false)
+	return NewFormatter(c.Ui, false, masker)
 }
 
 // planContext bundles the run-wide plan state per-task helpers share so

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -20,6 +20,11 @@ import (
 type ValidateCommand struct {
 	command.Meta
 
+	// masker holds the sensitive input values this run must not echo. Set in
+	// Run before any problem is rendered; the renderers below are methods so
+	// they can reach it without a parameter of their own.
+	masker *subprocess.Masker
+
 	tasksFile string
 	// tasksDisplay is tasksFile rendered for output; "<stdin>" when the
 	// recipe was piped in.
@@ -226,8 +231,7 @@ func (c *ValidateCommand) Run(args []string) int {
 	// Register the sensitive input values so a problem message that quotes an
 	// interpolated secret (e.g. a template render error) is masked. validate is
 	// offline, so only input-derived values are available to collect.
-	subprocess.SetGlobalSensitive(sensitiveValues)
-	defer subprocess.SetGlobalSensitive(nil)
+	c.masker = subprocess.NewMasker(sensitiveValues...)
 
 	problems := tasks.Validate(data, tasks.ValidateOptions{
 		Strict:         c.strict,
@@ -265,13 +269,13 @@ func (c *ValidateCommand) emitJSONProblem(p tasks.Problem) {
 		"version": 1,
 		"type":    "validate_problem",
 		"code":    p.Code,
-		"message": subprocess.MaskString(p.Message),
+		"message": c.masker.String(p.Message),
 	}
 	if p.Play != "" {
-		event["play"] = subprocess.MaskString(p.Play)
+		event["play"] = c.masker.String(p.Play)
 	}
 	if p.Task != "" {
-		event["task"] = subprocess.MaskString(p.Task)
+		event["task"] = c.masker.String(p.Task)
 	}
 	if p.Line > 0 {
 		event["line"] = p.Line
@@ -280,7 +284,7 @@ func (c *ValidateCommand) emitJSONProblem(p tasks.Problem) {
 		event["column"] = p.Column
 	}
 	if p.Hint != "" {
-		event["hint"] = subprocess.MaskString(p.Hint)
+		event["hint"] = c.masker.String(p.Hint)
 	}
 	b, err := json.Marshal(event)
 	if err != nil {
@@ -314,10 +318,10 @@ func (c *ValidateCommand) renderHumanProblems(problems []tasks.Problem) {
 
 	for _, play := range playOrder {
 		if play != "" {
-			c.Ui.Info(fmt.Sprintf("  %s", subprocess.MaskString(play)))
+			c.Ui.Info(fmt.Sprintf("  %s", c.masker.String(play)))
 		}
 		for _, p := range grouped[play] {
-			c.Ui.Info(fmt.Sprintf("    ! %s", subprocess.MaskString(formatProblem(p))))
+			c.Ui.Info(fmt.Sprintf("    ! %s", c.masker.String(formatProblem(p))))
 		}
 		c.Ui.Info("")
 	}

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -140,7 +140,7 @@ func (ecr ExecCommandResponse) StdoutBytes() []byte {
 func ResolveCommandString(ctx context.Context, input ExecCommandInput) string {
 	target := TargetFromContext(ctx)
 	if target.Host != "" && input.Command == "dokku" {
-		return resolveSshCommandString(input.Command, input.Args)
+		return resolveSshCommandString(MaskerFromContext(ctx), input.Command, input.Args)
 	}
 	cmd := input.Command
 	args := input.Args
@@ -148,25 +148,25 @@ func ResolveCommandString(ctx context.Context, input ExecCommandInput) string {
 		args = append([]string{"-n", "-u", "root", cmd}, args...)
 		cmd = "sudo"
 	}
-	return resolveLocalCommandString(cmd, args)
+	return resolveLocalCommandString(MaskerFromContext(ctx), cmd, args)
 }
 
 // resolveLocalCommandString joins a local command and args into the masked
 // form CallExecCommand records on the response.
-func resolveLocalCommandString(command string, args []string) string {
+func resolveLocalCommandString(m *Masker, command string, args []string) string {
 	if len(args) == 0 {
-		return MaskString(command)
+		return m.String(command)
 	}
-	return MaskString(command + " " + strings.Join(args, " "))
+	return m.String(command + " " + strings.Join(args, " "))
 }
 
 // resolveSshCommandString renders the bare `cmd arg1 arg2 ...` form the SSH
 // transport reports (sudo wrapping happens remotely and is not displayed).
-func resolveSshCommandString(command string, args []string) string {
+func resolveSshCommandString(m *Masker, command string, args []string) string {
 	if len(args) == 0 {
-		return MaskString(command)
+		return m.String(command)
 	}
-	return MaskString(command + " " + strings.Join(args, " "))
+	return m.String(command + " " + strings.Join(args, " "))
 }
 
 // ExecRunner is the shape of the executor CallExecCommand delegates to. A test
@@ -269,6 +269,7 @@ func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommand
 	if target.Host != "" && input.Command == "dokku" {
 		return CallSshCommand(ctx, target, input)
 	}
+	masker := MaskerFromContext(ctx)
 
 	// isatty reports whether our own stdout is a terminal, which is the
 	// signal used below to decide whether the child may read the terminal.
@@ -300,7 +301,7 @@ func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommand
 		if len(cmd.Args) > 0 {
 			argsSt = strings.Join(cmd.Args, " ")
 		}
-		log.Printf("exec: %s %s", MaskString(cmd.Command), MaskString(argsSt))
+		log.Printf("exec: %s %s", masker.String(cmd.Command), masker.String(argsSt))
 	}
 
 	if input.Stdin != nil {
@@ -325,7 +326,7 @@ func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommand
 		cmd.StdErrWriter = input.StderrWriter
 	}
 
-	resolved := resolveLocalCommandString(command, commandArgs)
+	resolved := resolveLocalCommandString(masker, command, commandArgs)
 
 	res, err := cmd.Execute(ctx)
 	if err != nil {

--- a/subprocess/exec_test.go
+++ b/subprocess/exec_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestResolveCommandString(t *testing.T) {
-	t.Cleanup(func() { SetGlobalSensitive(nil) })
 
 	tests := []struct {
 		name      string
@@ -63,9 +62,8 @@ func TestResolveCommandString(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			SetGlobalSensitive(tc.sensitive)
-			t.Cleanup(func() { SetGlobalSensitive(nil) })
 			ctx := ContextWithTarget(context.Background(), tc.target)
+			ctx = ContextWithMasker(ctx, NewMasker(tc.sensitive...))
 			if got := ResolveCommandString(ctx, tc.input); got != tc.want {
 				t.Errorf("ResolveCommandString = %q, want %q", got, tc.want)
 			}
@@ -280,10 +278,9 @@ func TestSetExecRunnerSwapsAndRestores(t *testing.T) {
 }
 
 func TestCallExecCommandResponseCommandIsMasked(t *testing.T) {
-	SetGlobalSensitive([]string{"topsecret123"})
-	defer SetGlobalSensitive(nil)
+	masker := NewMasker("topsecret123")
 
-	resp, err := CallExecCommand(context.Background(), ExecCommandInput{
+	resp, err := CallExecCommand(ContextWithMasker(context.Background(), masker), ExecCommandInput{
 		Command: "echo",
 		Args:    []string{"login", "topsecret123"},
 	})
@@ -305,15 +302,14 @@ func TestCallExecCommandResponseCommandIsMasked(t *testing.T) {
 
 func TestCallExecCommandTraceLogIsMasked(t *testing.T) {
 	t.Setenv("DOKKU_TRACE", "1")
-	SetGlobalSensitive([]string{"topsecret123"})
-	defer SetGlobalSensitive(nil)
+	masker := NewMasker("topsecret123")
 
 	var buf bytes.Buffer
 	prev := log.Writer()
 	log.SetOutput(&buf)
 	defer log.SetOutput(prev)
 
-	if _, err := CallExecCommand(context.Background(), ExecCommandInput{
+	if _, err := CallExecCommand(ContextWithMasker(context.Background(), masker), ExecCommandInput{
 		Command: "echo",
 		Args:    []string{"login", "topsecret123"},
 	}); err != nil {
@@ -329,7 +325,6 @@ func TestCallExecCommandTraceLogIsMasked(t *testing.T) {
 }
 
 func TestCallExecCommandResponseCommandUnmaskedWhenNoSecrets(t *testing.T) {
-	SetGlobalSensitive(nil)
 
 	resp, err := CallExecCommand(context.Background(), ExecCommandInput{
 		Command: "echo",

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -1,6 +1,7 @@
 package subprocess
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -19,59 +20,185 @@ import (
 // value has been registered here.
 const MaskPlaceholder = "***"
 
-var (
-	sensitiveMu     sync.RWMutex
-	sensitiveValues []string
-)
-
-// SetGlobalSensitive registers the set of literal string values that must be
-// masked anywhere they appear in user-facing output. Pass nil or an empty
-// slice to clear the registry. Empty entries in values are dropped (matching
-// every empty substring would otherwise mask everything).
+// Masker holds the set of literal string values that must not appear in
+// user-facing output, and replaces them with MaskPlaceholder wherever they
+// would.
 //
-// Callers (typically commands/apply.go and commands/plan.go) collect this set
-// from input values declared `sensitive: true` and from task struct fields
-// tagged `sensitive:"true"` before any subprocess runs, then defer a clear.
-// Note on scope: this registry is process-wide, and SetGlobalSensitive
-// *replaces* it, which is the one part of masking that does not survive two
-// runs sharing a process - the first run's deferred clear would blank the
-// second run's secrets while it is still writing output. AddGlobalSensitive
-// has no such problem. Masking stayed global when the target moved onto the
-// context because it is output rendering rather than routing: a shared
-// registry over-masks, which is fail-closed, and sensitiveMu already makes it
-// race-safe. Making it per-invocation is #501.
-func SetGlobalSensitive(values []string) {
-	cleaned := cleanSensitive(values)
-
-	sensitiveMu.Lock()
-	defer sensitiveMu.Unlock()
-	if len(cleaned) == 0 {
-		sensitiveValues = nil
-		return
-	}
-	sensitiveValues = cleaned
+// One Masker belongs to one run. That is the whole point of the type: the
+// registry it replaces was process-wide, and the API that populated it
+// *replaced* the set rather than adding to it, so two runs sharing a process
+// had the first one's teardown blank the second one's secrets while it was
+// still writing output. A Masker is never cleared - it goes out of scope with
+// the run that owns it - so there is no teardown to get wrong.
+//
+// A nil *Masker masks nothing and is safe to use. That is deliberate: a caller
+// that registered no secrets has nothing to hide, so code paths reached with
+// or without a masker need no branch of their own.
+type Masker struct {
+	mu     sync.RWMutex
+	values []string
 }
 
-// AddGlobalSensitive appends values to the sensitive registry, keeping the
-// entries already registered. Use it when a value that must be masked only
-// becomes known after the registry was first populated - typically a secret
-// read back from the server during Plan() (a drifted property's old value, or
-// scheduler-k3s trigger metadata), which the pre-run collection in
-// commands/apply.go and commands/plan.go cannot see. Values are de-duplicated
-// against the existing set, empties are dropped, and the whole registry is
-// re-sorted length-descending. A no-op when values contribute nothing new.
-func AddGlobalSensitive(values ...string) {
-	if len(values) == 0 {
+// NewMasker returns a Masker holding values, in the spellings cleanSensitive
+// derives. A Masker built with no values is still usable; more can be added.
+func NewMasker(values ...string) *Masker {
+	m := &Masker{}
+	m.Add(values...)
+	return m
+}
+
+// Add registers more values to mask, keeping the ones already there.
+//
+// There is no Set. Replacing the set is what made the old registry fail open,
+// and nothing needs it: a run's secrets only ever accumulate, as tasks read
+// values back off the server that the pre-run collection could not see - a
+// drifted property's old value, scheduler-k3s trigger metadata.
+func (m *Masker) Add(values ...string) {
+	if m == nil || len(values) == 0 {
 		return
 	}
-	sensitiveMu.Lock()
-	defer sensitiveMu.Unlock()
-	merged := cleanSensitive(append(append([]string{}, sensitiveValues...), values...))
-	if len(merged) == 0 {
-		sensitiveValues = nil
-		return
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.values = cleanSensitive(append(m.values, values...))
+}
+
+// Values returns a snapshot of the registered spellings, longest first.
+func (m *Masker) Values() []string {
+	if m == nil {
+		return nil
 	}
-	sensitiveValues = merged
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.values) == 0 {
+		return nil
+	}
+	out := make([]string, len(m.values))
+	copy(out, m.values)
+	return out
+}
+
+// String replaces every occurrence of a registered value in s with `***`.
+func (m *Masker) String(s string) string {
+	if m == nil || s == "" {
+		return s
+	}
+	m.mu.RLock()
+	values := m.values
+	m.mu.RUnlock()
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, v, MaskPlaceholder)
+	}
+	return s
+}
+
+// Value returns v with every registered value replaced by `***` in every
+// string it contains, walking slices and maps recursively. Non-string scalars
+// - numbers, booleans, nil - are returned unchanged: masking is substring
+// replacement over text, and a value that carried a secret would have been
+// rendered as a string before it got here.
+//
+// Map keys are masked as well as map values. A recipe is rendered as one
+// template before it is parsed, so a key is interpolated user data exactly as
+// a value is. Two keys that differ only inside a secret therefore collapse
+// into a single `***` entry - the same "two distinct values become
+// indistinguishable" trade-off masking already makes for task names.
+//
+// It exists for the values that reach a stream as interface{} - today the
+// `loop_item` field of `--list-tasks --json`, which carries whatever the
+// recipe's `loop:` resolved to: a scalar, a list, or a mapping. Masking the
+// value rather than the marshalled line is deliberate: a secret containing a
+// quote or a backslash is escaped in the serialised form, and String cannot be
+// relied on to match it there.
+func (m *Masker) Value(v interface{}) interface{} {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case string:
+		return m.String(t)
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, item := range t {
+			out[i] = m.Value(item)
+		}
+		return out
+	case []string:
+		out := make([]string, len(t))
+		for i, item := range t {
+			out[i] = m.String(item)
+		}
+		return out
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, item := range t {
+			out[m.String(k)] = m.Value(item)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]string, len(t))
+		for k, item := range t {
+			out[m.String(k)] = m.String(item)
+		}
+		return out
+	}
+	return m.reflectValue(v)
+}
+
+// reflectValue is the fallback for the container types the switch in Value
+// does not name - the typed slices and maps an expr-evaluated `loop:` can
+// produce, and the map[interface{}]interface{} shape a hand-built value can
+// carry. It mirrors the reflect normalisation tasks.resolveLoopList already
+// applies on the way in. The copy is interface{}-shaped because the only
+// consumer serialises it to JSON, where an object key is a string regardless.
+// Anything that is not a slice, array, or map is returned unchanged: a
+// non-string scalar cannot carry a secret.
+func (m *Masker) reflectValue(v interface{}) interface{} {
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.String:
+		return m.String(rv.String())
+	case reflect.Slice, reflect.Array:
+		out := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = m.Value(rv.Index(i).Interface())
+		}
+		return out
+	case reflect.Map:
+		out := make(map[string]interface{}, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			out[m.String(fmt.Sprint(iter.Key().Interface()))] = m.Value(iter.Value().Interface())
+		}
+		return out
+	case reflect.Ptr, reflect.Interface:
+		if rv.IsNil() {
+			return nil
+		}
+		return m.Value(rv.Elem().Interface())
+	}
+	return v
+}
+
+// maskerKey is the context key a run's Masker travels under.
+type maskerKey struct{}
+
+// ContextWithMasker returns a copy of ctx carrying m, so the layers that mask
+// text but have no other reason to know about a run - the subprocess
+// transports, a task registering a secret it just read back - can reach it.
+func ContextWithMasker(ctx context.Context, m *Masker) context.Context {
+	return context.WithValue(ctx, maskerKey{}, m)
+}
+
+// MaskerFromContext returns the Masker ctx carries, or nil when it carries
+// none. A nil Masker masks nothing, so callers need not check.
+func MaskerFromContext(ctx context.Context) *Masker {
+	if ctx == nil {
+		return nil
+	}
+	m, _ := ctx.Value(maskerKey{}).(*Masker)
+	return m
 }
 
 // cleanSensitive drops empty and duplicate entries and returns the values
@@ -135,124 +262,4 @@ func cleanSensitive(values []string) []string {
 func escapedSpelling(v string) string {
 	quoted := strconv.Quote(v)
 	return quoted[1 : len(quoted)-1]
-}
-
-// GlobalSensitive returns a snapshot of the current sensitive value set.
-func GlobalSensitive() []string {
-	sensitiveMu.RLock()
-	defer sensitiveMu.RUnlock()
-	if len(sensitiveValues) == 0 {
-		return nil
-	}
-	out := make([]string, len(sensitiveValues))
-	copy(out, sensitiveValues)
-	return out
-}
-
-// MaskString replaces every occurrence of any registered sensitive value in s
-// with `***`. Returns s unchanged when the registry is empty.
-func MaskString(s string) string {
-	if s == "" {
-		return s
-	}
-	sensitiveMu.RLock()
-	values := sensitiveValues
-	sensitiveMu.RUnlock()
-	if len(values) == 0 {
-		return s
-	}
-	for _, v := range values {
-		if v == "" {
-			continue
-		}
-		s = strings.ReplaceAll(s, v, MaskPlaceholder)
-	}
-	return s
-}
-
-// MaskValue returns v with every registered sensitive value replaced by `***`
-// in every string it contains, walking slices and maps recursively. Non-string
-// scalars - numbers, booleans, nil - are returned unchanged: masking is
-// substring replacement over text, and a value that carried a secret would
-// have been rendered as a string before it got here.
-//
-// Map keys are masked as well as map values. A recipe is rendered as one
-// template before it is parsed, so a key is interpolated user data exactly as
-// a value is. Two keys that differ only inside a secret therefore collapse
-// into a single `***` entry - the same "two distinct values become
-// indistinguishable" trade-off masking already makes for task names.
-//
-// It exists for the values that reach a stream as interface{} - today the
-// `loop_item` field of `--list-tasks --json`, which carries whatever the
-// recipe's `loop:` resolved to: a scalar, a list, or a mapping. Masking the
-// value rather than the marshalled line is deliberate: a secret containing a
-// quote or a backslash is escaped in the serialised form, and MaskString
-// cannot be relied on to match it there.
-func MaskValue(v interface{}) interface{} {
-	switch t := v.(type) {
-	case nil:
-		return nil
-	case string:
-		return MaskString(t)
-	case []interface{}:
-		out := make([]interface{}, len(t))
-		for i, item := range t {
-			out[i] = MaskValue(item)
-		}
-		return out
-	case []string:
-		out := make([]string, len(t))
-		for i, item := range t {
-			out[i] = MaskString(item)
-		}
-		return out
-	case map[string]interface{}:
-		out := make(map[string]interface{}, len(t))
-		for k, item := range t {
-			out[MaskString(k)] = MaskValue(item)
-		}
-		return out
-	case map[string]string:
-		out := make(map[string]string, len(t))
-		for k, item := range t {
-			out[MaskString(k)] = MaskString(item)
-		}
-		return out
-	}
-	return maskReflectValue(v)
-}
-
-// maskReflectValue is the fallback for the container types the switch in
-// MaskValue does not name - the typed slices and maps an expr-evaluated
-// `loop:` can produce, and the map[interface{}]interface{} shape a
-// hand-built value can carry. It mirrors the reflect normalisation
-// tasks.resolveLoopList already applies on the way in. The copy is
-// interface{}-shaped because the only consumer serialises it to JSON, where
-// an object key is a string regardless. Anything that is not a slice, array,
-// or map is returned unchanged: a non-string scalar cannot carry a secret.
-func maskReflectValue(v interface{}) interface{} {
-	rv := reflect.ValueOf(v)
-	switch rv.Kind() {
-	case reflect.String:
-		return MaskString(rv.String())
-	case reflect.Slice, reflect.Array:
-		out := make([]interface{}, rv.Len())
-		for i := 0; i < rv.Len(); i++ {
-			out[i] = MaskValue(rv.Index(i).Interface())
-		}
-		return out
-	case reflect.Map:
-		out := make(map[string]interface{}, rv.Len())
-		iter := rv.MapRange()
-		for iter.Next() {
-			out[MaskString(fmt.Sprint(iter.Key().Interface()))] = MaskValue(iter.Value().Interface())
-		}
-		return out
-	case reflect.Ptr, reflect.Interface:
-		if rv.IsNil() {
-			return nil
-		}
-		return MaskValue(rv.Elem().Interface())
-	}
-	return v
 }

--- a/subprocess/mask_test.go
+++ b/subprocess/mask_test.go
@@ -1,26 +1,25 @@
 package subprocess
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
 )
 
-func TestMaskStringNoGlobalSet(t *testing.T) {
-	SetGlobalSensitive(nil)
-	defer SetGlobalSensitive(nil)
+func TestMaskStringWithNothingRegistered(t *testing.T) {
+	m := NewMasker()
 
-	if got := MaskString("hello world"); got != "hello world" {
+	if got := m.String("hello world"); got != "hello world" {
 		t.Errorf("MaskString with no global set = %q, want input unchanged", got)
 	}
 }
 
 func TestMaskStringReplacesAllOccurrences(t *testing.T) {
-	SetGlobalSensitive([]string{"secret"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("secret")
 
-	got := MaskString("a secret and another secret")
+	got := m.String("a secret and another secret")
 	want := "a *** and another ***"
 	if got != want {
 		t.Errorf("MaskString = %q, want %q", got, want)
@@ -28,15 +27,14 @@ func TestMaskStringReplacesAllOccurrences(t *testing.T) {
 }
 
 func TestMaskStringEmptyEntriesSkipped(t *testing.T) {
-	SetGlobalSensitive([]string{"", "tok"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("", "tok")
 
-	got := MaskString("xtoky")
+	got := m.String("xtoky")
 	if got != "x***y" {
 		t.Errorf("MaskString = %q, want %q", got, "x***y")
 	}
 	// Verify the empty entry didn't cause every character to mask.
-	if strings.Contains(MaskString("abc"), "***") && !strings.Contains("abc", "tok") {
+	if strings.Contains(m.String("abc"), "***") && !strings.Contains("abc", "tok") {
 		t.Errorf("empty entry caused unintended masking")
 	}
 }
@@ -44,20 +42,18 @@ func TestMaskStringEmptyEntriesSkipped(t *testing.T) {
 func TestMaskStringLongerBeforeShorter(t *testing.T) {
 	// "ab" is a substring of "abcdef"; the longer one must be masked first
 	// so we don't see "***cdef" instead of a single "***".
-	SetGlobalSensitive([]string{"ab", "abcdef"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("ab", "abcdef")
 
-	got := MaskString("xabcdefy")
+	got := m.String("xabcdefy")
 	if got != "x***y" {
 		t.Errorf("MaskString = %q, want %q (longer match first)", got, "x***y")
 	}
 }
 
-func TestSetGlobalSensitiveDeduplicates(t *testing.T) {
-	SetGlobalSensitive([]string{"a", "a", "b"})
-	defer SetGlobalSensitive(nil)
+func TestMaskerSetDeduplicates(t *testing.T) {
+	m := NewMasker("a", "a", "b")
 
-	values := GlobalSensitive()
+	values := m.Values()
 	count := 0
 	for _, v := range values {
 		if v == "a" {
@@ -69,104 +65,107 @@ func TestSetGlobalSensitiveDeduplicates(t *testing.T) {
 	}
 }
 
-func TestSetGlobalSensitiveClear(t *testing.T) {
-	SetGlobalSensitive([]string{"x"})
-	SetGlobalSensitive(nil)
-	if got := MaskString("xyz"); got != "xyz" {
-		t.Errorf("MaskString after clear = %q, want %q", got, "xyz")
+// TestMaskersAreIndependent is the property that replaced clearing. The old
+// registry was cleared on the way out of a run, and that teardown is what made
+// a second run in the same process lose its secrets. A Masker is never cleared;
+// two of them simply do not see each other.
+func TestMaskersAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	first := NewMasker("first-secret")
+	second := NewMasker("second-secret")
+
+	if got := first.String("first-secret second-secret"); got != "*** second-secret" {
+		t.Errorf("first masker = %q, want it to mask only its own value", got)
+	}
+	if got := second.String("first-secret second-secret"); got != "first-secret ***" {
+		t.Errorf("second masker = %q, want it to mask only its own value", got)
 	}
 }
 
-func TestAddGlobalSensitiveAppendsKeepingExisting(t *testing.T) {
-	SetGlobalSensitive([]string{"first"})
-	defer SetGlobalSensitive(nil)
+func TestMaskerAddAppendsKeepingExisting(t *testing.T) {
+	m := NewMasker("first")
 
-	AddGlobalSensitive("second")
+	m.Add("second")
 
-	got := MaskString("first and second")
+	got := m.String("first and second")
 	if got != "*** and ***" {
 		t.Errorf("MaskString = %q, want both values masked", got)
 	}
 }
 
-func TestAddGlobalSensitiveDeduplicatesAgainstExisting(t *testing.T) {
-	SetGlobalSensitive([]string{"tok"})
-	defer SetGlobalSensitive(nil)
+func TestMaskerAddDeduplicatesAgainstExisting(t *testing.T) {
+	m := NewMasker("tok")
 
-	AddGlobalSensitive("tok", "", "tok")
+	m.Add("tok", "", "tok")
 
 	count := 0
-	for _, v := range GlobalSensitive() {
+	for _, v := range m.Values() {
 		if v == "tok" {
 			count++
 		}
 	}
 	if count != 1 {
-		t.Errorf("AddGlobalSensitive introduced duplicates: %v", GlobalSensitive())
+		t.Errorf("Add introduced duplicates: %v", m.Values())
 	}
 }
 
-func TestAddGlobalSensitiveKeepsLengthDescOrder(t *testing.T) {
+func TestMaskerAddKeepsLengthDescOrder(t *testing.T) {
 	// "ab" registered first; adding the longer "abcdef" must still mask the
 	// longer match first so a substring secret does not leak its remainder.
-	SetGlobalSensitive([]string{"ab"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("ab")
 
-	AddGlobalSensitive("abcdef")
+	m.Add("abcdef")
 
-	if got := MaskString("xabcdefy"); got != "x***y" {
+	if got := m.String("xabcdefy"); got != "x***y" {
 		t.Errorf("MaskString = %q, want %q (longer match first)", got, "x***y")
 	}
 }
 
-func TestAddGlobalSensitiveOnEmptyRegistry(t *testing.T) {
-	SetGlobalSensitive(nil)
-	defer SetGlobalSensitive(nil)
+func TestMaskerAddOnEmptyRegistry(t *testing.T) {
+	m := NewMasker()
 
-	AddGlobalSensitive("late")
+	m.Add("late")
 
-	if got := MaskString("a late value"); got != "a *** value" {
+	if got := m.String("a late value"); got != "a *** value" {
 		t.Errorf("MaskString = %q, want the added value masked", got)
 	}
 }
 
-func TestAddGlobalSensitiveNoValuesIsNoop(t *testing.T) {
-	SetGlobalSensitive([]string{"keep"})
-	defer SetGlobalSensitive(nil)
+func TestMaskerAddNoValuesIsNoop(t *testing.T) {
+	m := NewMasker("keep")
 
-	AddGlobalSensitive()
+	m.Add()
 
-	if got := MaskString("keep"); got != "***" {
+	if got := m.String("keep"); got != "***" {
 		t.Errorf("MaskString = %q, want existing registry untouched", got)
 	}
 }
 
-// TestSetGlobalSensitiveRegistersTrimmedSpelling covers #473: a secret whose
+// TestMaskerSetRegistersTrimmedSpelling covers #473: a secret whose
 // value carries leading or trailing whitespace is rendered trimmed in places
 // docket builds text - the `(item=<value>)` loop suffix on a task name - and
 // masking is literal substring replacement, so both spellings must register.
-func TestSetGlobalSensitiveRegistersTrimmedSpelling(t *testing.T) {
-	SetGlobalSensitive([]string{"  padded  "})
-	defer SetGlobalSensitive(nil)
+func TestMaskerSetRegistersTrimmedSpelling(t *testing.T) {
+	m := NewMasker("  padded  ")
 
-	if got := MaskString("deploy (item=padded)"); got != "deploy (item=***)" {
+	if got := m.String("deploy (item=padded)"); got != "deploy (item=***)" {
 		t.Errorf("MaskString = %q, want the trimmed spelling masked", got)
 	}
-	if got := MaskString("raw:  padded  ."); got != "raw:***." {
+	if got := m.String("raw:  padded  ."); got != "raw:***." {
 		t.Errorf("MaskString = %q, want the literal spelling masked", got)
 	}
 }
 
-// TestAddGlobalSensitiveRegistersTrimmedSpelling pins the same rule on the
+// TestMaskerAddRegistersTrimmedSpelling pins the same rule on the
 // late-registration path, which is how a task-declared secret joins the
 // registry - after the recipe has parsed and already named its expansions.
-func TestAddGlobalSensitiveRegistersTrimmedSpelling(t *testing.T) {
-	SetGlobalSensitive(nil)
-	defer SetGlobalSensitive(nil)
+func TestMaskerAddRegistersTrimmedSpelling(t *testing.T) {
+	m := NewMasker()
 
-	AddGlobalSensitive("\tlate\n")
+	m.Add("\tlate\n")
 
-	if got := MaskString("configure (item=late)"); got != "configure (item=***)" {
+	if got := m.String("configure (item=late)"); got != "configure (item=***)" {
 		t.Errorf("MaskString = %q, want the trimmed spelling masked", got)
 	}
 }
@@ -176,32 +175,30 @@ func TestAddGlobalSensitiveRegistersTrimmedSpelling(t *testing.T) {
 // replaced first, so text holding the full value masks to a single `***`
 // rather than leaving the padding behind around an inner match.
 func TestSensitiveTrimmedSpellingSortsAfterLiteral(t *testing.T) {
-	SetGlobalSensitive([]string{" tok "})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker(" tok ")
 
-	values := GlobalSensitive()
+	values := m.Values()
 	want := []string{" tok ", "tok"}
 	if len(values) != len(want) {
-		t.Fatalf("GlobalSensitive = %v, want %v", values, want)
+		t.Fatalf("Values() = %v, want %v", values, want)
 	}
 	for i := range want {
 		if values[i] != want[i] {
-			t.Fatalf("GlobalSensitive = %v, want %v", values, want)
+			t.Fatalf("Values() = %v, want %v", values, want)
 		}
 	}
 }
 
 // TestSensitiveWhitespaceOnlyValueIsDropped keeps the trimmed spelling from
-// reintroducing the empty entry SetGlobalSensitive drops: an all-whitespace
+// reintroducing the empty entry the masker drops: an all-whitespace
 // value trims to "", which would otherwise match every position in a string.
 func TestSensitiveWhitespaceOnlyValueIsDropped(t *testing.T) {
-	SetGlobalSensitive([]string{"   "})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("   ")
 
-	if got := GlobalSensitive(); len(got) != 1 || got[0] != "   " {
-		t.Fatalf("GlobalSensitive = %v, want only the literal whitespace value", got)
+	if got := m.Values(); len(got) != 1 || got[0] != "   " {
+		t.Fatalf("Values() = %v, want only the literal whitespace value", got)
 	}
-	if got := MaskString("plain"); got != "plain" {
+	if got := m.String("plain"); got != "plain" {
 		t.Errorf("MaskString = %q, want %q; an empty entry masked everything", got, "plain")
 	}
 }
@@ -209,40 +206,37 @@ func TestSensitiveWhitespaceOnlyValueIsDropped(t *testing.T) {
 // TestSensitiveUnpaddedValueRegistersOnce keeps the common case free of a
 // duplicate entry: a value that is already trimmed contributes one spelling.
 func TestSensitiveUnpaddedValueRegistersOnce(t *testing.T) {
-	SetGlobalSensitive([]string{"plain"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("plain")
 
-	if got := GlobalSensitive(); len(got) != 1 || got[0] != "plain" {
-		t.Errorf("GlobalSensitive = %v, want a single entry", got)
+	if got := m.Values(); len(got) != 1 || got[0] != "plain" {
+		t.Errorf("Values() = %v, want a single entry", got)
 	}
 }
 
-// TestSetGlobalSensitiveRegistersEscapedSpelling covers #475: a generated
+// TestMaskerSetRegistersEscapedSpelling covers #475: a generated
 // resource address wraps a key value in strconv.Quote when a bare form would
 // not parse back, which escapes the double quote the value carries, so the
 // registered literal no longer matches inside the address it produced.
-func TestSetGlobalSensitiveRegistersEscapedSpelling(t *testing.T) {
-	SetGlobalSensitive([]string{`quo"ted`})
-	defer SetGlobalSensitive(nil)
+func TestMaskerSetRegistersEscapedSpelling(t *testing.T) {
+	m := NewMasker(`quo"ted`)
 
-	if got := MaskString(`dokku_stub[key="quo\"ted"]`); got != `dokku_stub[key="***"]` {
+	if got := m.String(`dokku_stub[key="quo\"ted"]`); got != `dokku_stub[key="***"]` {
 		t.Errorf("MaskString = %q, want the escaped spelling masked", got)
 	}
-	if got := MaskString(`raw:quo"ted.`); got != "raw:***." {
+	if got := m.String(`raw:quo"ted.`); got != "raw:***." {
 		t.Errorf("MaskString = %q, want the literal spelling masked", got)
 	}
 }
 
-// TestAddGlobalSensitiveRegistersEscapedSpelling pins the same rule on the
+// TestMaskerAddRegistersEscapedSpelling pins the same rule on the
 // late-registration path, which is how a task-declared secret joins the
 // registry - after the recipe has parsed and already named its tasks.
-func TestAddGlobalSensitiveRegistersEscapedSpelling(t *testing.T) {
-	SetGlobalSensitive(nil)
-	defer SetGlobalSensitive(nil)
+func TestMaskerAddRegistersEscapedSpelling(t *testing.T) {
+	m := NewMasker()
 
-	AddGlobalSensitive(`la"te`)
+	m.Add(`la"te`)
 
-	if got := MaskString(`dokku_stub[key="la\"te"]`); got != `dokku_stub[key="***"]` {
+	if got := m.String(`dokku_stub[key="la\"te"]`); got != `dokku_stub[key="***"]` {
 		t.Errorf("MaskString = %q, want the escaped spelling masked", got)
 	}
 }
@@ -252,17 +246,16 @@ func TestAddGlobalSensitiveRegistersEscapedSpelling(t *testing.T) {
 // longer one, so it is replaced first; the reverse order would leave the
 // escaping backslash stranded next to a `***`.
 func TestSensitiveEscapedSpellingSortsBeforeLiteral(t *testing.T) {
-	SetGlobalSensitive([]string{`a"b`})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker(`a"b`)
 
-	values := GlobalSensitive()
+	values := m.Values()
 	want := []string{`a\"b`, `a"b`}
 	if len(values) != len(want) {
-		t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+		t.Fatalf("Values() = %q, want %q", values, want)
 	}
 	for i := range want {
 		if values[i] != want[i] {
-			t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+			t.Fatalf("Values() = %q, want %q", values, want)
 		}
 	}
 }
@@ -272,13 +265,12 @@ func TestSensitiveEscapedSpellingSortsBeforeLiteral(t *testing.T) {
 // own, so it reaches an address escaped only when the value also carries a
 // comma, a bracket, or a quote. Both spellings register either way.
 func TestSensitiveBackslashValueRegistersEscapedSpelling(t *testing.T) {
-	SetGlobalSensitive([]string{`a,b\c`})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker(`a,b\c`)
 
-	if got := MaskString(`dokku_stub[key="a,b\\c"]`); got != `dokku_stub[key="***"]` {
+	if got := m.String(`dokku_stub[key="a,b\\c"]`); got != `dokku_stub[key="***"]` {
 		t.Errorf("MaskString = %q, want the escaped spelling masked", got)
 	}
-	if got := MaskString(`raw:a,b\c.`); got != "raw:***." {
+	if got := m.String(`raw:a,b\c.`); got != "raw:***." {
 		t.Errorf("MaskString = %q, want the literal spelling masked", got)
 	}
 }
@@ -288,13 +280,12 @@ func TestSensitiveBackslashValueRegistersEscapedSpelling(t *testing.T) {
 // escaping inside those quotes, so the literal still matches there and the
 // registry stays at one entry.
 func TestSensitiveCommaValueRegistersOnce(t *testing.T) {
-	SetGlobalSensitive([]string{"a,b"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("a,b")
 
-	if got := GlobalSensitive(); len(got) != 1 || got[0] != "a,b" {
-		t.Errorf("GlobalSensitive = %q, want a single entry", got)
+	if got := m.Values(); len(got) != 1 || got[0] != "a,b" {
+		t.Errorf("Values() = %q, want a single entry", got)
 	}
-	if got := MaskString(`dokku_stub[key="a,b"]`); got != `dokku_stub[key="***"]` {
+	if got := m.String(`dokku_stub[key="a,b"]`); got != `dokku_stub[key="***"]` {
 		t.Errorf("MaskString = %q, want the quoted value masked", got)
 	}
 }
@@ -303,17 +294,16 @@ func TestSensitiveCommaValueRegistersOnce(t *testing.T) {
 // derivations compose. A value that is both padded and escape-bearing is
 // printed four ways, and every one of them masks.
 func TestSensitivePaddedEscapedValueRegistersEverySpelling(t *testing.T) {
-	SetGlobalSensitive([]string{` p"q `})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker(` p"q `)
 
-	values := GlobalSensitive()
+	values := m.Values()
 	want := []string{` p\"q `, ` p"q `, `p\"q`, `p"q`}
 	if len(values) != len(want) {
-		t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+		t.Fatalf("Values() = %q, want %q", values, want)
 	}
 	for i := range want {
 		if values[i] != want[i] {
-			t.Fatalf("GlobalSensitive = %q, want %q", values, want)
+			t.Fatalf("Values() = %q, want %q", values, want)
 		}
 	}
 }
@@ -322,42 +312,44 @@ func TestSensitivePaddedEscapedValueRegistersEverySpelling(t *testing.T) {
 // registering the escaped spelling must not widen masking to a value that
 // merely shares a prefix with a secret.
 func TestSensitiveEscapedSpellingLeavesLookalikesAlone(t *testing.T) {
-	SetGlobalSensitive([]string{`a"b`})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker(`a"b`)
 
-	if got := MaskString(`dokku_stub[key=keepzzz]`); got != `dokku_stub[key=keepzzz]` {
+	if got := m.String(`dokku_stub[key=keepzzz]`); got != `dokku_stub[key=keepzzz]` {
 		t.Errorf("MaskString = %q, want the non-secret value untouched", got)
 	}
 }
 
 func TestMaskStringConcurrent(t *testing.T) {
-	SetGlobalSensitive([]string{"secret"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("secret")
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			SetGlobalSensitive([]string{"secret", "token"})
+			m.Add("token")
 		}()
 		go func() {
 			defer wg.Done()
-			_ = MaskString("a secret token here")
+			_ = m.String("a secret token here")
 		}()
 	}
 	wg.Wait()
+
+	// A value added under contention is still registered afterwards.
+	if got := m.String("a secret token here"); got != "a *** *** here" {
+		t.Errorf("after concurrent use = %q, want both values masked", got)
+	}
 }
 
-func TestGlobalSensitiveReturnsCopy(t *testing.T) {
-	SetGlobalSensitive([]string{"a"})
-	defer SetGlobalSensitive(nil)
+func TestMaskerValuesReturnsCopy(t *testing.T) {
+	m := NewMasker("a")
 
-	values := GlobalSensitive()
+	values := m.Values()
 	values[0] = "mutated"
-	again := GlobalSensitive()
+	again := m.Values()
 	if again[0] != "a" {
-		t.Errorf("GlobalSensitive returned shared slice; mutation leaked: %v", again)
+		t.Errorf("Values returned a shared slice; mutation leaked: %v", again)
 	}
 }
 
@@ -366,8 +358,7 @@ func TestGlobalSensitiveReturnsCopy(t *testing.T) {
 // `loop:` can resolve to a scalar, a list, or a mapping, so a secret can sit
 // at any depth and on either side of a map entry.
 func TestMaskValue(t *testing.T) {
-	SetGlobalSensitive([]string{"sekret"})
-	defer SetGlobalSensitive(nil)
+	m := NewMasker("sekret")
 
 	cases := []struct {
 		name string
@@ -414,22 +405,79 @@ func TestMaskValue(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := MaskValue(tc.in); !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("MaskValue(%#v) = %#v, want %#v", tc.in, got, tc.want)
+			if got := m.Value(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("m.Value(%#v) = %#v, want %#v", tc.in, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestMaskValueEmptyRegistry pins that a value survives the walk unchanged
+// TestMaskValueWithNothingRegistered pins that a value survives the walk unchanged
 // when nothing is registered, so the listing renders identically for a recipe
 // that declares no secrets.
-func TestMaskValueEmptyRegistry(t *testing.T) {
-	SetGlobalSensitive(nil)
-	defer SetGlobalSensitive(nil)
+func TestMaskValueWithNothingRegistered(t *testing.T) {
+	m := NewMasker()
 
 	in := map[string]interface{}{"user": "alice", "ports": []interface{}{80, "443"}}
-	if got := MaskValue(in); !reflect.DeepEqual(got, in) {
+	if got := m.Value(in); !reflect.DeepEqual(got, in) {
 		t.Errorf("MaskValue with an empty registry = %#v, want input unchanged", got)
+	}
+}
+
+// TestMaskerSurvivesAnotherRunFinishing is the fail-open case #501 exists to
+// close. The registry this replaced was process-wide and the API that filled
+// it *replaced* the set, so a second run's teardown - a deferred clear - blanked
+// the first run's secrets while it was still writing output. A Masker is owned
+// by its run and never cleared, so a run that finishes cannot affect one that
+// has not.
+func TestMaskerSurvivesAnotherRunFinishing(t *testing.T) {
+	t.Parallel()
+
+	first := NewMasker("first-secret")
+
+	// A second run starts, does its work, and ends. Under the old registry
+	// this is the point the first run's secrets were lost.
+	func() {
+		second := NewMasker("second-secret")
+		if got := second.String("second-secret"); got != MaskPlaceholder {
+			t.Errorf("second run masked %q, want %q", got, MaskPlaceholder)
+		}
+	}()
+
+	if got := first.String("first-secret"); got != MaskPlaceholder {
+		t.Errorf("first run masked %q after the second finished, want %q", got, MaskPlaceholder)
+	}
+}
+
+// TestContextMaskerRoundTrip pins the carrier the layers with no other reason
+// to know about a run use to reach it.
+func TestContextMaskerRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	m := NewMasker("secret")
+	if got := MaskerFromContext(ContextWithMasker(context.Background(), m)); got != m {
+		t.Errorf("MaskerFromContext returned %p, want %p", got, m)
+	}
+}
+
+// TestNilMaskerMasksNothing pins the property that lets every masking site skip
+// a nil check: a caller that registered no secrets has nothing to hide.
+func TestNilMaskerMasksNothing(t *testing.T) {
+	t.Parallel()
+
+	var m *Masker
+	if got := m.String("secret"); got != "secret" {
+		t.Errorf("nil masker changed %q to %q", "secret", got)
+	}
+	if got := m.Value([]string{"secret"}); !reflect.DeepEqual(got, []string{"secret"}) {
+		t.Errorf("nil masker changed %v", got)
+	}
+	if got := m.Values(); got != nil {
+		t.Errorf("nil masker has values: %v", got)
+	}
+	m.Add("ignored") // must not panic
+	// A context carrying nothing yields the same nil masker.
+	if got := MaskerFromContext(context.Background()); got != nil {
+		t.Errorf("empty context yielded a masker: %v", got)
 	}
 }

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -303,6 +303,7 @@ func CallSshCommand(ctx context.Context, target Target, input ExecCommandInput) 
 	// isatty reports whether our own stdout is a terminal, which is the
 	// signal used below to decide whether the child may read the terminal.
 	isatty := !color.NoColor
+	masker := MaskerFromContext(ctx)
 
 	remote := append([]string{input.Command}, input.Args...)
 	argv, err := buildSshArgv(parsed, target, remote)
@@ -319,7 +320,7 @@ func CallSshCommand(ctx context.Context, target Target, input ExecCommandInput) 
 	}
 
 	if os.Getenv("DOKKU_TRACE") == "1" {
-		log.Printf("ssh: %s %s", MaskString("ssh"), MaskString(strings.Join(argv, " ")))
+		log.Printf("ssh: %s %s", masker.String("ssh"), masker.String(strings.Join(argv, " ")))
 	}
 
 	if input.Stdin != nil {
@@ -343,7 +344,7 @@ func CallSshCommand(ctx context.Context, target Target, input ExecCommandInput) 
 		cmd.StdErrWriter = input.StderrWriter
 	}
 
-	resolved := resolveSshCommandString(input.Command, input.Args)
+	resolved := resolveSshCommandString(masker, input.Command, input.Args)
 
 	res, runErr := cmd.Execute(ctx)
 	resp := ExecCommandResponse{

--- a/tasks/context_test.go
+++ b/tasks/context_test.go
@@ -1,11 +1,6 @@
 package tasks
 
-import (
-	"context"
-	"testing"
-
-	"github.com/dokku/docket/subprocess"
-)
+import "context"
 
 // testCtx is the context unit tests pass to Plan, Execute and the helpers
 // below them. It exists so a test file can call `t.Plan(testCtx())` without
@@ -16,20 +11,4 @@ import (
 // Tests that need cancellation or a target build their own context instead.
 func testCtx() context.Context {
 	return context.Background()
-}
-
-// isolateMaskRegistry gives the test an empty sensitive-value registry and puts
-// the previous set back when it finishes.
-//
-// Restoring rather than clearing is what lets TestMain's end-of-run check mean
-// anything. Production code in this package registers sensitive values and
-// never clears them - tasks/properties.go does it for a property marked
-// sensitive, registerSensitiveMapValues does it for a map field - so residue
-// outlives the test that created it. A test that cleared on the way out would
-// wipe an earlier test's residue and hide exactly what that check looks for.
-func isolateMaskRegistry(t *testing.T) {
-	t.Helper()
-	prev := subprocess.GlobalSensitive()
-	subprocess.SetGlobalSensitive(nil)
-	t.Cleanup(func() { subprocess.SetGlobalSensitive(prev) })
 }

--- a/tasks/identity_test.go
+++ b/tasks/identity_test.go
@@ -138,8 +138,7 @@ func TestIdentityAddressMasksQuotedSensitiveValue(t *testing.T) {
 		{name: "a tab is escaped once the value is quoted", option: "--label tab,\tzzz"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			isolateMaskRegistry(t)
-			subprocess.SetGlobalSensitive([]string{tt.option})
+			masker := subprocess.NewMasker(tt.option)
 
 			address := IdentityAddress("dokku_docker_options", DockerOptionsTask{
 				App:    "api",
@@ -149,9 +148,9 @@ func TestIdentityAddressMasksQuotedSensitiveValue(t *testing.T) {
 			if !strings.Contains(address, "zzz") {
 				t.Fatalf("address %q does not carry the value under test", address)
 			}
-			masked := subprocess.MaskString(address)
+			masked := masker.String(address)
 			if strings.Contains(masked, "zzz") {
-				t.Fatalf("MaskString(%q) = %q, want the sensitive option masked", address, masked)
+				t.Fatalf("masking %q gave %q, want the sensitive option masked", address, masked)
 			}
 		})
 	}

--- a/tasks/integration_helpers_test.go
+++ b/tasks/integration_helpers_test.go
@@ -10,33 +10,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
-
-	// Production code in this package registers sensitive values into a
-	// process-wide registry and never clears it: tasks/properties.go does it
-	// for a property the plugin marks sensitive, and registerSensitiveMapValues
-	// does it for a map field. Harmless in a CLI that exits afterwards; in a
-	// test binary the residue outlives the test that created it and masks any
-	// literal a later test expects to read back in the clear.
-	//
-	// Four property tests were doing exactly that, each leaving its secret
-	// registered for every test that ran after it. It went unnoticed because
-	// the tests that set the registry directly cleared it to nil on the way
-	// out, wiping the evidence before anything could observe it - so this
-	// check is only sound because isolateMaskRegistry restores the previous
-	// set instead. Nothing wipes residue any more, so anything a test
-	// registers survives to here.
-	if leaked := subprocess.GlobalSensitive(); len(leaked) > 0 {
-		fmt.Fprintf(os.Stderr,
-			"mask registry is not empty after the package run: %q\n"+
-				"a test registered a sensitive value without restoring the previous set; "+
-				"use isolateMaskRegistry\n", leaked)
-		if code == 0 {
-			code = 1
-		}
-	}
-
-	os.Exit(code)
+	os.Exit(m.Run())
 }
 
 func dokkuAvailable() bool {
@@ -60,7 +34,6 @@ func skipIfNoDokkuT(t *testing.T) {
 	// test and trip TestMain's end-of-run check. Isolating at the one gate every
 	// integration test already passes through covers all of them without each
 	// having to know whether the task it applies happens to be sensitive.
-	isolateMaskRegistry(t)
 }
 
 func dokkuPluginInstalled(plugin string) bool {

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -734,7 +734,7 @@ func planProperty(ctx context.Context, task PropertyTableDocer, state State, app
 	// directly would leave an unprobeable credential unmasked (#457).
 	sensitive := propertyEntry(plugin, property, keys).Sensitive
 	if sensitive {
-		subprocess.AddGlobalSensitive(value)
+		subprocess.MaskerFromContext(ctx).Add(value)
 	}
 
 	return DispatchPlan(state, map[State]func() PlanResult{
@@ -750,7 +750,7 @@ func planProperty(ctx context.Context, task PropertyTableDocer, state State, app
 			// surface SSH transport failures so the user sees `! ssh:`.
 			current, probeErr := getProperty(ctx, subcommand, app, global, property, keys)
 			if sensitive {
-				subprocess.AddGlobalSensitive(current)
+				subprocess.MaskerFromContext(ctx).Add(current)
 			}
 			var warnings []PlanWarning
 			if probeErr != nil {
@@ -795,7 +795,7 @@ func planProperty(ctx context.Context, task PropertyTableDocer, state State, app
 
 			current, probeErr := getProperty(ctx, subcommand, app, global, property, keys)
 			if sensitive {
-				subprocess.AddGlobalSensitive(current)
+				subprocess.MaskerFromContext(ctx).Add(current)
 			}
 			var warnings []PlanWarning
 			if probeErr != nil {

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -41,7 +41,7 @@ func TestGetPropertyArgsGlobal(t *testing.T) {
 }
 
 func TestPlanPropertyMasksSensitiveDriftValue(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 
 	keys := map[string]PropertyKeys{
 		"secret-prop": {PerApp: "", Global: "global-secret-prop", Sensitive: true},
@@ -50,31 +50,31 @@ func TestPlanPropertyMasksSensitiveDriftValue(t *testing.T) {
 		"--quiet myplugin:report --global --format json": `{"global-secret-prop":"oldsecret"}`,
 	}))()
 
-	res := planProperty(testCtx(), fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "secret-prop", "newsecret")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "secret-prop", "newsecret")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
 
 	// The probed old value and the desired new value are both secrets and must
 	// be registered so the drift reason and command echo mask them.
-	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "oldsecret") {
+	if masked := masker.String(res.Reason); strings.Contains(masked, "oldsecret") {
 		t.Errorf("drift reason leaked probed secret: %q -> %q", res.Reason, masked)
 	}
 	if !strings.Contains(res.Reason, "oldsecret") {
 		t.Fatalf("expected reason to embed the probed value pre-masking, got %q", res.Reason)
 	}
-	if masked := subprocess.MaskString(res.Reason); !strings.Contains(masked, "***") {
+	if masked := masker.String(res.Reason); !strings.Contains(masked, "***") {
 		t.Errorf("expected mask placeholder in masked reason, got %q", masked)
 	}
 	for _, cmd := range res.Commands {
-		if masked := subprocess.MaskString(cmd); strings.Contains(masked, "newsecret") {
+		if masked := masker.String(cmd); strings.Contains(masked, "newsecret") {
 			t.Errorf("command leaked desired secret after masking: %q -> %q", cmd, masked)
 		}
 	}
 }
 
 func TestPlanPropertyAbsentMasksSensitiveOldValue(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 
 	keys := map[string]PropertyKeys{
 		"secret-prop": {PerApp: "", Global: "global-secret-prop", Sensitive: true},
@@ -85,17 +85,17 @@ func TestPlanPropertyAbsentMasksSensitiveOldValue(t *testing.T) {
 
 	// The absent path leaks the current server secret even without a sensitive
 	// recipe value (the value must be empty for absent).
-	res := planProperty(testCtx(), fakePropertyTask("myplugin:set", keys), StateAbsent, "", true, "secret-prop", "")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), fakePropertyTask("myplugin:set", keys), StateAbsent, "", true, "secret-prop", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
-	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "livesecret") {
+	if masked := masker.String(res.Reason); strings.Contains(masked, "livesecret") {
 		t.Errorf("unset reason leaked server secret: %q -> %q", res.Reason, masked)
 	}
 }
 
 func TestPlanPropertyDoesNotMaskBenignDriftValue(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 
 	keys := map[string]PropertyKeys{
 		"timeout": {PerApp: "", Global: "global-timeout"},
@@ -104,12 +104,12 @@ func TestPlanPropertyDoesNotMaskBenignDriftValue(t *testing.T) {
 		"--quiet myplugin:report --global --format json": `{"global-timeout":"60s"}`,
 	}))()
 
-	res := planProperty(testCtx(), fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "timeout", "90s")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), fakePropertyTask("myplugin:set", keys), StatePresent, "", true, "timeout", "90s")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
 	// A non-sensitive property keeps its old value visible for a useful diff.
-	if masked := subprocess.MaskString(res.Reason); !strings.Contains(masked, "60s") {
+	if masked := masker.String(res.Reason); !strings.Contains(masked, "60s") {
 		t.Errorf("benign old value should not be masked, got %q", masked)
 	}
 }
@@ -225,8 +225,8 @@ func TestUnknownPropertyWarningInvalidFlag(t *testing.T) {
 // secret that reaches it must mask at emit time. The message is stored raw
 // (like PlanResult.Reason) so the assertion masks it the way the emitter does.
 func TestUnknownPropertyWarningMasksSensitiveStderr(t *testing.T) {
-	isolateMaskRegistry(t)
-	subprocess.AddGlobalSensitive("s3cr3t")
+	masker := subprocess.NewMasker()
+	masker.Add("s3cr3t")
 
 	execErr := &subprocess.ExecError{
 		Response: subprocess.ExecCommandResponse{
@@ -241,7 +241,7 @@ func TestUnknownPropertyWarningMasksSensitiveStderr(t *testing.T) {
 	if !strings.Contains(w.Message, "s3cr3t") {
 		t.Fatalf("message should embed raw stderr pre-masking, got %q", w.Message)
 	}
-	if masked := subprocess.MaskString(w.Message); strings.Contains(masked, "s3cr3t") {
+	if masked := masker.String(w.Message); strings.Contains(masked, "s3cr3t") {
 		t.Errorf("masked warning leaked secret: %q -> %q", w.Message, masked)
 	}
 }
@@ -283,6 +283,7 @@ func TestUnknownPropertyWarningDynamicPropertySkipsWarning(t *testing.T) {
 // report payload missing the probed key yields drift plus a PlanWarning the run
 // loop can drain. (#353)
 func TestPlanPropertyAttachesUnknownKeyWarning(t *testing.T) {
+	masker := subprocess.NewMasker()
 	keys := map[string]PropertyKeys{
 		"hsts": {PerApp: "hsts", Global: ""},
 	}
@@ -290,7 +291,7 @@ func TestPlanPropertyAttachesUnknownKeyWarning(t *testing.T) {
 		"--quiet nginx:report myapp --format json": `{"proxy-read-timeout":"60s"}`,
 	}))()
 
-	res := planProperty(testCtx(), fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -306,6 +307,7 @@ func TestPlanPropertyAttachesUnknownKeyWarning(t *testing.T) {
 // `:report --format json` fails with an "Invalid flag" stderr, so the probe
 // error becomes drift plus a probe_rejected PlanWarning. (#353)
 func TestPlanPropertyAttachesRejectedProbeWarning(t *testing.T) {
+	masker := subprocess.NewMasker()
 	keys := map[string]PropertyKeys{
 		"hsts": {PerApp: "hsts", Global: ""},
 	}
@@ -317,7 +319,7 @@ func TestPlanPropertyAttachesRejectedProbeWarning(t *testing.T) {
 		return resp, &subprocess.ExecError{Response: resp, Err: errors.New("exit status 1"), Ran: true}
 	})()
 
-	res := planProperty(testCtx(), fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), fakePropertyTask("nginx:set", keys), StatePresent, "myapp", false, "hsts", "true")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -427,12 +429,12 @@ func TestDynamicPropertiesFromReport(t *testing.T) {
 // dns-provider-* credential that already matches the recipe plans as in sync
 // instead of reporting drift on every run.
 func TestPlanPropertyDynamicLetsencryptInSync(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"token123"}`,
 	}))()
 
-	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -445,12 +447,12 @@ func TestPlanPropertyDynamicLetsencryptInSync(t *testing.T) {
 }
 
 func TestPlanPropertyDynamicLetsencryptGlobalInSync(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report --global --format json": `{"global-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
 	}))()
 
-	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "", true, "dns-provider-NAMECHEAP_API_USER", "deploy-bot")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), LetsencryptPropertyTask{}, StatePresent, "", true, "dns-provider-NAMECHEAP_API_USER", "deploy-bot")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -463,13 +465,13 @@ func TestPlanPropertyDynamicLetsencryptGlobalInSync(t *testing.T) {
 // mark on the synthesized keys: the probed credential reaches the drift reason
 // and must be registered with the masker.
 func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"oldtoken"}`,
 	}))()
 
-	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "newtoken")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "newtoken")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -479,11 +481,11 @@ func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
 	if !strings.Contains(res.Reason, "drift") {
 		t.Errorf("reason = %q; want a drift reason", res.Reason)
 	}
-	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "oldtoken") {
+	if masked := masker.String(res.Reason); strings.Contains(masked, "oldtoken") {
 		t.Errorf("drift reason leaked the probed credential: %q -> %q", res.Reason, masked)
 	}
 	for _, cmd := range res.Commands {
-		if masked := subprocess.MaskString(cmd); strings.Contains(masked, "newtoken") {
+		if masked := masker.String(cmd); strings.Contains(masked, "newtoken") {
 			t.Errorf("command leaked the desired credential: %q -> %q", cmd, masked)
 		}
 	}
@@ -493,12 +495,12 @@ func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
 // state: the plugin only emits a row once the property holds a value, so an
 // absent row is an unset property and not a probe failure worth warning about.
 func TestPlanPropertyDynamicLetsencryptMissingRowPlansCreate(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
 	}))()
 
-	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), LetsencryptPropertyTask{}, StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -514,11 +516,12 @@ func TestPlanPropertyDynamicLetsencryptMissingRowPlansCreate(t *testing.T) {
 }
 
 func TestPlanPropertyDynamicLetsencryptAbsentMissingRowIsInSync(t *testing.T) {
+	masker := subprocess.NewMasker()
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
 	}))()
 
-	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -528,20 +531,20 @@ func TestPlanPropertyDynamicLetsencryptAbsentMissingRowIsInSync(t *testing.T) {
 }
 
 func TestPlanPropertyDynamicLetsencryptAbsentPlansDestroy(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"livetoken"}`,
 	}))()
 
-	res := planProperty(testCtx(), LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), LetsencryptPropertyTask{}, StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
 	if res.Status != PlanStatusDestroy {
 		t.Errorf("status = %q; want %q", res.Status, PlanStatusDestroy)
 	}
-	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "livetoken") {
+	if masked := masker.String(res.Reason); strings.Contains(masked, "livetoken") {
 		t.Errorf("unset reason leaked the probed credential: %q -> %q", res.Reason, masked)
 	}
 }
@@ -550,14 +553,14 @@ func TestPlanPropertyDynamicLetsencryptAbsentPlansDestroy(t *testing.T) {
 // family on the unprobed path while dokku/dokku#8928 is open (#450): it must not
 // even attempt a report read.
 func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 	var ran []string
 	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		ran = append(ran, strings.Join(in.Args, " "))
 		return subprocess.ExecCommandResponse{}, nil
 	})()
 
-	res := planProperty(testCtx(), TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "token123")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -576,13 +579,13 @@ func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
 // all the same, so the desired value must reach the masker before it lands in
 // the command echo or the plan mutation line.
 func TestPlanPropertyDynamicTraefikMasksCredential(t *testing.T) {
-	isolateMaskRegistry(t)
+	masker := subprocess.NewMasker()
 
 	defer subprocess.SetExecRunner(func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
 		return subprocess.ExecCommandResponse{}, nil
 	})()
 
-	res := planProperty(testCtx(), TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "traefiktoken")
+	res := planProperty(subprocess.ContextWithMasker(testCtx(), masker), TraefikPropertyTask{}, StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "traefiktoken")
 	if res.Error != nil {
 		t.Fatalf("planProperty error: %v", res.Error)
 	}
@@ -592,12 +595,12 @@ func TestPlanPropertyDynamicTraefikMasksCredential(t *testing.T) {
 	// Commands are masked as they are resolved, so a leak here means the value
 	// was never registered; mutations are masked by the emitter instead.
 	for _, cmd := range res.Commands {
-		if masked := subprocess.MaskString(cmd); strings.Contains(masked, "traefiktoken") {
+		if masked := masker.String(cmd); strings.Contains(masked, "traefiktoken") {
 			t.Errorf("command leaked the credential: %q -> %q", cmd, masked)
 		}
 	}
 	for _, mutation := range res.Mutations {
-		if masked := subprocess.MaskString(mutation); strings.Contains(masked, "traefiktoken") {
+		if masked := masker.String(mutation); strings.Contains(masked, "traefiktoken") {
 			t.Errorf("mutation leaked the credential: %q -> %q", mutation, masked)
 		}
 	}

--- a/tasks/scheduler_k3s_autoscaling_auth.go
+++ b/tasks/scheduler_k3s_autoscaling_auth.go
@@ -61,7 +61,7 @@ func planSchedulerK3sAutoscalingAuthSet(ctx context.Context, spec schedulerK3sAu
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
-	registerSensitiveMapValues(current)
+	registerSensitiveMapValues(ctx, current)
 
 	drifted, allNew := driftedKeys(spec.Metadata, current)
 	if len(drifted) == 0 {
@@ -99,7 +99,7 @@ func planSchedulerK3sAutoscalingAuthUnset(ctx context.Context, spec schedulerK3s
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
-	registerSensitiveMapValues(current)
+	registerSensitiveMapValues(ctx, current)
 
 	toClear := intersectingKeys(spec.Metadata, current)
 	if len(toClear) == 0 {

--- a/tasks/scheduler_k3s_autoscaling_auth_task_test.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task_test.go
@@ -39,7 +39,10 @@ func TestSchedulerK3sAutoscalingAuthTaskSensitiveValuesAbsentEmpty(t *testing.T)
 }
 
 func TestSchedulerK3sAutoscalingAuthUnsetMasksProbedSecrets(t *testing.T) {
-	isolateMaskRegistry(t)
+	// The probed secrets are registered with whatever masker the planning
+	// context carries, so the test supplies one and reads back through it.
+	masker := subprocess.NewMasker()
+	ctx := subprocess.ContextWithMasker(testCtx(), masker)
 
 	// The server holds two metadata keys; the task clears one, so the other
 	// survives and is read back (with its secret value) for the restore call.
@@ -53,14 +56,14 @@ func TestSchedulerK3sAutoscalingAuthUnsetMasksProbedSecrets(t *testing.T) {
 		Metadata: map[string]string{"secretName": ""},
 		State:    StateAbsent,
 	}
-	result := task.Plan(testCtx())
+	result := task.Plan(ctx)
 	if result.Error != nil {
 		t.Fatalf("Plan returned error: %v", result.Error)
 	}
 
 	// Both the cleared key's old value and the surviving key's value are
 	// server-probed secrets; they must be registered so every sink masks them.
-	registered := subprocess.GlobalSensitive()
+	registered := masker.Values()
 	for _, secret := range []string{"my-secret", "REALSECRET"} {
 		found := false
 		for _, v := range registered {
@@ -76,7 +79,7 @@ func TestSchedulerK3sAutoscalingAuthUnsetMasksProbedSecrets(t *testing.T) {
 	// The rendered mutations (unset ... (was "my-secret"), restore ...=REALSECRET)
 	// must mask to *** once the probed values are registered.
 	for _, m := range result.Mutations {
-		if masked := subprocess.MaskString(m); strings.Contains(masked, "REALSECRET") || strings.Contains(masked, "my-secret") {
+		if masked := masker.String(m); strings.Contains(masked, "REALSECRET") || strings.Contains(masked, "my-secret") {
 			t.Errorf("mutation leaked a probed secret after masking: %q -> %q", m, masked)
 		}
 	}

--- a/tasks/sensitive.go
+++ b/tasks/sensitive.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/dokku/docket/subprocess"
@@ -77,13 +78,13 @@ func CollectPlaySensitiveValues(plays []*Play) []string {
 	return out
 }
 
-// registerSensitiveMapValues adds every non-empty value of m to the global
-// mask registry at plan time. It is for values that are secret but only become
+// registerSensitiveMapValues adds every non-empty value of m to the run's
+// masker at plan time. It is for values that are secret but only become
 // known after a server probe - the pre-run collection in commands/apply.go and
 // commands/plan.go walks task structs, so it cannot see them (e.g. a
 // scheduler-k3s trigger's surviving metadata read back from the server). The
 // keys are not masked; only the values.
-func registerSensitiveMapValues(m map[string]string) {
+func registerSensitiveMapValues(ctx context.Context, m map[string]string) {
 	if len(m) == 0 {
 		return
 	}
@@ -91,7 +92,7 @@ func registerSensitiveMapValues(m map[string]string) {
 	for _, v := range m {
 		values = append(values, v)
 	}
-	subprocess.AddGlobalSensitive(values...)
+	subprocess.MaskerFromContext(ctx).Add(values...)
 }
 
 // sensitiveValuesFromTask returns the masked-value set for a single task.

--- a/tasks/service_create_task_test.go
+++ b/tasks/service_create_task_test.go
@@ -25,9 +25,9 @@ func serviceMissing() func(context.Context, subprocess.ExecCommandInput) (subpro
 
 // planCreateCommand returns the single command Plan() would run to create the
 // task's service, failing the test if the plan did not reach a create.
-func planCreateCommand(t *testing.T, task ServiceCreateTask) string {
+func planCreateCommand(t *testing.T, ctx context.Context, task ServiceCreateTask) string {
 	t.Helper()
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if plan.Error != nil {
 		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
@@ -193,7 +193,7 @@ func TestServiceCreateTaskCreateFlags(t *testing.T) {
 			// a struct built in Go has to state it for DispatchPlan.
 			task := tc.task
 			task.State = StatePresent
-			if got := planCreateCommand(t, task); got != tc.want {
+			if got := planCreateCommand(t, testCtx(), task); got != tc.want {
 				t.Errorf("command = %q, want %q", got, tc.want)
 			}
 		})
@@ -243,11 +243,11 @@ func TestServiceCreateTaskMasksSecretsInCommands(t *testing.T) {
 		State:        StatePresent,
 	}
 
-	isolateMaskRegistry(t)
-	subprocess.SetGlobalSensitive(sensitiveValuesFromTask(&task))
+	masker := subprocess.NewMasker(sensitiveValuesFromTask(&task)...)
+	ctx := subprocess.ContextWithMasker(testCtx(), masker)
 	defer subprocess.SetExecRunner(serviceMissing())()
 
-	got := planCreateCommand(t, task)
+	got := planCreateCommand(t, ctx, task)
 	for _, secret := range []string{"env-secret", "user-secret", "root-secret"} {
 		if strings.Contains(got, secret) {
 			t.Errorf("command %q leaks %q", got, secret)
@@ -874,10 +874,9 @@ func TestServiceCreateTaskImageDriftUpgradeMasksSecrets(t *testing.T) {
 	task := driftTask()
 	task.ImageDrift = imageDriftUpgrade
 	task.CustomEnv = map[string]string{"GREETING": "s3cret"}
-	isolateMaskRegistry(t)
-	subprocess.SetGlobalSensitive(sensitiveValuesFromTask(&task))
+	ctx := subprocess.ContextWithMasker(testCtx(), subprocess.NewMasker(sensitiveValuesFromTask(&task)...))
 
-	plan := task.Plan(testCtx())
+	plan := task.Plan(ctx)
 	if len(plan.Commands) != 1 {
 		t.Fatalf("expected 1 command, got %v", plan.Commands)
 	}


### PR DESCRIPTION
The set of values docket must not print was process-wide, and the API that filled it *replaced* the set rather than adding to it. Each command populated it at the top of `Run` and deferred a clear, so two runs sharing a process had the first one's teardown blank the second one's secrets while it was still writing output. That is fail-open, and it is the last of the three globals #423 named.

It becomes a `subprocess.Masker` the run owns. The layers that mask text but have no other reason to know about a run - the subprocess transports, a task registering a secret it just read back off the server - reach it through the context they already receive. The layers that render but have no context - the human formatter, the JSON emitter, `docket validate` - are handed it at construction, which is where they already take the Ui.

There is no `Set`. Nothing needs one: a run's secrets only accumulate, and a masker goes out of scope with the run that owns it, so there is no teardown left to get wrong. A nil `*Masker` masks nothing and is safe to call, which is what lets every masking site drop its nil check - a caller that registered no secrets has nothing to hide.

Three places could not take either route. `unknownPlayError.Error()` has a fixed signature and formats lazily on purpose, because the message must name secrets registered after the error was built (#477); it carries the masker, and since that is a pointer to the run's own, the later registrations still reach it. `docket validate` has no context at all, being offline by contract, so its masker rides on the command struct. And `maskedStrings` straddles the emitter boundary, serving both the JSON stream and `--list-tasks`, so it takes the masker as an argument rather than becoming a method.

Two things from #507 are deleted rather than migrated. The `TestMain` canary that failed the `tasks` run when the registry was dirty, and the `isolateMaskRegistry` helper its soundness depended on, both existed to police a global that no longer exists. The three `tasks` test files that #502 had to leave serial for this reason are unblocked; turning them parallel belongs with the rest of that migration.

Fixes #501.

Unblocks the `commands` half of #502, alongside #505 and #506.
