### PR TITLE
refactor: take the command layer off process globals

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -20,6 +20,16 @@ import (
 type ApplyCommand struct {
 	command.Meta
 
+	// BaseDir is the directory relative paths resolve against - the recipe
+	// probed when --tasks is absent, and any output written to a relative
+	// path. Populated from main.go; empty means the process working
+	// directory, which is what it always was.
+	//
+	// It exists so a test can point a command at a temp directory instead of
+	// chdir'ing the whole process, which no test can do while another runs
+	// beside it.
+	BaseDir string
+
 	// Stdin is where a `--tasks -` recipe is read from. Populated from
 	// main.go; nil reads the process's standard input. A test hands over its
 	// own pipe instead of swapping os.Stdin, which no two tests can do at
@@ -124,7 +134,7 @@ func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f.StringVar(&c.startAtTask, "start-at-task", "", "skip every task before the matched name; the matched task and successors run normally. Filter order: --start-at-task -> --tags/--skip-tags -> per-task when: at execution. The name search walks every play in source order, narrowed by --play.")
 	f.BoolVar(&c.detailedExitCode, "detailed-exitcode", false, "exit 0 when nothing changed, 2 when at least one task changed, 1 on error. Without this flag apply exits 0 whether or not anything changed.")
 
-	data, format, source := preloadRecipeForFlags(c.argv(), true, c.stdinSource())
+	data, format, source := preloadRecipeForFlags(c.baseDir(), c.argv(), true, c.stdinSource())
 	if data == nil {
 		return f
 	}
@@ -227,7 +237,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	// The cached bytes are the ones FlagSet already read for this source
 	// (see tasksData); for a --tasks URL this avoids a second HTTP fetch
 	// of the same recipe.
-	recipe, err := loadRecipe(taskFile, formatOverride, true, c.tasksData, c.tasksDataSource, c.stdinSource())
+	recipe, err := loadRecipe(c.baseDir(), taskFile, formatOverride, true, c.tasksData, c.tasksDataSource, c.stdinSource())
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read error: %v", err))
 		return 1
@@ -1073,3 +1083,6 @@ func (c *ApplyCommand) stdinSource() *stdinRecipeSource {
 	}
 	return c.stdin
 }
+
+// baseDir returns the directory this command resolves relative paths against.
+func (c *ApplyCommand) baseDir() string { return c.BaseDir }

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -18,6 +19,21 @@ import (
 
 type ApplyCommand struct {
 	command.Meta
+
+	// Stdin is where a `--tasks -` recipe is read from. Populated from
+	// main.go; nil reads the process's standard input. A test hands over its
+	// own pipe instead of swapping os.Stdin, which no two tests can do at
+	// once.
+	Stdin io.Reader
+
+	stdin *stdinRecipeSource
+
+	// Argv is the process argv this command resolves its --tasks and
+	// --tasks-format from, before pflag has parsed anything. Populated from
+	// main.go; nil falls back to os.Args, which is what a command built
+	// directly gets. It exists so a test can hand the command its own argv
+	// instead of assigning to the process global and putting it back.
+	Argv []string
 
 	// Ctx is the run context, populated from main.go with the process signal
 	// context. It carries cancellation down through every task's Plan and
@@ -108,7 +124,7 @@ func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f.StringVar(&c.startAtTask, "start-at-task", "", "skip every task before the matched name; the matched task and successors run normally. Filter order: --start-at-task -> --tags/--skip-tags -> per-task when: at execution. The name search walks every play in source order, narrowed by --play.")
 	f.BoolVar(&c.detailedExitCode, "detailed-exitcode", false, "exit 0 when nothing changed, 2 when at least one task changed, 1 on error. Without this flag apply exits 0 whether or not anything changed.")
 
-	data, format, source := preloadRecipeForFlags(os.Args, true)
+	data, format, source := preloadRecipeForFlags(c.argv(), true, c.stdinSource())
 	if data == nil {
 		return f
 	}
@@ -211,7 +227,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	// The cached bytes are the ones FlagSet already read for this source
 	// (see tasksData); for a --tasks URL this avoids a second HTTP fetch
 	// of the same recipe.
-	recipe, err := loadRecipe(taskFile, formatOverride, true, c.tasksData, c.tasksDataSource)
+	recipe, err := loadRecipe(taskFile, formatOverride, true, c.tasksData, c.tasksDataSource, c.stdinSource())
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read error: %v", err))
 		return 1
@@ -1042,4 +1058,18 @@ func (c *ApplyCommand) newEmitter(masker *subprocess.Masker) EventEmitter {
 		return NewJSONEmitter(c.Ui, masker)
 	}
 	return NewFormatter(c.Ui, c.verbose, masker)
+}
+
+// argv returns the argv this command resolves its pre-parse flags from.
+func (c *ApplyCommand) argv() []string { return commandArgv(c.Argv) }
+
+// stdinSource returns this command's memoized standard-input reader, creating
+// it on first use. One per command: the recipe is read more than once per
+// invocation (FlagSet, Run, and Help on a flag error) but standard input only
+// yields its bytes once.
+func (c *ApplyCommand) stdinSource() *stdinRecipeSource {
+	if c.stdin == nil {
+		c.stdin = newStdinRecipeSource(c.Stdin)
+	}
+	return c.stdin
 }

--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -154,8 +154,8 @@ func (c *Argument) SetStringValue(ptr *string) {
 	c.stringValue = ptr
 }
 
-func getTaskYamlFilename(s []string) string {
-	path, _ := resolveTaskFileFromArgs(s)
+func getTaskYamlFilename(baseDir string, s []string) string {
+	path, _ := resolveTaskFileFromArgs(baseDir, s)
 	return path
 }
 
@@ -167,7 +167,7 @@ func getTaskYamlFilename(s []string) string {
 // path still fires with the familiar message. Format is keyed by file
 // extension; see detectTaskFileFormat. The format is empty for stdin,
 // which has no name - taskFileFormatFor sniffs the bytes instead.
-func resolveTaskFileFromArgs(s []string) (string, string) {
+func resolveTaskFileFromArgs(baseDir string, s []string) (string, string) {
 	positional := ""
 	skipNext := false
 	for i, arg := range s {
@@ -224,7 +224,7 @@ func resolveTaskFileFromArgs(s []string) (string, string) {
 		return taskFileStdin, ""
 	}
 	if positional != "" {
-		if _, err := os.Stat(positional); err == nil {
+		if _, err := os.Stat(inDir(baseDir, positional)); err == nil {
 			return positional, detectTaskFileFormat(positional)
 		}
 	}
@@ -235,7 +235,7 @@ func resolveTaskFileFromArgs(s []string) (string, string) {
 	// times before the command started. Run warns once, off recipeSource.
 	// A stat error likewise belongs to Run, which re-resolves the recipe
 	// and reports it properly.
-	chosen, _, _ := probeDefaultTaskFile()
+	chosen, _, _ := probeDefaultTaskFile(baseDir)
 	if chosen != "" {
 		return chosen, detectTaskFileFormat(chosen)
 	}

--- a/commands/apply_args_test.go
+++ b/commands/apply_args_test.go
@@ -127,7 +127,7 @@ func TestGetTaskYamlFilename(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getTaskYamlFilename(tt.args)
+			result := getTaskYamlFilename("", tt.args)
 			if result != tt.expected {
 				t.Errorf("getTaskYamlFilename(%v) = %q, want %q", tt.args, result, tt.expected)
 			}

--- a/commands/apply_envelope_test.go
+++ b/commands/apply_envelope_test.go
@@ -19,11 +19,9 @@ import (
 // before invoking Run.
 func runApply(t *testing.T, path string, args ...string) (string, string, int) {
 	t.Helper()
-	origArgs := os.Args
-	os.Args = []string{"docket-test", "apply", "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", "apply", "--tasks", path}
 
-	c := &ApplyCommand{}
+	c := &ApplyCommand{Argv: argv}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
 	all := append([]string{"--tasks", path}, args...)
 	exit := c.Run(all)

--- a/commands/cancellation_test.go
+++ b/commands/cancellation_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 
@@ -16,19 +15,17 @@ import (
 // helpers leave Ctx nil, which is the "constructed directly" path.
 func runWithCtx(t *testing.T, ctx context.Context, sub, path string, args ...string) (string, string, int) {
 	t.Helper()
-	origArgs := os.Args
-	os.Args = []string{"docket-test", sub, "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", sub, "--tasks", path}
 
 	ui := cli.NewMockUi()
 	all := append([]string{"--tasks", path}, args...)
 	var exit int
 	switch sub {
 	case "apply":
-		c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+		c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
 		exit = c.Run(all)
 	case "plan":
-		c := &PlanCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+		c := &PlanCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
 		exit = c.Run(all)
 	default:
 		t.Fatalf("unknown subcommand %q", sub)

--- a/commands/export.go
+++ b/commands/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -30,6 +31,22 @@ const varsFileMode = 0o600
 // `docket apply --vars-file <vars>`.
 type ExportCommand struct {
 	command.Meta
+
+	// BaseDir is the directory relative paths resolve against - the recipe
+	// probed when --tasks is absent, and any output written to a relative
+	// path. Populated from main.go; empty means the process working
+	// directory, which is what it always was.
+	//
+	// It exists so a test can point a command at a temp directory instead of
+	// chdir'ing the whole process, which no test can do while another runs
+	// beside it.
+	BaseDir string
+
+	// Stdout is where a streamed recipe, diff or catalog is written. Populated
+	// from main.go; nil writes to the process's standard output. These writes
+	// bypass Ui on purpose - it is wrapped in a log formatter - so a test that
+	// asserts on them needs somewhere of its own to capture.
+	Stdout io.Writer
 
 	// Ctx is the run context, populated from main.go with the process signal
 	// context. It carries cancellation down through every task's Plan and
@@ -257,7 +274,7 @@ func (c *ExportCommand) Run(args []string) int {
 	}
 
 	if toStdout {
-		if _, err := os.Stdout.Write(recipeBytes); err != nil {
+		if _, err := c.stdout().Write(recipeBytes); err != nil {
 			c.Ui.Error(fmt.Sprintf("write error: %v", err))
 			return 1
 		}
@@ -286,7 +303,7 @@ func (c *ExportCommand) Run(args []string) int {
 			targets = append(targets, varsOutput)
 		}
 		for _, path := range targets {
-			exists, err := pathExists(path)
+			exists, err := pathExists(c.baseDir(), path)
 			if err != nil {
 				c.Ui.Error(fmt.Sprintf("stat error: %v", err))
 				return 1
@@ -306,7 +323,7 @@ func (c *ExportCommand) Run(args []string) int {
 		}
 	}
 
-	if err := os.WriteFile(c.output, recipeBytes, 0o644); err != nil {
+	if err := os.WriteFile(inDir(c.baseDir(), c.output), recipeBytes, 0o644); err != nil {
 		c.Ui.Error(fmt.Sprintf("write error: %v", err))
 		return 1
 	}
@@ -408,7 +425,7 @@ func (c *ExportCommand) chmodVarsFile() chmodFunc {
 // operator just has to know this half is exposed. The message names the path
 // unmasked for the reason exitForMissingApps gives.
 func (c *ExportCommand) writeVarsFile(path string, data []byte) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, varsFileMode)
+	f, err := os.OpenFile(inDir(c.baseDir(), path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, varsFileMode)
 	if err != nil {
 		return err
 	}
@@ -434,8 +451,8 @@ func deriveVarsOutput(output string) string {
 
 // pathExists reports whether path exists, distinguishing a genuine stat error
 // from a not-found.
-func pathExists(path string) (bool, error) {
-	if _, err := os.Stat(path); err == nil {
+func pathExists(baseDir, path string) (bool, error) {
+	if _, err := os.Stat(inDir(baseDir, path)); err == nil {
 		return true, nil
 	} else if errors.Is(err, fs.ErrNotExist) {
 		return false, nil
@@ -443,3 +460,9 @@ func pathExists(path string) (bool, error) {
 		return false, err
 	}
 }
+
+// stdout returns the writer this command streams bytes to.
+func (c *ExportCommand) stdout() io.Writer { return commandStdout(c.Stdout) }
+
+// baseDir returns the directory this command resolves relative paths against.
+func (c *ExportCommand) baseDir() string { return c.BaseDir }

--- a/commands/export.go
+++ b/commands/export.go
@@ -37,6 +37,10 @@ type ExportCommand struct {
 	// in which case Run falls back to context.Background().
 	Ctx context.Context
 
+	// ChmodVarsFile overrides how the companion vars-file's mode is set. Only
+	// a test sets it, to force the failure path; nil uses os.File.Chmod.
+	ChmodVarsFile chmodFunc
+
 	output     string
 	varsOutput string
 	// formatFlag is the raw --format value; it is normalised by
@@ -373,11 +377,22 @@ func (c *ExportCommand) confirmOverwrite(path string) (bool, error) {
 	return answer == "y" || answer == "yes", nil
 }
 
-// chmodVarsFile is os.File.Chmod, indirected so the warning below can be
-// tested: no filesystem a test can portably create rejects fchmod, and a
-// fallback that tells the operator their secrets are exposed is worth more
-// than an untested one.
-var chmodVarsFile = func(f *os.File, mode os.FileMode) error { return f.Chmod(mode) }
+// chmodFile is os.File.Chmod, indirected so the warning below can be tested:
+// no filesystem a test can portably create rejects fchmod, and a fallback that
+// tells the operator their secrets are exposed is worth more than an untested
+// one.
+//
+// It lives on the command rather than in a package variable so a test that
+// forces the failure does not have to swap process state and put it back.
+type chmodFunc func(f *os.File, mode os.FileMode) error
+
+// chmodVarsFile returns the chmod this command writes its vars-file with.
+func (c *ExportCommand) chmodVarsFile() chmodFunc {
+	if c.ChmodVarsFile != nil {
+		return c.ChmodVarsFile
+	}
+	return func(f *os.File, mode os.FileMode) error { return f.Chmod(mode) }
+}
 
 // writeVarsFile writes the companion vars-file at varsFileMode. os.WriteFile
 // is not enough on its own: O_CREATE's mode applies only to a file the call
@@ -397,7 +412,7 @@ func (c *ExportCommand) writeVarsFile(path string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	if err := chmodVarsFile(f, varsFileMode); err != nil {
+	if err := c.chmodVarsFile()(f, varsFileMode); err != nil {
 		c.Ui.Warn(fmt.Sprintf("warning: could not set mode %#o on %s: %v; it holds secrets in the clear", varsFileMode, path, err))
 	}
 	if _, err := f.Write(data); err != nil {

--- a/commands/export_masking_test.go
+++ b/commands/export_masking_test.go
@@ -38,9 +38,7 @@ func TestExportCommandWarningMasksAConfigValue(t *testing.T) {
 		"--quiet apps:locked web",
 		errors.New(`apps:locked: unreadable lock state "abc123"`),
 	))()
-	t.Chdir(t.TempDir())
-
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(t.TempDir())
 	if code := c.Run(nil); code != 0 {
 		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 	}
@@ -75,9 +73,8 @@ func TestExportCommandRedactWarningMasksAConfigValue(t *testing.T) {
 		errors.New(`apps:locked: unreadable lock state "abc123"`),
 	))()
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--redact"}); code != 0 {
 		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 	}
@@ -106,9 +103,7 @@ func TestExportCommandFailureMasksASecretReadBeforeTheAppList(t *testing.T) {
 		"--quiet apps:list",
 		errors.New("apps:list: server rejected cluster token s3cr3ttoken"),
 	))()
-	t.Chdir(t.TempDir())
-
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(t.TempDir())
 	if code := c.Run(nil); code != 1 {
 		t.Fatalf("Run exit = %d, want 1: %s", code, ui.ErrorWriter.String())
 	}
@@ -133,9 +128,8 @@ func TestExportCommandFailureMasksASecretReadBeforeTheAppList(t *testing.T) {
 func TestExportCommandMaskingLeavesTheVarsFileInTheClear(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run(nil); code != 0 {
 		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 	}
@@ -160,9 +154,7 @@ func TestExportCommandMissingAppNameStaysReadable(t *testing.T) {
 	responses := exportCommandFixture()
 	responses["--quiet config:export --format json web"] = `{"API_KEY":"nope-app"}`
 	defer subprocess.SetExecRunner(fakeExecRunner(responses))()
-	t.Chdir(t.TempDir())
-
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(t.TempDir())
 	if code := c.Run([]string{"--app", "web", "--app", "nope-app"}); code != 1 {
 		t.Fatalf("Run exit = %d, want 1: %s", code, ui.ErrorWriter.String())
 	}

--- a/commands/export_mode_test.go
+++ b/commands/export_mode_test.go
@@ -159,15 +159,12 @@ func TestExportCommandRecipeModeLeftAlone(t *testing.T) {
 func TestExportCommandWarnsWhenTheModeCannotBeSet(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
 
-	orig := chmodVarsFile
-	chmodVarsFile = func(*os.File, os.FileMode) error { return errors.New("operation not supported") }
-	defer func() { chmodVarsFile = orig }()
-
 	dir := t.TempDir()
 	recipe := filepath.Join(dir, "tasks.yml")
 	vars := filepath.Join(dir, "tasks.vars.yml")
 
 	c, ui := newExportCommand()
+	c.ChmodVarsFile = func(*os.File, os.FileMode) error { return errors.New("operation not supported") }
 	if code := c.Run([]string{"--output", recipe}); code != 0 {
 		t.Fatalf("a mode that cannot be set must not fail the export, got exit %d", code)
 	}

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,9 +28,16 @@ func exportCommandFixture() map[string]string {
 	}
 }
 
-func newExportCommand() (*ExportCommand, *cli.MockUi) {
+// newExportCommand builds an ExportCommand writing into baseDir. Passing one
+// is what replaced chdir'ing the process: export's --output default is
+// relative, and several tests are precisely about what that default resolves
+// to.
+func newExportCommand(baseDir ...string) (*ExportCommand, *cli.MockUi) {
 	ui := cli.NewMockUi()
 	c := &ExportCommand{Meta: command.Meta{Ui: ui}}
+	if len(baseDir) > 0 {
+		c.BaseDir = baseDir[0]
+	}
 	return c, ui
 }
 
@@ -50,7 +58,7 @@ func TestExportCommandWritesRecipeAndVars(t *testing.T) {
 	recipe := filepath.Join(dir, "tasks.yml")
 	vars := filepath.Join(dir, "tasks.vars.yml")
 
-	c, _ := newExportCommand()
+	c, _ := newExportCommand(dir)
 	if code := c.Run([]string{"--output", recipe}); code != 0 {
 		t.Fatalf("Run exit = %d, want 0", code)
 	}
@@ -84,7 +92,7 @@ func TestExportCommandOverwritePromptDeclined(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	ui.InputReader = strings.NewReader("n\n")
 	if code := c.Run([]string{"--output", recipe}); code != 1 {
 		t.Fatalf("declined overwrite should exit 1, got %d", code)
@@ -104,7 +112,7 @@ func TestExportCommandOverwriteConfirmed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	ui.InputReader = strings.NewReader("y\n")
 	if code := c.Run([]string{"--output", recipe}); code != 0 {
 		t.Fatalf("confirmed overwrite should exit 0, got %d", code)
@@ -124,7 +132,7 @@ func TestExportCommandOverwriteFlagSkipsPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, _ := newExportCommand()
+	c, _ := newExportCommand(dir)
 	// No InputReader set: --overwrite must not prompt.
 	if code := c.Run([]string{"--output", recipe, "--overwrite"}); code != 0 {
 		t.Fatalf("--overwrite should exit 0 without prompting, got %d", code)
@@ -142,7 +150,7 @@ func TestExportOutputValidates(t *testing.T) {
 	recipe := filepath.Join(dir, "tasks.yml")
 	vars := filepath.Join(dir, "tasks.vars.yml")
 
-	c, _ := newExportCommand()
+	c, _ := newExportCommand(dir)
 	if code := c.Run([]string{"--output", recipe}); code != 0 {
 		t.Fatalf("export exit = %d", code)
 	}
@@ -172,11 +180,10 @@ func TestExportOutputValidatesJSON5(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
 
 	dir := t.TempDir()
-	t.Chdir(dir)
 	recipe := filepath.Join(dir, "tasks.json")
 	vars := filepath.Join(dir, "tasks.vars.json")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--format", "json5"}); code != 0 {
 		t.Fatalf("export exit = %d: %s", code, ui.ErrorWriter.String())
 	}
@@ -200,9 +207,8 @@ func TestExportCommandFormatJSON5WritesJSONPair(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
 
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--format", "json5"}); code != 0 {
 		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 	}
@@ -250,7 +256,7 @@ func TestExportCommandFormatOverridesOutputExtension(t *testing.T) {
 	dir := t.TempDir()
 	recipe := filepath.Join(dir, "tasks.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--output", recipe, "--format", "json5"}); code != 0 {
 		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 	}
@@ -277,7 +283,7 @@ func TestExportCommandFormatGovernsVarsFile(t *testing.T) {
 	recipe := filepath.Join(dir, "tasks.json5")
 	vars := filepath.Join(dir, "tasks.vars.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--output", recipe, "--vars-output", vars, "--format", "json5"}); code != 0 {
 		t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 	}
@@ -313,7 +319,7 @@ func TestExportCommandVarsFileKeepsItsOwnExtensionWithoutFormat(t *testing.T) {
 			dir := t.TempDir()
 			vars := filepath.Join(dir, tt.varsName)
 
-			c, ui := newExportCommand()
+			c, ui := newExportCommand(dir)
 			code := c.Run([]string{"--output", filepath.Join(dir, "tasks.yml"), "--vars-output", vars})
 			if code != 0 {
 				t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
@@ -337,12 +343,12 @@ func TestExportCommandFormatJSON5ToStdout(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
 
 	dir := t.TempDir()
-	t.Chdir(dir)
 
 	var ui *cli.MockUi
-	captured, exit := captureStdout(t, func() int {
+	captured, exit := captureStdout(t, func(out io.Writer) int {
 		var c *ExportCommand
-		c, ui = newExportCommand()
+		c, ui = newExportCommand(dir)
+		c.Stdout = out
 		return c.Run([]string{"--output", "-", "--format", "json5"})
 	})
 	if exit != 0 {
@@ -371,13 +377,12 @@ func TestExportCommandFormatJSON5PromptsOnAdjustedPath(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
 
 	dir := t.TempDir()
-	t.Chdir(dir)
 	recipe := filepath.Join(dir, "tasks.json")
 	if err := os.WriteFile(recipe, []byte("OLD\n"), 0o644); err != nil {
 		t.Fatalf("seed tasks.json: %v", err)
 	}
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	ui.InputReader = strings.NewReader("n\n")
 	if code := c.Run([]string{"--format", "json5"}); code != 1 {
 		t.Fatalf("declined overwrite exit = %d, want 1", code)
@@ -397,7 +402,7 @@ func TestExportCommandRejectsUnknownFormatBeforeReadingServer(t *testing.T) {
 	dir := t.TempDir()
 	recipe := filepath.Join(dir, "tasks.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--format", "toml", "--output", recipe}); code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
@@ -429,7 +434,6 @@ func TestExportCommandRejectsStdoutInertFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			t.Chdir(dir)
 			vars := filepath.Join(dir, "secrets.yml")
 
 			args := []string{"--output", "-"}
@@ -440,7 +444,7 @@ func TestExportCommandRejectsStdoutInertFlags(t *testing.T) {
 				args = append(args, a)
 			}
 
-			c, ui := newExportCommand()
+			c, ui := newExportCommand(dir)
 			if code := c.Run(args); code != 1 {
 				t.Fatalf("exit = %d, want 1", code)
 			}
@@ -482,7 +486,7 @@ func TestExportCommandReportsUnusedVarsOutput(t *testing.T) {
 		recipe := filepath.Join(dir, "tasks.yml")
 		vars := filepath.Join(dir, "secrets.yml")
 
-		c, ui := newExportCommand()
+		c, ui := newExportCommand(dir)
 		if code := c.Run([]string{"--output", recipe, "--vars-output", vars}); code != 0 {
 			t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 		}
@@ -508,7 +512,7 @@ func TestExportCommandReportsUnusedVarsOutput(t *testing.T) {
 		dir := t.TempDir()
 		recipe := filepath.Join(dir, "tasks.yml")
 
-		c, ui := newExportCommand()
+		c, ui := newExportCommand(dir)
 		if code := c.Run([]string{"--output", recipe}); code != 0 {
 			t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
 		}
@@ -527,7 +531,7 @@ func TestExportCommandSummaryExcludesGlobalPlay(t *testing.T) {
 	dir := t.TempDir()
 	recipe := filepath.Join(dir, "tasks.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--output", recipe}); code != 0 {
 		t.Fatalf("Run exit = %d, want 0", code)
 	}
@@ -547,7 +551,7 @@ func TestExportCommandNonexistentAppExitsNonZero(t *testing.T) {
 	dir := t.TempDir()
 	recipe := filepath.Join(dir, "tasks.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	code := c.Run([]string{"--app", "nope", "--output", recipe})
 	if code != 1 {
 		t.Fatalf("Run exit = %d, want 1", code)
@@ -568,7 +572,7 @@ func TestExportCommandPartialMissingAppStillWrites(t *testing.T) {
 	dir := t.TempDir()
 	recipe := filepath.Join(dir, "tasks.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	code := c.Run([]string{"--app", "web", "--app", "nope", "--output", recipe})
 	if code != 1 {
 		t.Fatalf("Run exit = %d, want 1", code)
@@ -611,7 +615,7 @@ func TestExportCommandResourceSelectsOneResource(t *testing.T) {
 	dir := t.TempDir()
 	recipe := filepath.Join(dir, "tasks.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--output", recipe, "--resource", "dokku_config[app=web]"}); code != 0 {
 		t.Fatalf("Run exit = %d, want 0; stderr=%s", code, ui.ErrorWriter.String())
 	}
@@ -692,7 +696,7 @@ func TestExportOutputValidatesWithUnappliableK3sProfile(t *testing.T) {
 	recipe := filepath.Join(dir, "tasks.yml")
 	vars := filepath.Join(dir, "tasks.vars.yml")
 
-	c, ui := newExportCommand()
+	c, ui := newExportCommand(dir)
 	if code := c.Run([]string{"--output", recipe}); code != 0 {
 		t.Fatalf("export exit = %d: %s", code, ui.ErrorWriter.String())
 	}

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -152,14 +152,11 @@ func TestExportOutputValidates(t *testing.T) {
 	// and the required inputs resolve from the vars-file. This is the
 	// offline stand-in for the apply round-trip contract.
 	// ValidateCommand.FlagSet loads the recipe's inputs from the --tasks path
-	// in os.Args (before flag parsing), so set os.Args as the real CLI would.
+	// in its argv (before flag parsing), so hand it one as the real CLI would.
 	valArgs := []string{"--tasks", recipe, "--vars-file", vars, "--strict"}
-	oldArgs := os.Args
-	os.Args = append([]string{"docket", "validate"}, valArgs...)
-	defer func() { os.Args = oldArgs }()
 
 	vui := cli.NewMockUi()
-	v := &ValidateCommand{Meta: command.Meta{Ui: vui}}
+	v := &ValidateCommand{Meta: command.Meta{Ui: vui}, Argv: append([]string{"docket", "validate"}, valArgs...)}
 	if code := v.Run(valArgs); code != 0 {
 		rb, _ := os.ReadFile(recipe)
 		vb, _ := os.ReadFile(vars)
@@ -185,12 +182,9 @@ func TestExportOutputValidatesJSON5(t *testing.T) {
 	}
 
 	valArgs := []string{"--tasks", recipe, "--vars-file", vars, "--strict"}
-	oldArgs := os.Args
-	os.Args = append([]string{"docket", "validate"}, valArgs...)
-	defer func() { os.Args = oldArgs }()
 
 	vui := cli.NewMockUi()
-	v := &ValidateCommand{Meta: command.Meta{Ui: vui}}
+	v := &ValidateCommand{Meta: command.Meta{Ui: vui}, Argv: append([]string{"docket", "validate"}, valArgs...)}
 	if code := v.Run(valArgs); code != 0 {
 		rb, _ := os.ReadFile(recipe)
 		vb, _ := os.ReadFile(vars)
@@ -724,12 +718,9 @@ func TestExportOutputValidatesWithUnappliableK3sProfile(t *testing.T) {
 	}
 
 	valArgs := []string{"--tasks", recipe, "--vars-file", vars, "--strict"}
-	oldArgs := os.Args
-	os.Args = append([]string{"docket", "validate"}, valArgs...)
-	defer func() { os.Args = oldArgs }()
 
 	vui := cli.NewMockUi()
-	v := &ValidateCommand{Meta: command.Meta{Ui: vui}}
+	v := &ValidateCommand{Meta: command.Meta{Ui: vui}, Argv: append([]string{"docket", "validate"}, valArgs...)}
 	if code := v.Run(valArgs); code != 0 {
 		t.Fatalf("docket validate --strict exit = %d, want 0\n--- validate stderr ---\n%s\n--- recipe ---\n%s",
 			code, vui.ErrorWriter.String(), recipeBytes)

--- a/commands/fmt.go
+++ b/commands/fmt.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,6 +27,14 @@ import (
 // contacts the Dokku server.
 type FmtCommand struct {
 	command.Meta
+
+	// Stdin is where a `--tasks -` recipe is read from. Populated from
+	// main.go; nil reads the process's standard input. A test hands over its
+	// own pipe instead of swapping os.Stdin, which no two tests can do at
+	// once.
+	Stdin io.Reader
+
+	stdin *stdinRecipeSource
 
 	check bool
 	diff  bool
@@ -168,7 +177,7 @@ func (c *FmtCommand) Run(args []string) int {
 // --tasks-format, wins over the sniff - a flow-style YAML recipe starts
 // with [ and would otherwise be reformatted as JSON5.
 func (c *FmtCommand) runStdin(formatOverride string) int {
-	src, err := readStdinRecipe()
+	src, err := c.stdinSource().recipe()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read stdin: %v", err))
 		return 1
@@ -423,4 +432,15 @@ func bytesEqual(a, b []byte) bool {
 		}
 	}
 	return true
+}
+
+// stdinSource returns this command's memoized standard-input reader, creating
+// it on first use. One per command: the recipe is read more than once per
+// invocation (FlagSet, Run, and Help on a flag error) but standard input only
+// yields its bytes once.
+func (c *FmtCommand) stdinSource() *stdinRecipeSource {
+	if c.stdin == nil {
+		c.stdin = newStdinRecipeSource(c.Stdin)
+	}
+	return c.stdin
 }

--- a/commands/fmt.go
+++ b/commands/fmt.go
@@ -28,6 +28,22 @@ import (
 type FmtCommand struct {
 	command.Meta
 
+	// BaseDir is the directory relative paths resolve against - the recipe
+	// probed when --tasks is absent, and any output written to a relative
+	// path. Populated from main.go; empty means the process working
+	// directory, which is what it always was.
+	//
+	// It exists so a test can point a command at a temp directory instead of
+	// chdir'ing the whole process, which no test can do while another runs
+	// beside it.
+	BaseDir string
+
+	// Stdout is where a streamed recipe, diff or catalog is written. Populated
+	// from main.go; nil writes to the process's standard output. These writes
+	// bypass Ui on purpose - it is wrapped in a log formatter - so a test that
+	// asserts on them needs somewhere of its own to capture.
+	Stdout io.Writer
+
 	// Stdin is where a `--tasks -` recipe is read from. Populated from
 	// main.go; nil reads the process's standard input. A test hands over its
 	// own pipe instead of swapping os.Stdin, which no two tests can do at
@@ -120,7 +136,7 @@ func (c *FmtCommand) Run(args []string) int {
 		return 1
 	}
 
-	if err := applyColorMode(c.color); err != nil {
+	if err := applyColorMode(c.color, c.stdout()); err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
@@ -146,7 +162,7 @@ func (c *FmtCommand) Run(args []string) int {
 		}
 	}
 
-	paths, ambiguous, err := expandPaths(positional)
+	paths, ambiguous, err := expandPaths(c.baseDir(), positional)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -191,7 +207,7 @@ func (c *FmtCommand) runStdin(formatOverride string) int {
 	changed := !bytesEqual(src, formatted)
 
 	if c.diff && changed {
-		_, _ = os.Stdout.WriteString(renderDiff("<stdin>", string(src), string(formatted)))
+		_, _ = io.WriteString(c.stdout(), renderDiff("<stdin>", string(src), string(formatted)))
 	}
 
 	if c.check {
@@ -207,7 +223,7 @@ func (c *FmtCommand) runStdin(formatOverride string) int {
 		return 0
 	}
 
-	if _, err := os.Stdout.Write(formatted); err != nil {
+	if _, err := c.stdout().Write(formatted); err != nil {
 		c.Ui.Error(fmt.Sprintf("write stdout: %v", err))
 		return 1
 	}
@@ -233,7 +249,7 @@ func (c *FmtCommand) formatPath(path, formatOverride string) int {
 	changed := !bytesEqual(src, formatted)
 
 	if c.diff && changed {
-		_, _ = os.Stdout.WriteString(renderDiff(path, string(src), string(formatted)))
+		_, _ = io.WriteString(c.stdout(), renderDiff(path, string(src), string(formatted)))
 	}
 
 	if c.check {
@@ -307,22 +323,25 @@ func sniffStdinFormat(src []byte) string {
 // The second return value carries the other default candidates the probe
 // passed over, for ambiguousTaskFileWarning. Named arguments select their
 // own files, so it is only ever set for the empty-argument case.
-func expandPaths(args []string) ([]string, []string, error) {
+func expandPaths(baseDir string, args []string) ([]string, []string, error) {
 	if len(args) == 0 {
-		chosen, others, err := probeDefaultTaskFile()
+		chosen, others, err := probeDefaultTaskFile(baseDir)
 		if err != nil {
 			return nil, nil, err
 		}
+		// The probe answers in bare candidate names because the ambiguity
+		// warning reads better that way; the paths handed on have to be
+		// concrete.
 		if chosen == "" {
-			return []string{defaultTaskFileCandidates[0]}, nil, nil
+			return []string{inDir(baseDir, defaultTaskFileCandidates[0])}, nil, nil
 		}
-		return []string{chosen}, others, nil
+		return []string{inDir(baseDir, chosen)}, others, nil
 	}
 
 	seen := map[string]bool{}
 	var paths []string
 	for _, arg := range args {
-		matches, err := filepath.Glob(arg)
+		matches, err := filepath.Glob(inDir(baseDir, arg))
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid glob %q: %w", arg, err)
 		}
@@ -330,7 +349,7 @@ func expandPaths(args []string) ([]string, []string, error) {
 			// A literal path with no glob metacharacters that does
 			// not exist still flows through to the read step so
 			// the user gets a clean "no such file" error.
-			matches = []string{arg}
+			matches = []string{inDir(baseDir, arg)}
 		}
 		for _, m := range matches {
 			if !seen[m] {
@@ -346,7 +365,7 @@ func expandPaths(args []string) ([]string, []string, error) {
 // applyColorMode resolves the --color flag value into the global
 // fatih/color state. auto delegates to the library's TTY / NO_COLOR
 // detection; always forces colors on; never forces colors off.
-func applyColorMode(mode string) error {
+func applyColorMode(mode string, out io.Writer) error {
 	switch mode {
 	case "auto":
 		// Default behaviour: respect TTY and NO_COLOR. fatih/color
@@ -354,7 +373,7 @@ func applyColorMode(mode string) error {
 		// package-default value. Re-derive the default explicitly
 		// so a previous --color always/never invocation in the same
 		// process (i.e. tests) does not leak state.
-		color.NoColor = noColorDefault()
+		color.NoColor = noColorDefault(out)
 	case "always":
 		color.NoColor = false
 	case "never":
@@ -367,11 +386,19 @@ func applyColorMode(mode string) error {
 
 // noColorDefault matches fatih/color's own default detection: colors
 // on when stdout is a terminal AND NO_COLOR is unset.
-func noColorDefault() bool {
+//
+// A writer that is not the process's own stdout has no file descriptor to ask,
+// and is not a terminal by definition - it is a buffer a test or a caller is
+// collecting bytes in - so it answers "no color" without consulting isatty.
+func noColorDefault(w io.Writer) bool {
 	if _, ok := os.LookupEnv("NO_COLOR"); ok {
 		return true
 	}
-	return !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())
+	f, ok := w.(*os.File)
+	if !ok {
+		return true
+	}
+	return !isatty.IsTerminal(f.Fd()) && !isatty.IsCygwinTerminal(f.Fd())
 }
 
 // renderDiff produces a colorized GNU unified diff between original
@@ -444,3 +471,9 @@ func (c *FmtCommand) stdinSource() *stdinRecipeSource {
 	}
 	return c.stdin
 }
+
+// stdout returns the writer this command streams bytes to.
+func (c *FmtCommand) stdout() io.Writer { return commandStdout(c.Stdout) }
+
+// baseDir returns the directory this command resolves relative paths against.
+func (c *FmtCommand) baseDir() string { return c.BaseDir }

--- a/commands/fmt_test.go
+++ b/commands/fmt_test.go
@@ -213,8 +213,9 @@ func TestFmtCheckAloneEmitsNoDiff(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	captured, exit := captureStdout(t, func() int {
+	captured, exit := captureStdout(t, func(out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdout = out
 		return c.Run([]string{"--check", "--color", "never", path})
 	})
 	if exit != 1 {
@@ -232,8 +233,9 @@ func TestFmtDiffPrintsDiffAndDoesNotWrite(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	captured, exit := captureStdout(t, func() int {
+	captured, exit := captureStdout(t, func(out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdout = out
 		return c.Run([]string{"--diff", "--color", "never", path})
 	})
 	if exit != 0 {
@@ -261,8 +263,9 @@ func TestFmtCheckDiffComposes(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	captured, exit := captureStdout(t, func() int {
+	captured, exit := captureStdout(t, func(out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdout = out
 		return c.Run([]string{"--check", "--diff", "--color", "never", path})
 	})
 	if exit != 1 {
@@ -288,8 +291,9 @@ func TestFmtColorNeverProducesPlainOutput(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	captured, _ := captureStdout(t, func() int {
+	captured, _ := captureStdout(t, func(out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdout = out
 		return c.Run([]string{"--diff", "--color", "never", path})
 	})
 	if strings.Contains(captured, "\x1b[") {
@@ -312,8 +316,9 @@ func TestFmtColorAlwaysProducesAnsiEvenInPipe(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	captured, _ := captureStdout(t, func() int {
+	captured, _ := captureStdout(t, func(out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdout = out
 		return c.Run([]string{"--diff", "--color", "always", path})
 	})
 	if !strings.Contains(captured, "\x1b[") {
@@ -329,8 +334,10 @@ func TestFmtColorInvalidValueFails(t *testing.T) {
 }
 
 func TestFmtStdinReadsAndWritesStdout(t *testing.T) {
-	captured, exit := withStdinAndStdout(t, messyTasksYAML, func() int {
+	captured, exit := withStdinAndStdout(t, messyTasksYAML, func(in io.Reader, out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdin = in
+		c.Stdout = out
 		return c.Run([]string{"-"})
 	})
 	if exit != 0 {
@@ -342,8 +349,10 @@ func TestFmtStdinReadsAndWritesStdout(t *testing.T) {
 }
 
 func TestFmtStdinInvalidTasksFormatFails(t *testing.T) {
-	captured, exit := withStdinAndStdout(t, messyTasksYAML, func() int {
+	captured, exit := withStdinAndStdout(t, messyTasksYAML, func(in io.Reader, out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdin = in
+		c.Stdout = out
 		return c.Run([]string{"--tasks-format", "toml", "-"})
 	})
 	if exit != 1 {
@@ -361,8 +370,10 @@ func TestFmtStdinInvalidTasksFormatFails(t *testing.T) {
 func TestFmtStdinTasksFormatOverridesSniff(t *testing.T) {
 	const flowYAML = "[{tasks: [{name: flow, dokku_app: {app: api}}]}]\n"
 
-	sniffed, exit := withStdinAndStdout(t, flowYAML, func() int {
+	sniffed, exit := withStdinAndStdout(t, flowYAML, func(in io.Reader, out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdin = in
+		c.Stdout = out
 		return c.Run([]string{"-"})
 	})
 	if exit != 0 {
@@ -372,8 +383,10 @@ func TestFmtStdinTasksFormatOverridesSniff(t *testing.T) {
 		t.Errorf("without an override the sniff should pick JSON5, got:\n%s", sniffed)
 	}
 
-	forced, exit := withStdinAndStdout(t, flowYAML, func() int {
+	forced, exit := withStdinAndStdout(t, flowYAML, func(in io.Reader, out io.Writer) int {
 		c := newTestFmtCommand()
+		c.Stdin = in
+		c.Stdout = out
 		return c.Run([]string{"--tasks-format", "yaml", "-"})
 	})
 	if exit != 0 {
@@ -431,7 +444,6 @@ func TestFmtRejectsStdinMixedWithPaths(t *testing.T) {
 // picked.
 func TestFmtWarnsOnAmbiguousDefaultProbe(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "tasks.yml"), []byte(canonicalTasksYAML), 0o644); err != nil {
 		t.Fatalf("write tasks.yml: %v", err)
 	}
@@ -439,7 +451,7 @@ func TestFmtWarnsOnAmbiguousDefaultProbe(t *testing.T) {
 		t.Fatalf("write tasks.json: %v", err)
 	}
 
-	c := newTestFmtCommand()
+	c := newTestFmtCommand(dir)
 	if exit := c.Run([]string{"--check"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, c.Ui.(*cli.MockUi).ErrorWriter.String())
 	}
@@ -455,7 +467,6 @@ func TestFmtWarnsOnAmbiguousDefaultProbe(t *testing.T) {
 // files, so there is no probe to be ambiguous about.
 func TestFmtDoesNotWarnForNamedPaths(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "tasks.yml"), []byte(canonicalTasksYAML), 0o644); err != nil {
 		t.Fatalf("write tasks.yml: %v", err)
 	}
@@ -463,7 +474,7 @@ func TestFmtDoesNotWarnForNamedPaths(t *testing.T) {
 		t.Fatalf("write tasks.json: %v", err)
 	}
 
-	c := newTestFmtCommand()
+	c := newTestFmtCommand(dir)
 	if exit := c.Run([]string{"--check", "tasks.json"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, c.Ui.(*cli.MockUi).ErrorWriter.String())
 	}
@@ -540,60 +551,35 @@ func TestFmtParseErrorReturnsExit1(t *testing.T) {
 // don't nil-panic during Run. Tests assert via the file system or
 // captured stdout; the MockUi error/output buffers are inspected only
 // when needed.
-func newTestFmtCommand() *FmtCommand {
+func newTestFmtCommand(baseDir ...string) *FmtCommand {
 	c := &FmtCommand{}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
+	if len(baseDir) > 0 {
+		c.BaseDir = baseDir[0]
+	}
 	return c
 }
 
-// captureStdout swaps os.Stdout for a pipe, runs fn, and returns the
-// captured output. Used to assert on diff output.
-func captureStdout(t *testing.T, fn func() int) (string, int) {
+// captureStdout gives fn a buffer to write to and returns what it wrote plus
+// the exit code. The commands stream a recipe, diff or catalog straight to
+// their Stdout rather than through the Ui, which is wrapped in a log formatter,
+// so fn hands the buffer to whichever command it builds.
+//
+// It used to swap the os.Stdout package variable for a pipe - process state no
+// two tests can hold at once.
+func captureStdout(t *testing.T, fn func(out io.Writer) int) (string, int) {
 	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	origStdout := os.Stdout
-	os.Stdout = w
-	t.Cleanup(func() { os.Stdout = origStdout })
-
-	exitCh := make(chan int, 1)
-	go func() {
-		exit := fn()
-		w.Close()
-		exitCh <- exit
-	}()
-
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatalf("read pipe: %v", err)
-	}
-	return buf.String(), <-exitCh
+	exit := fn(&buf)
+	return buf.String(), exit
 }
 
-// withStdinAndStdout pipes the given input to os.Stdin and captures
-// os.Stdout while fn runs. Returns the captured stdout.
-func withStdinAndStdout(t *testing.T, input string, fn func() int) (string, int) {
+// withStdinAndStdout gives fn a reader holding input and a buffer to write to,
+// and returns what it wrote plus the exit code. fn hands both to the command it
+// builds, so neither os.Stdin nor os.Stdout is touched.
+func withStdinAndStdout(t *testing.T, input string, fn func(in io.Reader, out io.Writer) int) (string, int) {
 	t.Helper()
-
-	stdinR, stdinW, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("stdin pipe: %v", err)
-	}
-	origStdin := os.Stdin
-	os.Stdin = stdinR
-	// readStdinRecipe memoizes the one read a process gets, so the memo
-	// has to be dropped around every test that swaps os.Stdin -
-	// otherwise the second such test is served the first one's bytes.
-	t.Cleanup(func() {
-		os.Stdin = origStdin
-	})
-
-	go func() {
-		_, _ = stdinW.WriteString(input)
-		stdinW.Close()
-	}()
-
-	return captureStdout(t, fn)
+	var buf bytes.Buffer
+	exit := fn(strings.NewReader(input), &buf)
+	return buf.String(), exit
 }

--- a/commands/fmt_test.go
+++ b/commands/fmt_test.go
@@ -586,10 +586,8 @@ func withStdinAndStdout(t *testing.T, input string, fn func() int) (string, int)
 	// readStdinRecipe memoizes the one read a process gets, so the memo
 	// has to be dropped around every test that swaps os.Stdin -
 	// otherwise the second such test is served the first one's bytes.
-	resetStdinRecipe()
 	t.Cleanup(func() {
 		os.Stdin = origStdin
-		resetStdinRecipe()
 	})
 
 	go func() {

--- a/commands/init.go
+++ b/commands/init.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -26,6 +27,22 @@ import (
 // directory (cwd basename for --name, ./.git/config for --repo).
 type InitCommand struct {
 	command.Meta
+
+	// BaseDir is the directory relative paths resolve against - the recipe
+	// probed when --tasks is absent, and any output written to a relative
+	// path. Populated from main.go; empty means the process working
+	// directory, which is what it always was.
+	//
+	// It exists so a test can point a command at a temp directory instead of
+	// chdir'ing the whole process, which no test can do while another runs
+	// beside it.
+	BaseDir string
+
+	// Stdout is where a streamed recipe, diff or catalog is written. Populated
+	// from main.go; nil writes to the process's standard output. These writes
+	// bypass Ui on purpose - it is wrapped in a log formatter - so a test that
+	// asserts on them needs somewhere of its own to capture.
+	Stdout io.Writer
 
 	output string
 	// formatFlag is the raw --format value; it is normalised by
@@ -83,8 +100,8 @@ func (c *InitCommand) FlagSet() *flag.FlagSet {
 	f.StringVar(&c.formatFlag, "format", "", "write the scaffold as this format (yaml or json5) instead of inferring it from the --output extension. Without an explicit --output, json5 writes "+defaultRecipeOutputJSON5+"; this is also the only way to get JSON5 on stdout.")
 	f.BoolVar(&c.force, "force", false, "overwrite an existing output file")
 	f.BoolVar(&c.minimal, "minimal", false, "emit a minimal one-task scaffold without an inputs block")
-	f.StringVar(&c.name, "name", defaultName(), "play name and default app input value")
-	f.StringVar(&c.repo, "repo", defaultRepo(), "git repository URL used as the default for the repo input")
+	f.StringVar(&c.name, "name", defaultName(c.baseDir()), "play name and default app input value")
+	f.StringVar(&c.repo, "repo", defaultRepo(c.baseDir()), "git repository URL used as the default for the repo input")
 	return f
 }
 
@@ -147,7 +164,7 @@ func (c *InitCommand) Run(args []string) int {
 	toStdout := c.output == taskFileStdin
 
 	if !toStdout {
-		if _, err := os.Stat(c.output); err == nil {
+		if _, err := os.Stat(inDir(c.baseDir(), c.output)); err == nil {
 			if !c.force {
 				c.Ui.Error(fmt.Sprintf("file %s already exists; pass --force to overwrite", c.output))
 				return 1
@@ -179,14 +196,14 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	if toStdout {
-		if _, err := os.Stdout.Write(rendered); err != nil {
+		if _, err := c.stdout().Write(rendered); err != nil {
 			c.Ui.Error(fmt.Sprintf("write error: %v", err))
 			return 1
 		}
 		return 0
 	}
 
-	if err := os.WriteFile(c.output, rendered, 0o644); err != nil {
+	if err := os.WriteFile(inDir(c.baseDir(), c.output), rendered, 0o644); err != nil {
 		c.Ui.Error(fmt.Sprintf("write error: %v", err))
 		return 1
 	}
@@ -290,25 +307,29 @@ func selectInitTemplate(format string, minimal bool) string {
 	return "default." + suffix + ".tmpl"
 }
 
-// defaultName returns the basename of the working directory, or "app" if
-// the cwd cannot be derived to a usable name.
-func defaultName() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "app"
+// defaultName returns the basename of dir, or "app" if it cannot be derived to
+// a usable name. An empty dir means the process working directory, which is
+// what `docket init` in a project folder gets.
+func defaultName(dir string) string {
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "app"
+		}
+		dir = cwd
 	}
-	base := filepath.Base(cwd)
+	base := filepath.Base(dir)
 	if base == "" || base == "." || base == string(filepath.Separator) {
 		return "app"
 	}
 	return base
 }
 
-// defaultRepo reads ./.git/config and returns the value of the `url` key
+// defaultRepo reads dir's .git/config and returns the value of the `url` key
 // inside the `[remote "origin"]` section. Returns "" when the file does
 // not exist, when there is no origin section, or on any parse error.
-func defaultRepo() string {
-	f, err := os.Open(".git/config")
+func defaultRepo(dir string) string {
+	f, err := os.Open(inDir(dir, filepath.Join(".git", "config")))
 	if err != nil {
 		return ""
 	}
@@ -365,3 +386,9 @@ func appName() string {
 	}
 	return "docket"
 }
+
+// stdout returns the writer this command streams bytes to.
+func (c *InitCommand) stdout() io.Writer { return commandStdout(c.Stdout) }
+
+// baseDir returns the directory this command resolves relative paths against.
+func (c *InitCommand) baseDir() string { return c.BaseDir }

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -96,7 +96,7 @@ func TestInitRefusesToOverwriteWithoutForce(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	c := newTestInitCommand()
+	c := newTestInitCommand(dir)
 	if exit := c.Run([]string{"--output", path, "--name", "demo"}); exit != 1 {
 		t.Errorf("exit = %d, want 1", exit)
 	}
@@ -116,7 +116,7 @@ func TestInitForceOverwrites(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	c := newTestInitCommand()
+	c := newTestInitCommand(dir)
 	if exit := c.Run([]string{"--output", path, "--force", "--name", "demo"}); exit != 0 {
 		t.Errorf("exit = %d, want 0", exit)
 	}
@@ -133,7 +133,7 @@ func TestInitWritesDefaultTemplateToDisk(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "tasks.yml")
 
-	c := newTestInitCommand()
+	c := newTestInitCommand(dir)
 	if exit := c.Run([]string{"--output", path, "--name", "demo"}); exit != 0 {
 		t.Errorf("exit = %d, want 0", exit)
 	}
@@ -222,10 +222,9 @@ func TestInitDefaultNameFromCwd(t *testing.T) {
 	if err := os.Mkdir(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	t.Chdir(dir)
 
-	if got := defaultName(); got != "widget-svc" {
-		t.Errorf("defaultName() = %q, want %q", got, "widget-svc")
+	if got := defaultName(dir); got != "widget-svc" {
+		t.Errorf("defaultName(dir) = %q, want %q", got, "widget-svc")
 	}
 }
 
@@ -242,18 +241,16 @@ func TestInitDefaultRepoFromGitConfig(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".git", "config"), []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write git config: %v", err)
 	}
-	t.Chdir(dir)
 
-	if got := defaultRepo(); got != "git@example.com:owner/repo.git" {
-		t.Errorf("defaultRepo() = %q, want git@example.com:owner/repo.git", got)
+	if got := defaultRepo(dir); got != "git@example.com:owner/repo.git" {
+		t.Errorf("defaultRepo(dir) = %q, want git@example.com:owner/repo.git", got)
 	}
 }
 
 func TestInitNoGitConfigYieldsEmptyRepo(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
-	if got := defaultRepo(); got != "" {
-		t.Errorf("defaultRepo() with no .git/config = %q, want empty", got)
+	if got := defaultRepo(dir); got != "" {
+		t.Errorf("defaultRepo(dir) with no .git/config = %q, want empty", got)
 	}
 }
 
@@ -266,10 +263,9 @@ func TestInitGitConfigWithoutOriginYieldsEmptyRepo(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".git", "config"), []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write git config: %v", err)
 	}
-	t.Chdir(dir)
 
-	if got := defaultRepo(); got != "" {
-		t.Errorf("defaultRepo() with no origin = %q, want empty", got)
+	if got := defaultRepo(dir); got != "" {
+		t.Errorf("defaultRepo(dir) with no origin = %q, want empty", got)
 	}
 }
 
@@ -357,7 +353,7 @@ func TestInitSpecialCharacterNameWritesValidFile(t *testing.T) {
 	// write) does not reject it (#355).
 	dir := t.TempDir()
 	path := filepath.Join(dir, "tasks.yml")
-	c := newTestInitCommand()
+	c := newTestInitCommand(dir)
 	if exit := c.Run([]string{"--output", path, "--name", "@web", "--repo", "https://example.com/r.git"}); exit != 0 {
 		t.Fatalf("init --name @web exit = %d, want 0", exit)
 	}
@@ -511,10 +507,11 @@ func TestInitDefaultRecipeShape(t *testing.T) {
 
 func TestInitOutputDashWritesToStdout(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	captured, exit := captureStdout(t, func() int {
-		return newTestInitCommand().Run([]string{"--output", "-", "--name", "demo"})
+	captured, exit := captureStdout(t, func(out io.Writer) int {
+		c := newTestInitCommand(dir)
+		c.Stdout = out
+		return c.Run([]string{"--output", "-", "--name", "demo"})
 	})
 	if exit != 0 {
 		t.Errorf("exit = %d, want 0", exit)
@@ -539,9 +536,8 @@ func TestInitOutputDashWritesToStdout(t *testing.T) {
 // otherwise be read off the flag set and dropped.
 func TestInitRejectsForceWithStdout(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(dir)
 	if exit := c.Run([]string{"--output", "-", "--force", "--name", "demo"}); exit != 1 {
 		t.Fatalf("exit = %d, want 1", exit)
 	}
@@ -564,9 +560,8 @@ func TestInitRejectsForceWithStdout(t *testing.T) {
 // JSON5 document under a .yml name.
 func TestInitFormatJSON5WritesTasksJSON(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(dir)
 	if exit := c.Run([]string{"--format", "json5", "--name", "demo"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 	}
@@ -600,9 +595,8 @@ func TestInitFormatJSON5WritesTasksJSON(t *testing.T) {
 // so it drives the default-path swap too.
 func TestInitFormatJSONAliasWritesTasksJSON(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	if exit := newTestInitCommand().Run([]string{"--format", "json"}); exit != 0 {
+	if exit := newTestInitCommand(dir).Run([]string{"--format", "json"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0", exit)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "tasks.json")); err != nil {
@@ -614,9 +608,8 @@ func TestInitFormatJSONAliasWritesTasksJSON(t *testing.T) {
 // json5 moves the path.
 func TestInitFormatYAMLKeepsDefaultPath(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	if exit := newTestInitCommand().Run([]string{"--format", "yaml"}); exit != 0 {
+	if exit := newTestInitCommand(dir).Run([]string{"--format", "yaml"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0", exit)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "tasks.json")); err == nil {
@@ -637,9 +630,8 @@ func TestInitFormatYAMLKeepsDefaultPath(t *testing.T) {
 // which is legal and warned about.
 func TestInitExplicitOutputWinsOverFormatDefault(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(dir)
 	if exit := c.Run([]string{"--output", "recipe.yml", "--format", "json5"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 	}
@@ -664,7 +656,7 @@ func TestInitFormatOverridesOutputExtension(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "tasks.json")
 
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(dir)
 	if exit := c.Run([]string{"--output", path, "--format", "yaml"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 	}
@@ -689,7 +681,6 @@ func TestInitFormatOverridesOutputExtension(t *testing.T) {
 // an unrelated file, then clobbering the relevant one.
 func TestInitFormatJSON5ChecksForceOnAdjustedPath(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
 	jsonPath := filepath.Join(dir, "tasks.json")
 	yamlPath := filepath.Join(dir, "tasks.yml")
@@ -700,7 +691,7 @@ func TestInitFormatJSON5ChecksForceOnAdjustedPath(t *testing.T) {
 		t.Fatalf("seed tasks.yml: %v", err)
 	}
 
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(dir)
 	if exit := c.Run([]string{"--format", "json5"}); exit != 1 {
 		t.Fatalf("exit = %d, want 1", exit)
 	}
@@ -711,7 +702,7 @@ func TestInitFormatJSON5ChecksForceOnAdjustedPath(t *testing.T) {
 		t.Errorf("tasks.json was overwritten without --force: %q", body)
 	}
 
-	if exit := newTestInitCommand().Run([]string{"--format", "json5", "--force"}); exit != 0 {
+	if exit := newTestInitCommand(dir).Run([]string{"--format", "json5", "--force"}); exit != 0 {
 		t.Fatalf("--force exit = %d, want 0", exit)
 	}
 	body, err := os.ReadFile(jsonPath)
@@ -730,10 +721,11 @@ func TestInitFormatJSON5ChecksForceOnAdjustedPath(t *testing.T) {
 // --format, `--output -` could only ever emit YAML.
 func TestInitFormatJSON5ToStdout(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	captured, exit := captureStdout(t, func() int {
-		return newTestInitCommand().Run([]string{"--output", "-", "--format", "json5", "--name", "demo"})
+	captured, exit := captureStdout(t, func(out io.Writer) int {
+		c := newTestInitCommand(dir)
+		c.Stdout = out
+		return c.Run([]string{"--output", "-", "--format", "json5", "--name", "demo"})
 	})
 	if exit != 0 {
 		t.Fatalf("exit = %d, want 0", exit)
@@ -764,9 +756,8 @@ func TestInitFormatJSON5ToStdout(t *testing.T) {
 // user actually typed, not the --tasks-format it shares a parser with.
 func TestInitRejectsUnknownFormat(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(dir)
 	if exit := c.Run([]string{"--format", "toml"}); exit != 1 {
 		t.Fatalf("exit = %d, want 1", exit)
 	}
@@ -790,9 +781,7 @@ func TestInitRejectsUnknownFormat(t *testing.T) {
 // would be noise. The literal lines are asserted because the padding is
 // what keeps the three comments in one column.
 func TestInitNextStepsDefaultOutputStaysBare(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(t.TempDir())
 	if exit := c.Run(nil); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 	}
@@ -832,12 +821,11 @@ func TestInitNextStepsNameNonDefaultOutput(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			t.Chdir(dir)
 			if err := os.MkdirAll(filepath.Join(dir, "staging"), 0o755); err != nil {
 				t.Fatalf("mkdir staging: %v", err)
 			}
 
-			c, ui := newTestInitCommandUi()
+			c, ui := newTestInitCommandUi(dir)
 			if exit := c.Run(tc.args); exit != 0 {
 				t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 			}
@@ -856,9 +844,7 @@ func TestInitNextStepsNameNonDefaultOutput(t *testing.T) {
 // TestInitNextStepsCleansRelativeDefault: "./tasks.yml" is the first
 // probe candidate spelled differently, so it stays on the bare path.
 func TestInitNextStepsCleansRelativeDefault(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(t.TempDir())
 	if exit := c.Run([]string{"--output", "./tasks.yml"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 	}
@@ -871,9 +857,7 @@ func TestInitNextStepsCleansRelativeDefault(t *testing.T) {
 // the three comments share a column, and the --tasks suffix must not
 // break that.
 func TestInitNextStepsCommentsStayAligned(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	c, ui := newTestInitCommandUi()
+	c, ui := newTestInitCommandUi(t.TempDir())
 	if exit := c.Run([]string{"--format", "json5"}); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 	}
@@ -903,18 +887,21 @@ func TestInitNextStepsCommentsStayAligned(t *testing.T) {
 // newTestInitCommand wires up a Meta backed by cli.MockUi so c.Ui.* calls
 // don't nil-panic during Run. Tests assert via the file system or stdout
 // capture; MockUi's buffers are ignored.
-func newTestInitCommand() *InitCommand {
-	c, _ := newTestInitCommandUi()
+func newTestInitCommand(baseDir ...string) *InitCommand {
+	c, _ := newTestInitCommandUi(baseDir...)
 	return c
 }
 
 // newTestInitCommandUi is newTestInitCommand for tests that also need to
 // read what the command said - the mismatch warning lands on the UI's
 // error buffer, not on stdout.
-func newTestInitCommandUi() (*InitCommand, *cli.MockUi) {
+func newTestInitCommandUi(baseDir ...string) (*InitCommand, *cli.MockUi) {
 	ui := cli.NewMockUi()
 	c := &InitCommand{}
 	c.Meta = command.Meta{Ui: ui}
+	if len(baseDir) > 0 {
+		c.BaseDir = baseDir[0]
+	}
 	return c, ui
 }
 

--- a/commands/output.go
+++ b/commands/output.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -199,7 +200,7 @@ type Formatter struct {
 // controls whether `→`-prefixed continuation lines are emitted under
 // each task line in apply mode.
 func NewFormatter(ui cli.Ui, verbose bool, masker *subprocess.Masker) *Formatter {
-	useColor := !noColorDefault()
+	useColor := !noColorDefault(os.Stdout)
 	return &Formatter{
 		ui:      ui,
 		verbose: verbose,

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -19,6 +20,21 @@ import (
 // per-task Plan() method; the apply path is never invoked.
 type PlanCommand struct {
 	command.Meta
+
+	// Stdin is where a `--tasks -` recipe is read from. Populated from
+	// main.go; nil reads the process's standard input. A test hands over its
+	// own pipe instead of swapping os.Stdin, which no two tests can do at
+	// once.
+	Stdin io.Reader
+
+	stdin *stdinRecipeSource
+
+	// Argv is the process argv this command resolves its --tasks and
+	// --tasks-format from, before pflag has parsed anything. Populated from
+	// main.go; nil falls back to os.Args, which is what a command built
+	// directly gets. It exists so a test can hand the command its own argv
+	// instead of assigning to the process global and putting it back.
+	Argv []string
 
 	// Ctx is the run context, populated from main.go with the process signal
 	// context. It carries cancellation down through every task's Plan and
@@ -103,7 +119,7 @@ func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f.StringVar(&c.play, "play", "", "plan only the play with this name (matches the play's `name:` field; auto-named plays use `play #N`)")
 	f.BoolVar(&c.listTasks, "list-tasks", false, "print the resolved task plan and exit without contacting the server. Honors --play / --tags / --skip-tags and shows expanded loop iterations and [skipped] markers for when:-skipped tasks.")
 
-	data, format, source := preloadRecipeForFlags(os.Args, true)
+	data, format, source := preloadRecipeForFlags(c.argv(), true, c.stdinSource())
 	if data == nil {
 		return f
 	}
@@ -201,7 +217,7 @@ func (c *PlanCommand) Run(args []string) int {
 	// The cached bytes are the ones FlagSet already read for this source
 	// (see tasksData); for a --tasks URL this avoids a second HTTP fetch
 	// of the same recipe.
-	recipe, err := loadRecipe(taskFile, formatOverride, true, c.tasksData, c.tasksDataSource)
+	recipe, err := loadRecipe(taskFile, formatOverride, true, c.tasksData, c.tasksDataSource, c.stdinSource())
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read error: %v", err))
 		return 1
@@ -725,4 +741,18 @@ func planGroup(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask
 		Timestamp: time.Now().UTC(),
 	})
 	return out
+}
+
+// argv returns the argv this command resolves its pre-parse flags from.
+func (c *PlanCommand) argv() []string { return commandArgv(c.Argv) }
+
+// stdinSource returns this command's memoized standard-input reader, creating
+// it on first use. One per command: the recipe is read more than once per
+// invocation (FlagSet, Run, and Help on a flag error) but standard input only
+// yields its bytes once.
+func (c *PlanCommand) stdinSource() *stdinRecipeSource {
+	if c.stdin == nil {
+		c.stdin = newStdinRecipeSource(c.Stdin)
+	}
+	return c.stdin
 }

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -21,6 +21,16 @@ import (
 type PlanCommand struct {
 	command.Meta
 
+	// BaseDir is the directory relative paths resolve against - the recipe
+	// probed when --tasks is absent, and any output written to a relative
+	// path. Populated from main.go; empty means the process working
+	// directory, which is what it always was.
+	//
+	// It exists so a test can point a command at a temp directory instead of
+	// chdir'ing the whole process, which no test can do while another runs
+	// beside it.
+	BaseDir string
+
 	// Stdin is where a `--tasks -` recipe is read from. Populated from
 	// main.go; nil reads the process's standard input. A test hands over its
 	// own pipe instead of swapping os.Stdin, which no two tests can do at
@@ -119,7 +129,7 @@ func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f.StringVar(&c.play, "play", "", "plan only the play with this name (matches the play's `name:` field; auto-named plays use `play #N`)")
 	f.BoolVar(&c.listTasks, "list-tasks", false, "print the resolved task plan and exit without contacting the server. Honors --play / --tags / --skip-tags and shows expanded loop iterations and [skipped] markers for when:-skipped tasks.")
 
-	data, format, source := preloadRecipeForFlags(c.argv(), true, c.stdinSource())
+	data, format, source := preloadRecipeForFlags(c.baseDir(), c.argv(), true, c.stdinSource())
 	if data == nil {
 		return f
 	}
@@ -217,7 +227,7 @@ func (c *PlanCommand) Run(args []string) int {
 	// The cached bytes are the ones FlagSet already read for this source
 	// (see tasksData); for a --tasks URL this avoids a second HTTP fetch
 	// of the same recipe.
-	recipe, err := loadRecipe(taskFile, formatOverride, true, c.tasksData, c.tasksDataSource, c.stdinSource())
+	recipe, err := loadRecipe(c.baseDir(), taskFile, formatOverride, true, c.tasksData, c.tasksDataSource, c.stdinSource())
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read error: %v", err))
 		return 1
@@ -756,3 +766,6 @@ func (c *PlanCommand) stdinSource() *stdinRecipeSource {
 	}
 	return c.stdin
 }
+
+// baseDir returns the directory this command resolves relative paths against.
+func (c *PlanCommand) baseDir() string { return c.BaseDir }

--- a/commands/play_executor_test.go
+++ b/commands/play_executor_test.go
@@ -31,11 +31,9 @@ func writeMultiPlayTasks(t *testing.T, body string) string {
 // runs against the per-call args).
 func runPlan(t *testing.T, path string, args ...string) (string, string, int) {
 	t.Helper()
-	origArgs := os.Args
-	os.Args = []string{"docket-test", "plan", "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", "plan", "--tasks", path}
 
-	c := &PlanCommand{}
+	c := &PlanCommand{Argv: argv}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
 	all := append([]string{"--tasks", path}, args...)
 	exit := c.Run(all)

--- a/commands/play_target_test.go
+++ b/commands/play_target_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -17,9 +16,7 @@ import (
 // type and lets the runner answer for it.
 func runApplyWithTarget(t *testing.T, path string, args ...string) (map[string][]string, string) {
 	t.Helper()
-	origArgs := os.Args
-	os.Args = []string{"docket-test", "apply", "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", "apply", "--tasks", path}
 
 	seen := map[string][]string{}
 	ctx := subprocess.ContextWithRunner(context.Background(),
@@ -30,7 +27,7 @@ func runApplyWithTarget(t *testing.T, path string, args ...string) (map[string][
 		})
 
 	ui := cli.NewMockUi()
-	c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+	c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
 	c.Run(append([]string{"--tasks", path}, args...))
 	return seen, ui.OutputWriter.String()
 }
@@ -119,9 +116,7 @@ func TestApplyPlaySudoInheritsAndDeclines(t *testing.T) {
       dokku_app: { app: b }
 `)
 
-	origArgs := os.Args
-	os.Args = []string{"docket-test", "apply", "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", "apply", "--tasks", path}
 
 	sudoByHost := map[string]bool{}
 	ctx := subprocess.ContextWithRunner(context.Background(),
@@ -131,7 +126,7 @@ func TestApplyPlaySudoInheritsAndDeclines(t *testing.T) {
 			return subprocess.ExecCommandResponse{}, nil
 		})
 
-	c := &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Ctx: ctx}
+	c := &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Argv: argv, Ctx: ctx}
 	c.Run([]string{"--tasks", path, "--sudo"})
 
 	if !sudoByHost["deploy@one.example.com"] {
@@ -148,9 +143,7 @@ func TestApplyPlaySudoInheritsAndDeclines(t *testing.T) {
 func TestPlanRoutesEachPlayToItsOwnHost(t *testing.T) {
 	path := writeTasksFile(t, twoHostRecipe)
 
-	origArgs := os.Args
-	os.Args = []string{"docket-test", "plan", "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", "plan", "--tasks", path}
 
 	seen := map[string]bool{}
 	ctx := subprocess.ContextWithRunner(context.Background(),
@@ -160,7 +153,7 @@ func TestPlanRoutesEachPlayToItsOwnHost(t *testing.T) {
 		})
 
 	ui := cli.NewMockUi()
-	c := &PlanCommand{Meta: command.Meta{Ui: ui}, Ctx: ctx}
+	c := &PlanCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
 	c.Run([]string{"--tasks", path})
 
 	if !seen[""] || !seen["deploy@remote.example.com"] {

--- a/commands/play_when_test.go
+++ b/commands/play_when_test.go
@@ -23,24 +23,22 @@ import (
 // outcome we want to assert. With `!=`, `nil != "x"` is true and the
 // play would run regardless of whether the variable was visible.
 
-func newTestPlanCommand() *PlanCommand {
-	c := &PlanCommand{}
+func newTestPlanCommand(argv []string) *PlanCommand {
+	c := &PlanCommand{Argv: argv}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
 	return c
 }
 
 // playOutput drives plan with the given args against the tasks file at
-// path and returns the captured stdout / stderr / exit code. It also
-// stages os.Args because PlanCommand.FlagSet() reads --tasks from
-// os.Args (not from the args slice) so it can pre-register input flags
-// before flag.Parse runs against the per-call args.
+// path and returns the captured stdout / stderr / exit code. It hands the
+// command its own argv because PlanCommand.FlagSet() reads --tasks from argv
+// (not from the args slice) so it can pre-register input flags before
+// flag.Parse runs against the per-call args.
 func playOutput(t *testing.T, path string, args ...string) (string, string, int) {
 	t.Helper()
-	origArgs := os.Args
-	os.Args = []string{"docket-test", "plan", "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", "plan", "--tasks", path}
 
-	c := newTestPlanCommand()
+	c := newTestPlanCommand(argv)
 	all := append([]string{"--tasks", path}, args...)
 	exit := c.Run(all)
 	ui := c.Ui.(*cli.MockUi)

--- a/commands/schema_command.go
+++ b/commands/schema_command.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/dokku/docket/tasks"
@@ -31,6 +32,22 @@ import (
 // the published JSON Schema covers both.
 type SchemaCommand struct {
 	command.Meta
+
+	// BaseDir is the directory relative paths resolve against - the recipe
+	// probed when --tasks is absent, and any output written to a relative
+	// path. Populated from main.go; empty means the process working
+	// directory, which is what it always was.
+	//
+	// It exists so a test can point a command at a temp directory instead of
+	// chdir'ing the whole process, which no test can do while another runs
+	// beside it.
+	BaseDir string
+
+	// Stdout is where a streamed recipe, diff or catalog is written. Populated
+	// from main.go; nil writes to the process's standard output. These writes
+	// bypass Ui on purpose - it is wrapped in a log formatter - so a test that
+	// asserts on them needs somewhere of its own to capture.
+	Stdout io.Writer
 
 	output    string
 	taskTypes []string
@@ -164,16 +181,22 @@ func (c *SchemaCommand) Run(args []string) int {
 	// wrapped in a human log formatter. Same reason init and export write
 	// their rendered output directly.
 	if c.output == "-" {
-		if _, err := os.Stdout.Write(buf.Bytes()); err != nil {
+		if _, err := c.stdout().Write(buf.Bytes()); err != nil {
 			c.Ui.Error(fmt.Sprintf("write error: %v", err))
 			return 1
 		}
 		return 0
 	}
 
-	if err := os.WriteFile(c.output, buf.Bytes(), 0o644); err != nil {
+	if err := os.WriteFile(inDir(c.baseDir(), c.output), buf.Bytes(), 0o644); err != nil {
 		c.Ui.Error(fmt.Sprintf("write error: %v", err))
 		return 1
 	}
 	return 0
 }
+
+// stdout returns the writer this command streams bytes to.
+func (c *SchemaCommand) stdout() io.Writer { return commandStdout(c.Stdout) }
+
+// baseDir returns the directory this command resolves relative paths against.
+func (c *SchemaCommand) baseDir() string { return c.BaseDir }

--- a/commands/schema_command_test.go
+++ b/commands/schema_command_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -23,7 +24,10 @@ func runSchema(t *testing.T, args ...string) (string, string, int) {
 	t.Helper()
 	c := &SchemaCommand{}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
-	out, exit := captureStdout(t, func() int { return c.Run(args) })
+	out, exit := captureStdout(t, func(w io.Writer) int {
+		c.Stdout = w
+		return c.Run(args)
+	})
 	return out, c.Ui.(*cli.MockUi).ErrorWriter.String(), exit
 }
 

--- a/commands/sensitive_default_masking_test.go
+++ b/commands/sensitive_default_masking_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -30,25 +29,30 @@ type helpCommand interface {
 // helpCommands builds each command whose --help page can carry input flags.
 // The three share registerInputFlags but reach it from three separate
 // FlagSet() implementations, so each is exercised on its own.
-var helpCommands = map[string]func() helpCommand{
-	"apply":    func() helpCommand { return &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}} },
-	"plan":     func() helpCommand { return &PlanCommand{Meta: command.Meta{Ui: cli.NewMockUi()}} },
-	"validate": func() helpCommand { return &ValidateCommand{Meta: command.Meta{Ui: cli.NewMockUi()}} },
+var helpCommands = map[string]func(argv []string) helpCommand{
+	"apply": func(argv []string) helpCommand {
+		return &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Argv: argv}
+	},
+	"plan": func(argv []string) helpCommand {
+		return &PlanCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Argv: argv}
+	},
+	"validate": func(argv []string) helpCommand {
+		return &ValidateCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Argv: argv}
+	},
 }
 
 // helpText renders one command's --help page for the recipe at path. FlagSet()
-// resolves the recipe out of os.Args rather than from the parsed flags, so the
-// argv has to be staged the way runApply and runPlan stage it.
+// resolves the recipe out of the command's argv rather than from the parsed
+// flags, so the argv is handed over the way runApply and runPlan hand it.
 func helpText(t *testing.T, name, path string) string {
 	t.Helper()
 	build, ok := helpCommands[name]
 	if !ok {
 		t.Fatalf("no help command registered for %q", name)
 	}
-	origArgs := os.Args
-	os.Args = []string{"docket-test", name, "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
-	return build().Help()
+	argv := []string{"docket-test", name, "--tasks", path}
+
+	return build(argv).Help()
 }
 
 // TestHelpMasksSensitiveInputDefault is the #490 regression. A recipe that

--- a/commands/stdin_test.go
+++ b/commands/stdin_test.go
@@ -171,16 +171,14 @@ func TestValidateStdinRegistersRecipeInputs(t *testing.T) {
 // reports the real error there.
 func TestPreloadRecipeForFlagsSkipsMissingFile(t *testing.T) {
 	dir := t.TempDir()
-	withCwd(t, dir, func() {
-		data, format, source := preloadRecipeForFlags([]string{"docket", "validate"}, false, newStdinRecipeSource(nil))
-		if data != nil {
-			t.Errorf("data = %q, want nil when no recipe exists", data)
-		}
-		if format != "" {
-			t.Errorf("format = %q, want empty when no recipe exists", format)
-		}
-		if source != defaultTaskFileCandidates[0] {
-			t.Errorf("source = %q, want the probed default %q", source, defaultTaskFileCandidates[0])
-		}
-	})
+	data, format, source := preloadRecipeForFlags(dir, []string{"docket", "validate"}, false, newStdinRecipeSource(nil))
+	if data != nil {
+		t.Errorf("data = %q, want nil when no recipe exists", data)
+	}
+	if format != "" {
+		t.Errorf("format = %q, want empty when no recipe exists", format)
+	}
+	if source != defaultTaskFileCandidates[0] {
+		t.Errorf("source = %q, want the probed default %q", source, defaultTaskFileCandidates[0])
+	}
 }

--- a/commands/stdin_test.go
+++ b/commands/stdin_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -15,30 +16,23 @@ import (
 // recipe. Returns the MockUi so callers can assert on output.
 //
 // resetStdinRecipe bookends the swap because readStdinRecipe memoizes
-// the single read a process gets; without it the second test here would
-// be served the first one's bytes.
-func withStdinArgs(t *testing.T, recipe string, args []string, fn func()) {
+// its own pipe and argv, so two of these can no longer serve each other the
+// wrong bytes through a process-wide memo.
+func withStdinArgs(t *testing.T, recipe string, args []string, fn func(stdin io.Reader, argv []string)) {
 	t.Helper()
 
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("stdin pipe: %v", err)
 	}
-	origStdin, origArgs := os.Stdin, os.Args
-	os.Stdin = r
-	os.Args = append([]string{"docket", "validate"}, args...)
-	resetStdinRecipe()
-	t.Cleanup(func() {
-		os.Stdin, os.Args = origStdin, origArgs
-		resetStdinRecipe()
-	})
+	t.Cleanup(func() { r.Close() })
 
 	go func() {
 		_, _ = w.WriteString(recipe)
 		w.Close()
 	}()
 
-	fn()
+	fn(r, append([]string{"docket", "validate"}, args...))
 }
 
 // runValidateOverStdin pipes recipe into `docket validate <args>` and
@@ -48,9 +42,9 @@ func runValidateOverStdin(t *testing.T, recipe string, args []string) (int, stri
 
 	var exit int
 	var out string
-	withStdinArgs(t, recipe, args, func() {
+	withStdinArgs(t, recipe, args, func(stdin io.Reader, argv []string) {
 		ui := cli.NewMockUi()
-		c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+		c := &ValidateCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Stdin: stdin}
 		exit = c.Run(args)
 		out = ui.OutputWriter.String() + ui.ErrorWriter.String()
 	})
@@ -178,7 +172,7 @@ func TestValidateStdinRegistersRecipeInputs(t *testing.T) {
 func TestPreloadRecipeForFlagsSkipsMissingFile(t *testing.T) {
 	dir := t.TempDir()
 	withCwd(t, dir, func() {
-		data, format, source := preloadRecipeForFlags([]string{"docket", "validate"}, false)
+		data, format, source := preloadRecipeForFlags([]string{"docket", "validate"}, false, newStdinRecipeSource(nil))
 		if data != nil {
 			t.Errorf("data = %q, want nil when no recipe exists", data)
 		}

--- a/commands/task_file.go
+++ b/commands/task_file.go
@@ -265,8 +265,8 @@ func isTaskFileURL(path string) bool {
 // readTaskFileData returns the bytes of the recipe at path, allowing an
 // http(s) URL. Kept as the name apply and plan already call, now a thin
 // wrapper so there is only one read path to reason about.
-func readTaskFileData(path string) ([]byte, error) {
-	return readRecipeBytes(path, true)
+func readTaskFileData(path string, stdin *stdinRecipeSource) ([]byte, error) {
+	return readRecipeBytes(path, true, stdin)
 }
 
 // readRecipeBytes returns the bytes of the recipe at path.
@@ -278,9 +278,9 @@ func readTaskFileData(path string) ([]byte, error) {
 // rather than hidden in a function name. Any other value is read from
 // disk so the familiar os.ReadFile "no such file" error still surfaces
 // for a mistyped path.
-func readRecipeBytes(path string, allowURL bool) ([]byte, error) {
+func readRecipeBytes(path string, allowURL bool, stdin *stdinRecipeSource) ([]byte, error) {
 	if path == taskFileStdin {
-		return readStdinRecipe()
+		return stdin.recipe()
 	}
 	if allowURL && isTaskFileURL(path) {
 		return fetchTaskFileURL(path)
@@ -288,44 +288,44 @@ func readRecipeBytes(path string, allowURL bool) ([]byte, error) {
 	return os.ReadFile(path)
 }
 
-// stdinRecipe memoizes the one read of os.Stdin a process gets. Each of
-// apply, plan, and validate touches the recipe at least twice - once in
-// FlagSet() to pre-register the recipe's own inputs as flags, once in
-// Run() - and a flag-parse error adds two more reads via Help(). Only
-// the first read can return data, so every later caller is served from
-// here.
+// stdinRecipeSource memoizes the one read of standard input a command gets.
+// Each of apply, plan, and validate touches the recipe at least twice - once in
+// FlagSet() to pre-register the recipe's own inputs as flags, once in Run() -
+// and a flag-parse error adds two more reads via Help(). Only the first read
+// can return data, so every later caller is served from here.
 //
-// The error is memoized alongside the data on purpose. Without it a
-// second call would see an empty, successful read and turn a real stdin
-// failure into a misleading "no recipe found in tasks file".
+// The error is memoized alongside the data on purpose. Without it a second call
+// would see an empty, successful read and turn a real stdin failure into a
+// misleading "no recipe found in tasks file".
 //
-// A plain sentinel rather than sync.Once: the command path is
-// single-goroutine, and a Once paired with a test reset hook reads like
-// a concurrency bug that isn't there.
-var stdinRecipe struct {
+// One source belongs to one command. It used to be a package variable with a
+// test-only reset hook, which meant a test exercising a piped recipe had to
+// swap os.Stdin and put it back - process state no two tests can hold at once.
+type stdinRecipeSource struct {
+	in   io.Reader
 	read bool
 	data []byte
 	err  error
 }
 
-// readStdinRecipe returns the recipe piped into standard input, reading
-// it at most once per process.
-func readStdinRecipe() ([]byte, error) {
-	if !stdinRecipe.read {
-		stdinRecipe.read = true
-		stdinRecipe.data, stdinRecipe.err = io.ReadAll(os.Stdin)
+// newStdinRecipeSource returns a source reading from in, or from the process's
+// standard input when in is nil.
+func newStdinRecipeSource(in io.Reader) *stdinRecipeSource {
+	if in == nil {
+		in = os.Stdin
 	}
-	return stdinRecipe.data, stdinRecipe.err
+	return &stdinRecipeSource{in: in}
 }
 
-// resetStdinRecipe clears the memo so a test can swap os.Stdin and read
-// again. Production code never calls it - a process only ever has one
-// stdin.
-func resetStdinRecipe() {
-	stdinRecipe.read = false
-	stdinRecipe.data = nil
-	stdinRecipe.err = nil
+// recipe returns the recipe piped in, reading it at most once.
+func (s *stdinRecipeSource) recipe() ([]byte, error) {
+	if !s.read {
+		s.read = true
+		s.data, s.err = io.ReadAll(s.in)
+	}
+	return s.data, s.err
 }
+
 
 // fetchTaskFileURL GETs a recipe from an http(s) URL. A transport error, a
 // non-2xx response, or a body larger than maxTaskFileBytes is reported as
@@ -503,11 +503,11 @@ type recipeSource struct {
 // cached / cachedSource carry bytes an earlier phase already read for
 // the same source, so a --tasks URL is not fetched over HTTP twice; pass
 // nil / "" when there is nothing to reuse. stdin needs no help here -
-// readStdinRecipe memoizes it globally - but a URL fetch is not memoized
+// stdinRecipeSource memoizes it - but a URL fetch is not memoized
 // and would otherwise hit the network again.
 //
 // allowURL is threaded through to readRecipeBytes; see its doc comment.
-func loadRecipe(taskFile, formatOverride string, allowURL bool, cached []byte, cachedSource string) (recipeSource, error) {
+func loadRecipe(taskFile, formatOverride string, allowURL bool, cached []byte, cachedSource string, stdin *stdinRecipeSource) (recipeSource, error) {
 	path, detected, ambiguous, err := resolveTaskFilePath(taskFile)
 	if err != nil {
 		return recipeSource{}, err
@@ -515,7 +515,7 @@ func loadRecipe(taskFile, formatOverride string, allowURL bool, cached []byte, c
 
 	data := cached
 	if data == nil || cachedSource != path {
-		data, err = readRecipeBytes(path, allowURL)
+		data, err = readRecipeBytes(path, allowURL, stdin)
 		if err != nil {
 			return recipeSource{}, err
 		}
@@ -555,12 +555,12 @@ func loadRecipe(taskFile, formatOverride string, allowURL bool, cached []byte, c
 // commandHelp, which calls FlagSet twice), so reading an interactive
 // terminal here would hang instead of printing the message the user
 // asked for. Only Run may block on stdin.
-func preloadRecipeForFlags(argv []string, allowURL bool) (data []byte, format string, source string) {
+func preloadRecipeForFlags(argv []string, allowURL bool, stdin *stdinRecipeSource) (data []byte, format string, source string) {
 	path, detected := resolveTaskFileFromArgs(argv)
 	if path == taskFileStdin && isatty.IsTerminal(os.Stdin.Fd()) {
 		return nil, "", path
 	}
-	data, err := readRecipeBytes(path, allowURL)
+	data, err := readRecipeBytes(path, allowURL, stdin)
 	if err != nil {
 		return nil, "", path
 	}
@@ -615,4 +615,17 @@ func recipeFormatAutocomplete() complete.Predictor {
 // argument across apply / plan / validate / fmt / init / export.
 func taskFileAutocomplete() complete.Predictor {
 	return predictFilesByExtension(taskFileExtensions)
+}
+
+// commandArgv returns the argv a command should resolve its pre-parse flags
+// from: the one it was given, or the process's when it was given none.
+//
+// Reading os.Args directly is what forced every test that exercises FlagSet to
+// assign to the process global and restore it afterwards, which is a thing
+// t.Parallel() makes unsafe.
+func commandArgv(argv []string) []string {
+	if argv != nil {
+		return argv
+	}
+	return os.Args
 }

--- a/commands/task_file.go
+++ b/commands/task_file.go
@@ -265,8 +265,8 @@ func isTaskFileURL(path string) bool {
 // readTaskFileData returns the bytes of the recipe at path, allowing an
 // http(s) URL. Kept as the name apply and plan already call, now a thin
 // wrapper so there is only one read path to reason about.
-func readTaskFileData(path string, stdin *stdinRecipeSource) ([]byte, error) {
-	return readRecipeBytes(path, true, stdin)
+func readTaskFileData(baseDir, path string, stdin *stdinRecipeSource) ([]byte, error) {
+	return readRecipeBytes(baseDir, path, true, stdin)
 }
 
 // readRecipeBytes returns the bytes of the recipe at path.
@@ -278,14 +278,14 @@ func readTaskFileData(path string, stdin *stdinRecipeSource) ([]byte, error) {
 // rather than hidden in a function name. Any other value is read from
 // disk so the familiar os.ReadFile "no such file" error still surfaces
 // for a mistyped path.
-func readRecipeBytes(path string, allowURL bool, stdin *stdinRecipeSource) ([]byte, error) {
+func readRecipeBytes(baseDir, path string, allowURL bool, stdin *stdinRecipeSource) ([]byte, error) {
 	if path == taskFileStdin {
 		return stdin.recipe()
 	}
 	if allowURL && isTaskFileURL(path) {
 		return fetchTaskFileURL(path)
 	}
-	return os.ReadFile(path)
+	return os.ReadFile(inDir(baseDir, path))
 }
 
 // stdinRecipeSource memoizes the one read of standard input a command gets.
@@ -383,10 +383,10 @@ func hasTaskFileExtension(path string) bool {
 // always done by returning on its first hit: an unreadable tasks.json
 // sitting next to a perfectly good tasks.yml has never been fatal, and
 // collecting others must not make it so.
-func probeDefaultTaskFile() (string, []string, error) {
+func probeDefaultTaskFile(baseDir string) (string, []string, error) {
 	var existing []string
 	for _, candidate := range defaultTaskFileCandidates {
-		_, err := os.Stat(candidate)
+		_, err := os.Stat(inDir(baseDir, candidate))
 		if err == nil {
 			existing = append(existing, candidate)
 			continue
@@ -434,7 +434,7 @@ func ambiguousTaskFileWarning(chosen string, others []string) string {
 //
 // The third return value carries the other candidates the probe found,
 // for ambiguousTaskFileWarning; it is nil whenever the probe did not run.
-func resolveTaskFilePath(explicit string) (string, string, []string, error) {
+func resolveTaskFilePath(baseDir string, explicit string) (string, string, []string, error) {
 	if explicit == taskFileStdin {
 		// stdin has no name to detect a format from; the empty format
 		// tells taskFileFormatFor to sniff the bytes instead. Probing
@@ -445,7 +445,7 @@ func resolveTaskFilePath(explicit string) (string, string, []string, error) {
 	if explicit != "" {
 		return explicit, detectTaskFileFormat(explicit), nil, nil
 	}
-	chosen, others, err := probeDefaultTaskFile()
+	chosen, others, err := probeDefaultTaskFile(baseDir)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -507,15 +507,15 @@ type recipeSource struct {
 // and would otherwise hit the network again.
 //
 // allowURL is threaded through to readRecipeBytes; see its doc comment.
-func loadRecipe(taskFile, formatOverride string, allowURL bool, cached []byte, cachedSource string, stdin *stdinRecipeSource) (recipeSource, error) {
-	path, detected, ambiguous, err := resolveTaskFilePath(taskFile)
+func loadRecipe(baseDir, taskFile, formatOverride string, allowURL bool, cached []byte, cachedSource string, stdin *stdinRecipeSource) (recipeSource, error) {
+	path, detected, ambiguous, err := resolveTaskFilePath(baseDir, taskFile)
 	if err != nil {
 		return recipeSource{}, err
 	}
 
 	data := cached
 	if data == nil || cachedSource != path {
-		data, err = readRecipeBytes(path, allowURL, stdin)
+		data, err = readRecipeBytes(baseDir, path, allowURL, stdin)
 		if err != nil {
 			return recipeSource{}, err
 		}
@@ -555,12 +555,12 @@ func loadRecipe(taskFile, formatOverride string, allowURL bool, cached []byte, c
 // commandHelp, which calls FlagSet twice), so reading an interactive
 // terminal here would hang instead of printing the message the user
 // asked for. Only Run may block on stdin.
-func preloadRecipeForFlags(argv []string, allowURL bool, stdin *stdinRecipeSource) (data []byte, format string, source string) {
-	path, detected := resolveTaskFileFromArgs(argv)
+func preloadRecipeForFlags(baseDir string, argv []string, allowURL bool, stdin *stdinRecipeSource) (data []byte, format string, source string) {
+	path, detected := resolveTaskFileFromArgs(baseDir, argv)
 	if path == taskFileStdin && isatty.IsTerminal(os.Stdin.Fd()) {
 		return nil, "", path
 	}
-	data, err := readRecipeBytes(path, allowURL, stdin)
+	data, err := readRecipeBytes(baseDir, path, allowURL, stdin)
 	if err != nil {
 		return nil, "", path
 	}
@@ -628,4 +628,34 @@ func commandArgv(argv []string) []string {
 		return argv
 	}
 	return os.Args
+}
+
+// commandStdout returns the writer a command streams a recipe, diff or catalog
+// to: the one it was given, or the process's standard output when it was given
+// none.
+//
+// These writes deliberately bypass c.Ui, which is wrapped in a human log
+// formatter that would decorate bytes meant to be piped. Reading os.Stdout
+// directly is what forced every test asserting on them to swap the process
+// global and put it back.
+func commandStdout(w io.Writer) io.Writer {
+	if w != nil {
+		return w
+	}
+	return os.Stdout
+}
+
+// inDir resolves path against baseDir: unchanged when baseDir is empty (the
+// command was given none, so the process working directory applies as it
+// always has) or when path is already absolute.
+//
+// It is the one place relative paths become concrete, so a command can be
+// pointed at a directory without the process having to chdir into it - which
+// is what let every test that seeds a recipe or checks an output file stop
+// moving the working directory out from under everything else.
+func inDir(baseDir, path string) string {
+	if baseDir == "" || path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(baseDir, path)
 }

--- a/commands/task_file_test.go
+++ b/commands/task_file_test.go
@@ -302,10 +302,10 @@ func TestResolveTaskFilePathStdin(t *testing.T) {
 // it passes allowURL=false and an http(s) --tasks must not be fetched.
 func TestReadRecipeBytesURLPermission(t *testing.T) {
 	const url = "https://example.invalid/tasks.yml"
-	if _, err := readRecipeBytes(url, false); err == nil {
-		t.Fatal("readRecipeBytes(url, false) = nil error, want a local-read failure")
+	if _, err := readRecipeBytes(url, false, newStdinRecipeSource(nil)); err == nil {
+		t.Fatal("readRecipeBytes(url, false, newStdinRecipeSource(nil)) = nil error, want a local-read failure")
 	} else if strings.Contains(err.Error(), "fetch") {
-		t.Errorf("readRecipeBytes(url, false) attempted a fetch: %v", err)
+		t.Errorf("readRecipeBytes(url, false, newStdinRecipeSource(nil)) attempted a fetch: %v", err)
 	}
 }
 

--- a/commands/task_file_test.go
+++ b/commands/task_file_test.go
@@ -281,28 +281,26 @@ func TestResolveTaskFilePathStdin(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "tasks.yml"), []byte("---\n"), 0o644); err != nil {
 		t.Fatalf("write yml: %v", err)
 	}
-	withCwd(t, dir, func() {
-		path, format, ambiguous, err := resolveTaskFilePath(taskFileStdin)
-		if err != nil {
-			t.Fatalf("resolveTaskFilePath: %v", err)
-		}
-		if path != taskFileStdin {
-			t.Errorf("path = %q, want %q", path, taskFileStdin)
-		}
-		if format != "" {
-			t.Errorf("format = %q, want empty so the caller sniffs", format)
-		}
-		if len(ambiguous) != 0 {
-			t.Errorf("ambiguous = %v, want none; stdin never runs the probe", ambiguous)
-		}
-	})
+	path, format, ambiguous, err := resolveTaskFilePath("", taskFileStdin)
+	if err != nil {
+		t.Fatalf("resolveTaskFilePath: %v", err)
+	}
+	if path != taskFileStdin {
+		t.Errorf("path = %q, want %q", path, taskFileStdin)
+	}
+	if format != "" {
+		t.Errorf("format = %q, want empty so the caller sniffs", format)
+	}
+	if len(ambiguous) != 0 {
+		t.Errorf("ambiguous = %v, want none; stdin never runs the probe", ambiguous)
+	}
 }
 
 // TestReadRecipeBytesURLPermission: validate is offline by contract, so
 // it passes allowURL=false and an http(s) --tasks must not be fetched.
 func TestReadRecipeBytesURLPermission(t *testing.T) {
 	const url = "https://example.invalid/tasks.yml"
-	if _, err := readRecipeBytes(url, false, newStdinRecipeSource(nil)); err == nil {
+	if _, err := readRecipeBytes("", url, false, newStdinRecipeSource(nil)); err == nil {
 		t.Fatal("readRecipeBytes(url, false, newStdinRecipeSource(nil)) = nil error, want a local-read failure")
 	} else if strings.Contains(err.Error(), "fetch") {
 		t.Errorf("readRecipeBytes(url, false, newStdinRecipeSource(nil)) attempted a fetch: %v", err)
@@ -355,13 +353,13 @@ func TestResolveTaskFileFromArgsPositional(t *testing.T) {
 
 	// A --vars-file value that looks like a recipe must not be picked as
 	// the positional; the real positional recipe path should win.
-	got, _ := resolveTaskFileFromArgs([]string{"docket", "validate", "--vars-file", vars, recipe})
+	got, _ := resolveTaskFileFromArgs("", []string{"docket", "validate", "--vars-file", vars, recipe})
 	if got != recipe {
 		t.Errorf("expected positional %q, got %q", recipe, got)
 	}
 
 	// --tasks still takes precedence for preregistration.
-	got, _ = resolveTaskFileFromArgs([]string{"docket", "validate", "--tasks", recipe})
+	got, _ = resolveTaskFileFromArgs("", []string{"docket", "validate", "--tasks", recipe})
 	if got != recipe {
 		t.Errorf("expected --tasks %q, got %q", recipe, got)
 	}
@@ -373,7 +371,7 @@ func TestResolveTaskFilePathExplicit(t *testing.T) {
 	if err := os.WriteFile(path, []byte("[]"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	gotPath, gotFormat, ambiguous, err := resolveTaskFilePath(path)
+	gotPath, gotFormat, ambiguous, err := resolveTaskFilePath("", path)
 	if err != nil {
 		t.Fatalf("resolveTaskFilePath: %v", err)
 	}
@@ -396,21 +394,19 @@ func TestResolveTaskFilePathDefaultPrefersYAML(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "tasks.json"), []byte("[]"), 0o644); err != nil {
 		t.Fatalf("write json: %v", err)
 	}
-	withCwd(t, dir, func() {
-		path, format, ambiguous, err := resolveTaskFilePath("")
-		if err != nil {
-			t.Fatalf("resolveTaskFilePath: %v", err)
-		}
-		if path != "tasks.yml" {
-			t.Errorf("path = %q, want tasks.yml", path)
-		}
-		if format != taskFileFormatYAML {
-			t.Errorf("format = %q, want yaml", format)
-		}
-		if !slices.Equal(ambiguous, []string{"tasks.json"}) {
-			t.Errorf("ambiguous = %v, want [tasks.json]", ambiguous)
-		}
-	})
+	path, format, ambiguous, err := resolveTaskFilePath(dir, "")
+	if err != nil {
+		t.Fatalf("resolveTaskFilePath: %v", err)
+	}
+	if path != "tasks.yml" {
+		t.Errorf("path = %q, want tasks.yml", path)
+	}
+	if format != taskFileFormatYAML {
+		t.Errorf("format = %q, want yaml", format)
+	}
+	if !slices.Equal(ambiguous, []string{"tasks.json"}) {
+		t.Errorf("ambiguous = %v, want [tasks.json]", ambiguous)
+	}
 }
 
 func TestResolveTaskFilePathDefaultFallsThroughToJSON(t *testing.T) {
@@ -418,34 +414,30 @@ func TestResolveTaskFilePathDefaultFallsThroughToJSON(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "tasks.json"), []byte("[]"), 0o644); err != nil {
 		t.Fatalf("write json: %v", err)
 	}
-	withCwd(t, dir, func() {
-		path, format, ambiguous, err := resolveTaskFilePath("")
-		if err != nil {
-			t.Fatalf("resolveTaskFilePath: %v", err)
-		}
-		if path != "tasks.json" {
-			t.Errorf("path = %q, want tasks.json", path)
-		}
-		if format != taskFileFormatJSON5 {
-			t.Errorf("format = %q, want json5", format)
-		}
-		if len(ambiguous) != 0 {
-			t.Errorf("ambiguous = %v, want none; tasks.json was the only candidate", ambiguous)
-		}
-	})
+	path, format, ambiguous, err := resolveTaskFilePath(dir, "")
+	if err != nil {
+		t.Fatalf("resolveTaskFilePath: %v", err)
+	}
+	if path != "tasks.json" {
+		t.Errorf("path = %q, want tasks.json", path)
+	}
+	if format != taskFileFormatJSON5 {
+		t.Errorf("format = %q, want json5", format)
+	}
+	if len(ambiguous) != 0 {
+		t.Errorf("ambiguous = %v, want none; tasks.json was the only candidate", ambiguous)
+	}
 }
 
 func TestResolveTaskFilePathDefaultErrorsWhenNoneExist(t *testing.T) {
 	dir := t.TempDir()
-	withCwd(t, dir, func() {
-		_, _, _, err := resolveTaskFilePath("")
-		if err == nil {
-			t.Fatal("expected error when no candidate task file exists")
-		}
-		if !strings.Contains(err.Error(), "no task file found") {
-			t.Errorf("error = %q, want substring 'no task file found'", err.Error())
-		}
-	})
+	_, _, _, err := resolveTaskFilePath(dir, "")
+	if err == nil {
+		t.Fatal("expected error when no candidate task file exists")
+	}
+	if !strings.Contains(err.Error(), "no task file found") {
+		t.Errorf("error = %q, want substring 'no task file found'", err.Error())
+	}
 }
 
 // TestProbeDefaultTaskFile covers the shared probe every command reaches
@@ -491,18 +483,16 @@ func TestProbeDefaultTaskFile(t *testing.T) {
 					t.Fatalf("write %s: %v", name, err)
 				}
 			}
-			withCwd(t, dir, func() {
-				chosen, others, err := probeDefaultTaskFile()
-				if err != nil {
-					t.Fatalf("probeDefaultTaskFile: %v", err)
-				}
-				if chosen != tc.wantChosen {
-					t.Errorf("chosen = %q, want %q", chosen, tc.wantChosen)
-				}
-				if !slices.Equal(others, tc.wantOthers) {
-					t.Errorf("others = %v, want %v", others, tc.wantOthers)
-				}
-			})
+			chosen, others, err := probeDefaultTaskFile(dir)
+			if err != nil {
+				t.Fatalf("probeDefaultTaskFile: %v", err)
+			}
+			if chosen != tc.wantChosen {
+				t.Errorf("chosen = %q, want %q", chosen, tc.wantChosen)
+			}
+			if !slices.Equal(others, tc.wantOthers) {
+				t.Errorf("others = %v, want %v", others, tc.wantOthers)
+			}
 		})
 	}
 }
@@ -573,7 +563,7 @@ func TestShellQuotePath(t *testing.T) {
 }
 
 func TestResolveTaskFileFromArgsUsesExplicitFlag(t *testing.T) {
-	path, format := resolveTaskFileFromArgs([]string{"docket", "apply", "--tasks", "custom.json"})
+	path, format := resolveTaskFileFromArgs("", []string{"docket", "apply", "--tasks", "custom.json"})
 	if path != "custom.json" {
 		t.Errorf("path = %q, want custom.json", path)
 	}
@@ -581,7 +571,7 @@ func TestResolveTaskFileFromArgsUsesExplicitFlag(t *testing.T) {
 		t.Errorf("format = %q, want json5", format)
 	}
 
-	path, format = resolveTaskFileFromArgs([]string{"docket", "apply", "--tasks=other.yml"})
+	path, format = resolveTaskFileFromArgs("", []string{"docket", "apply", "--tasks=other.yml"})
 	if path != "other.yml" {
 		t.Errorf("path = %q, want other.yml", path)
 	}
@@ -614,19 +604,17 @@ func TestResolveTaskFileFromArgsStdin(t *testing.T) {
 		t.Fatalf("seed tasks.yml: %v", err)
 	}
 
-	withCwd(t, dir, func() {
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				path, format := resolveTaskFileFromArgs(tt.argv)
-				if path != taskFileStdin {
-					t.Errorf("path = %q, want %q", path, taskFileStdin)
-				}
-				if format != "" {
-					t.Errorf("format = %q, want empty so the caller sniffs stdin", format)
-				}
-			})
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, format := resolveTaskFileFromArgs("", tt.argv)
+			if path != taskFileStdin {
+				t.Errorf("path = %q, want %q", path, taskFileStdin)
+			}
+			if format != "" {
+				t.Errorf("format = %q, want empty so the caller sniffs stdin", format)
+			}
+		})
+	}
 }
 
 // TestResolveTaskFileFromArgsStdinNotAFlagValue: a "-" that is the value
@@ -641,7 +629,7 @@ func TestResolveTaskFileFromArgsStdinNotAFlagValue(t *testing.T) {
 
 	for _, flagName := range []string{"--play", "--vars-file", "--host", "--start-at-task", "--tasks-format"} {
 		t.Run(flagName, func(t *testing.T) {
-			path, _ := resolveTaskFileFromArgs([]string{"docket", "apply", flagName, "-", recipe})
+			path, _ := resolveTaskFileFromArgs("", []string{"docket", "apply", flagName, "-", recipe})
 			if path != recipe {
 				t.Errorf("path = %q, want %q (the %s value must not be read as the recipe)", path, recipe, flagName)
 			}
@@ -689,23 +677,27 @@ func TestTaskFileAutocompleteMatchesRecipeExtensions(t *testing.T) {
 		t.Fatalf("mkdir sub: %v", err)
 	}
 
-	withCwd(t, dir, func() {
-		counts := map[string]int{}
-		for _, match := range taskFileAutocomplete().Predict(complete.Args{Last: ""}) {
-			counts[match]++
+	// Driven the way a shell drives it - with the directory already typed -
+	// rather than by moving the process into it.
+	// Driven the way a shell drives it - with the directory already typed -
+	// rather than by moving the process into it. The prefix is trimmed rather
+	// than taking the base name, so a directory keeps its trailing separator.
+	prefix := dir + string(filepath.Separator)
+	counts := map[string]int{}
+	for _, match := range taskFileAutocomplete().Predict(complete.Args{Last: prefix}) {
+		counts[strings.TrimPrefix(match, prefix)]++
+	}
+	for _, name := range recipes {
+		if counts[name] == 0 {
+			t.Errorf("expected %q to be offered, got %v", name, counts)
 		}
-		for _, name := range recipes {
-			if counts[name] == 0 {
-				t.Errorf("expected %q to be offered, got %v", name, counts)
-			}
-		}
-		if counts["notes.txt"] != 0 {
-			t.Errorf("non-recipe notes.txt must not be offered, got %v", counts)
-		}
-		if counts["sub/"] != 1 {
-			t.Errorf("directory sub/ should be offered exactly once, got %d (%v)", counts["sub/"], counts)
-		}
-	})
+	}
+	if counts["notes.txt"] != 0 {
+		t.Errorf("non-recipe notes.txt must not be offered, got %v", counts)
+	}
+	if counts["sub/"] != 1 {
+		t.Errorf("directory sub/ should be offered exactly once, got %d (%v)", counts["sub/"], counts)
+	}
 }
 
 // TestPredictFilesByExtension proves the completion mechanism is generic and
@@ -718,21 +710,20 @@ func TestPredictFilesByExtension(t *testing.T) {
 		}
 	}
 
-	withCwd(t, dir, func() {
-		got := map[string]bool{}
-		for _, match := range predictFilesByExtension([]string{"md", "txt"}).Predict(complete.Args{Last: ""}) {
-			got[match] = true
-		}
-		if !got["readme.md"] {
-			t.Errorf("expected readme.md to be offered, got %v", got)
-		}
-		if !got["todo.txt"] {
-			t.Errorf("expected todo.txt to be offered, got %v", got)
-		}
-		if got["ignore.yml"] {
-			t.Errorf("ignore.yml must not be offered for extensions {md,txt}, got %v", got)
-		}
-	})
+	prefix := dir + string(filepath.Separator)
+	got := map[string]bool{}
+	for _, match := range predictFilesByExtension([]string{"md", "txt"}).Predict(complete.Args{Last: prefix}) {
+		got[strings.TrimPrefix(match, prefix)] = true
+	}
+	if !got["readme.md"] {
+		t.Errorf("expected readme.md to be offered, got %v", got)
+	}
+	if !got["todo.txt"] {
+		t.Errorf("expected todo.txt to be offered, got %v", got)
+	}
+	if got["ignore.yml"] {
+		t.Errorf("ignore.yml must not be offered for extensions {md,txt}, got %v", got)
+	}
 }
 
 func TestHasTaskFileExtension(t *testing.T) {
@@ -748,20 +739,4 @@ func TestHasTaskFileExtension(t *testing.T) {
 			t.Errorf("hasTaskFileExtension(%q) = true, want false", p)
 		}
 	}
-}
-
-// withCwd chdirs to dir for the duration of body and restores the
-// original cwd afterwards. Centralised so the resolveTaskFilePath
-// tests do not each handle the t.Cleanup dance.
-func withCwd(t *testing.T, dir string, body func()) {
-	t.Helper()
-	prev, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir %s: %v", dir, err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(prev) })
-	body()
 }

--- a/commands/task_file_url_test.go
+++ b/commands/task_file_url_test.go
@@ -30,9 +30,9 @@ func TestReadTaskFileDataFetchesURL(t *testing.T) {
 	const recipe = "---\n- tasks:\n    - name: x\n      dokku_app: { app: demo }\n"
 	srv := serveRecipe(t, recipe)
 
-	data, err := readTaskFileData(srv.URL + "/tasks.yml")
+	data, err := readTaskFileData(srv.URL+"/tasks.yml", newStdinRecipeSource(nil))
 	if err != nil {
-		t.Fatalf("readTaskFileData(url) error: %v", err)
+		t.Fatalf("readTaskFileData(url, newStdinRecipeSource(nil)) error: %v", err)
 	}
 	if string(data) != recipe {
 		t.Errorf("fetched body = %q, want %q", string(data), recipe)
@@ -48,7 +48,7 @@ func TestReadTaskFileDataURLNon2xx(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	url := srv.URL + "/missing.yml"
-	_, err := readTaskFileData(url)
+	_, err := readTaskFileData(url, newStdinRecipeSource(nil))
 	if err == nil {
 		t.Fatal("expected an error for a 404 response")
 	}
@@ -68,9 +68,9 @@ func TestReadTaskFileDataLocalFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	data, err := readTaskFileData(path)
+	data, err := readTaskFileData(path, newStdinRecipeSource(nil))
 	if err != nil {
-		t.Fatalf("readTaskFileData(path) error: %v", err)
+		t.Fatalf("readTaskFileData(path, newStdinRecipeSource(nil)) error: %v", err)
 	}
 	if string(data) != body {
 		t.Errorf("read body = %q, want %q", string(data), body)
@@ -80,7 +80,7 @@ func TestReadTaskFileDataLocalFile(t *testing.T) {
 // TestReadTaskFileDataLocalMissing: a missing local path surfaces the
 // familiar os.ReadFile error (not a URL fetch error).
 func TestReadTaskFileDataLocalMissing(t *testing.T) {
-	_, err := readTaskFileData(filepath.Join(t.TempDir(), "nope.yml"))
+	_, err := readTaskFileData(filepath.Join(t.TempDir(), "nope.yml"), newStdinRecipeSource(nil))
 	if err == nil {
 		t.Fatal("expected an error for a missing local file")
 	}

--- a/commands/task_file_url_test.go
+++ b/commands/task_file_url_test.go
@@ -30,7 +30,7 @@ func TestReadTaskFileDataFetchesURL(t *testing.T) {
 	const recipe = "---\n- tasks:\n    - name: x\n      dokku_app: { app: demo }\n"
 	srv := serveRecipe(t, recipe)
 
-	data, err := readTaskFileData(srv.URL+"/tasks.yml", newStdinRecipeSource(nil))
+	data, err := readTaskFileData("", srv.URL+"/tasks.yml", newStdinRecipeSource(nil))
 	if err != nil {
 		t.Fatalf("readTaskFileData(url, newStdinRecipeSource(nil)) error: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestReadTaskFileDataURLNon2xx(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	url := srv.URL + "/missing.yml"
-	_, err := readTaskFileData(url, newStdinRecipeSource(nil))
+	_, err := readTaskFileData("", url, newStdinRecipeSource(nil))
 	if err == nil {
 		t.Fatal("expected an error for a 404 response")
 	}
@@ -68,7 +68,7 @@ func TestReadTaskFileDataLocalFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	data, err := readTaskFileData(path, newStdinRecipeSource(nil))
+	data, err := readTaskFileData("", path, newStdinRecipeSource(nil))
 	if err != nil {
 		t.Fatalf("readTaskFileData(path, newStdinRecipeSource(nil)) error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestReadTaskFileDataLocalFile(t *testing.T) {
 // TestReadTaskFileDataLocalMissing: a missing local path surfaces the
 // familiar os.ReadFile error (not a URL fetch error).
 func TestReadTaskFileDataLocalMissing(t *testing.T) {
-	_, err := readTaskFileData(filepath.Join(t.TempDir(), "nope.yml"), newStdinRecipeSource(nil))
+	_, err := readTaskFileData("", filepath.Join(t.TempDir(), "nope.yml"), newStdinRecipeSource(nil))
 	if err == nil {
 		t.Fatal("expected an error for a missing local file")
 	}

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -21,6 +21,16 @@ import (
 type ValidateCommand struct {
 	command.Meta
 
+	// BaseDir is the directory relative paths resolve against - the recipe
+	// probed when --tasks is absent, and any output written to a relative
+	// path. Populated from main.go; empty means the process working
+	// directory, which is what it always was.
+	//
+	// It exists so a test can point a command at a temp directory instead of
+	// chdir'ing the whole process, which no test can do while another runs
+	// beside it.
+	BaseDir string
+
 	// Stdin is where a `--tasks -` recipe is read from. Populated from
 	// main.go; nil reads the process's standard input. A test hands over its
 	// own pipe instead of swapping os.Stdin, which no two tests can do at
@@ -107,7 +117,7 @@ func (c *ValidateCommand) FlagSet() *flag.FlagSet {
 	// validate is offline by contract, so its recipe read never fetches
 	// a URL - unlike apply and plan, its --tasks help has never
 	// advertised one.
-	data, format, _ := preloadRecipeForFlags(c.argv(), false, c.stdinSource())
+	data, format, _ := preloadRecipeForFlags(c.baseDir(), c.argv(), false, c.stdinSource())
 	if data == nil {
 		return f
 	}
@@ -203,7 +213,7 @@ func (c *ValidateCommand) Run(args []string) int {
 		return 1
 	}
 
-	recipe, err := loadRecipe(taskFile, formatOverride, false, nil, "", c.stdinSource())
+	recipe, err := loadRecipe(c.baseDir(), taskFile, formatOverride, false, nil, "", c.stdinSource())
 	if err != nil {
 		if c.json {
 			c.emitJSONProblem(tasks.Problem{
@@ -382,3 +392,6 @@ func (c *ValidateCommand) stdinSource() *stdinRecipeSource {
 	}
 	return c.stdin
 }
+
+// baseDir returns the directory this command resolves relative paths against.
+func (c *ValidateCommand) baseDir() string { return c.BaseDir }

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -19,6 +20,21 @@ import (
 // docket recipe without contacting a Dokku server.
 type ValidateCommand struct {
 	command.Meta
+
+	// Stdin is where a `--tasks -` recipe is read from. Populated from
+	// main.go; nil reads the process's standard input. A test hands over its
+	// own pipe instead of swapping os.Stdin, which no two tests can do at
+	// once.
+	Stdin io.Reader
+
+	stdin *stdinRecipeSource
+
+	// Argv is the process argv this command resolves its --tasks and
+	// --tasks-format from, before pflag has parsed anything. Populated from
+	// main.go; nil falls back to os.Args, which is what a command built
+	// directly gets. It exists so a test can hand the command its own argv
+	// instead of assigning to the process global and putting it back.
+	Argv []string
 
 	// masker holds the sensitive input values this run must not echo. Set in
 	// Run before any problem is rendered; the renderers below are methods so
@@ -91,7 +107,7 @@ func (c *ValidateCommand) FlagSet() *flag.FlagSet {
 	// validate is offline by contract, so its recipe read never fetches
 	// a URL - unlike apply and plan, its --tasks help has never
 	// advertised one.
-	data, format, _ := preloadRecipeForFlags(os.Args, false)
+	data, format, _ := preloadRecipeForFlags(c.argv(), false, c.stdinSource())
 	if data == nil {
 		return f
 	}
@@ -187,7 +203,7 @@ func (c *ValidateCommand) Run(args []string) int {
 		return 1
 	}
 
-	recipe, err := loadRecipe(taskFile, formatOverride, false, nil, "")
+	recipe, err := loadRecipe(taskFile, formatOverride, false, nil, "", c.stdinSource())
 	if err != nil {
 		if c.json {
 			c.emitJSONProblem(tasks.Problem{
@@ -351,4 +367,18 @@ func formatProblem(p tasks.Problem) string {
 		fmt.Fprintf(&b, " - %s", p.Hint)
 	}
 	return b.String()
+}
+
+// argv returns the argv this command resolves its pre-parse flags from.
+func (c *ValidateCommand) argv() []string { return commandArgv(c.Argv) }
+
+// stdinSource returns this command's memoized standard-input reader, creating
+// it on first use. One per command: the recipe is read more than once per
+// invocation (FlagSet, Run, and Help on a flag error) but standard input only
+// yields its bytes once.
+func (c *ValidateCommand) stdinSource() *stdinRecipeSource {
+	if c.stdin == nil {
+		c.stdin = newStdinRecipeSource(c.Stdin)
+	}
+	return c.stdin
 }

--- a/commands/validate_input_declaration_test.go
+++ b/commands/validate_input_declaration_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -21,11 +20,9 @@ import (
 // rather than from the parsed flags, so the argv is staged first.
 func runValidate(t *testing.T, path string, args ...string) (string, string, int) {
 	t.Helper()
-	origArgs := os.Args
-	os.Args = []string{"docket-test", "validate", "--tasks", path}
-	t.Cleanup(func() { os.Args = origArgs })
+	argv := []string{"docket-test", "validate", "--tasks", path}
 
-	c := &ValidateCommand{Meta: command.Meta{Ui: cli.NewMockUi()}}
+	c := &ValidateCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Argv: argv}
 	all := append([]string{"--tasks", path}, args...)
 	exit := c.Run(all)
 	ui := c.Ui.(*cli.MockUi)

--- a/commands/validate_test.go
+++ b/commands/validate_test.go
@@ -216,11 +216,10 @@ func TestValidateJSONEmitsNothingOnSuccess(t *testing.T) {
 // to stderr, so a --json consumer reading stdout is unaffected.
 func TestValidateWarnsOnAmbiguousDefaultProbe(t *testing.T) {
 	dir := t.TempDir()
-	t.Chdir(dir)
 	writeAmbiguousRecipes(t, dir)
 
 	ui := cli.NewMockUi()
-	c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+	c := &ValidateCommand{Meta: command.Meta{Ui: ui}, BaseDir: dir}
 	if exit := c.Run(nil); exit != 0 {
 		t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 	}
@@ -242,11 +241,10 @@ func TestValidateWarnsOnAmbiguousDefaultProbe(t *testing.T) {
 func TestValidateDoesNotWarnWhenTasksIsExplicit(t *testing.T) {
 	t.Run("explicit --tasks", func(t *testing.T) {
 		dir := t.TempDir()
-		t.Chdir(dir)
 		writeAmbiguousRecipes(t, dir)
 
 		ui := cli.NewMockUi()
-		c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+		c := &ValidateCommand{Meta: command.Meta{Ui: ui}, BaseDir: dir}
 		if exit := c.Run([]string{"--tasks", "tasks.json"}); exit != 0 {
 			t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 		}
@@ -257,13 +255,12 @@ func TestValidateDoesNotWarnWhenTasksIsExplicit(t *testing.T) {
 
 	t.Run("single candidate", func(t *testing.T) {
 		dir := t.TempDir()
-		t.Chdir(dir)
 		if err := os.WriteFile(filepath.Join(dir, "tasks.yml"), []byte(stdinYAMLRecipe), 0o644); err != nil {
 			t.Fatalf("write tasks.yml: %v", err)
 		}
 
 		ui := cli.NewMockUi()
-		c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+		c := &ValidateCommand{Meta: command.Meta{Ui: ui}, BaseDir: dir}
 		if exit := c.Run(nil); exit != 0 {
 			t.Fatalf("exit = %d, want 0: %s", exit, ui.ErrorWriter.String())
 		}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func Run(args []string) int {
 func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFactory {
 	return map[string]cli.CommandFactory{
 		"apply": func() (cli.Command, error) {
-			return &commands.ApplyCommand{Meta: meta, Ctx: ctx}, nil
+			return &commands.ApplyCommand{Meta: meta, Ctx: ctx, Argv: os.Args}, nil
 		},
 		"export": func() (cli.Command, error) {
 			return &commands.ExportCommand{Meta: meta, Ctx: ctx}, nil
@@ -65,13 +65,13 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 			return &commands.InitCommand{Meta: meta}, nil
 		},
 		"plan": func() (cli.Command, error) {
-			return &commands.PlanCommand{Meta: meta, Ctx: ctx}, nil
+			return &commands.PlanCommand{Meta: meta, Ctx: ctx, Argv: os.Args}, nil
 		},
 		"schema": func() (cli.Command, error) {
 			return &commands.SchemaCommand{Meta: meta}, nil
 		},
 		"validate": func() (cli.Command, error) {
-			return &commands.ValidateCommand{Meta: meta}, nil
+			return &commands.ValidateCommand{Meta: meta, Argv: os.Args}, nil
 		},
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{Meta: meta}, nil

--- a/main.go
+++ b/main.go
@@ -56,19 +56,19 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 			return &commands.ApplyCommand{Meta: meta, Ctx: ctx, Argv: os.Args}, nil
 		},
 		"export": func() (cli.Command, error) {
-			return &commands.ExportCommand{Meta: meta, Ctx: ctx}, nil
+			return &commands.ExportCommand{Meta: meta, Ctx: ctx, Stdout: os.Stdout}, nil
 		},
 		"fmt": func() (cli.Command, error) {
-			return &commands.FmtCommand{Meta: meta}, nil
+			return &commands.FmtCommand{Meta: meta, Stdout: os.Stdout}, nil
 		},
 		"init": func() (cli.Command, error) {
-			return &commands.InitCommand{Meta: meta}, nil
+			return &commands.InitCommand{Meta: meta, Stdout: os.Stdout}, nil
 		},
 		"plan": func() (cli.Command, error) {
 			return &commands.PlanCommand{Meta: meta, Ctx: ctx, Argv: os.Args}, nil
 		},
 		"schema": func() (cli.Command, error) {
-			return &commands.SchemaCommand{Meta: meta}, nil
+			return &commands.SchemaCommand{Meta: meta, Stdout: os.Stdout}, nil
 		},
 		"validate": func() (cli.Command, error) {
 			return &commands.ValidateCommand{Meta: meta, Argv: os.Args}, nil


### PR DESCRIPTION
Every command resolved its flags, its recipe, its output paths and its streamed bytes through process state - `os.Args`, the working directory, `os.Stdin`, `os.Stdout` - which is state no two tests can hold at once. A test exercising any of it had to assign to a global and put it back, and one that needed a recipe on disk had to move the whole process into a temp directory.

Each becomes a field the command is handed, nil-defaulting to the process value so nothing changes for the CLI. `Argv` is read before pflag parses, to pre-register a recipe's inputs as flags. `BaseDir` is what relative paths resolve against - the recipe probed when `--tasks` is absent, and any output written to a relative path. `Stdin` is where a `--tasks -` recipe comes from, and `Stdout` is where a streamed recipe, diff or catalog goes; those writes bypass the Ui on purpose, since it is wrapped in a log formatter.

`main.go` is now the one place process state enters. The behaviour is unchanged: an unset field still means "the process's", which is what `docket init` in a project folder or `docket validate` beside a `tasks.yml` has always relied on.

Three seams moved with them. The stdin memo was a package variable with a test-only reset hook; it is per-command state now, which is what it always described - the recipe is read more than once per invocation but standard input only yields its bytes once. `chmodVarsFile` was a swappable package variable; it is a field on the export command, its only caller. And `noColorDefault` asked isatty about `os.Stdout` directly; it takes the writer, and a writer that is not a file is not a terminal.

Every `t.Chdir` and `os.Chdir` in the package is gone - 34 of them across six files - along with the `withCwd` helper, whose restore was registered with `t.Cleanup` rather than deferred, so the directory change outlived the body it was meant to wrap. The two autocomplete tests that genuinely needed a directory now drive the predictor the way a shell does, with the directory already typed, rather than moving the process into it.

Refs #505.

Does not on its own make `commands/` parallel - #506 and the `SetExecRunner` and `color.NoColor` items listed on #502 remain - but it removes the one class of blocker that had to land as a single sweep, since a serial test's chdir moves the working directory out from under any parallel test running beside it.
