### PR TITLE
test: give each test its own stub fixtures

### DIFF
--- a/commands/apply_envelope_test.go
+++ b/commands/apply_envelope_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ func runApply(t *testing.T, path string, args ...string) (string, string, int) {
 	t.Helper()
 	argv := []string{"docket-test", "apply", "--tasks", path}
 
-	c := &ApplyCommand{Argv: argv}
+	c := &ApplyCommand{Argv: argv, Ctx: withStubFixtures(context.Background(), stubsFor(t))}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
 	all := append([]string{"--tasks", path}, args...)
 	exit := c.Run(all)
@@ -44,9 +45,8 @@ func writeTasksFile(t *testing.T, body string) string {
 // `registered.first.Changed`. The follow-up should run when first
 // changed and skip otherwise.
 func TestApplyRegisterMakesPriorResultAvailable(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: false})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -73,9 +73,8 @@ func TestApplyRegisterMakesPriorResultAvailable(t *testing.T) {
 // not change, the follow-up's when: predicate is falsy and the task
 // renders as [skipped].
 func TestApplyRegisterFalseSkipsFollowUp(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false})
-	stubSet("b", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: false})
+	stubSet(t, "b", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -98,8 +97,7 @@ func TestApplyRegisterFalseSkipsFollowUp(t *testing.T) {
 // TestApplyChangedWhenFalseFlipsToOK: changed_when: false flips a
 // self-reported-changed task to [ok].
 func TestApplyChangedWhenFalseFlipsToOK(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -122,8 +120,7 @@ func TestApplyChangedWhenFalseFlipsToOK(t *testing.T) {
 // TestApplyChangedWhenTrueFlipsToChanged: changed_when: true converts
 // an in-sync task to [changed].
 func TestApplyChangedWhenTrueFlipsToChanged(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: false})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -143,8 +140,7 @@ func TestApplyChangedWhenTrueFlipsToChanged(t *testing.T) {
 // TestApplyFailedWhenSuppressesExpectedError: failed_when matching the
 // stderr pattern clears the error, exit is 0.
 func TestApplyFailedWhenSuppressesExpectedError(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{
+	stubSet(t, "a", StubFixture{
 		ExecuteError: stubExecError("App nonexistent does not exist"),
 		Stderr:       "App nonexistent does not exist",
 	})
@@ -167,8 +163,7 @@ func TestApplyFailedWhenSuppressesExpectedError(t *testing.T) {
 // TestApplyFailedWhenTrueMarksSuccessAsError: failed_when: true on a
 // successful task flips it to [error] and the run aborts (exit 1).
 func TestApplyFailedWhenTrueMarksSuccessAsError(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: false})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -190,8 +185,7 @@ func TestApplyFailedWhenTrueMarksSuccessAsError(t *testing.T) {
 // and aborts the run with a non-zero exit. This is the baseline the
 // group path is expected to match (see TestApplyGroupBlockStateMismatchFailsGroup).
 func TestApplyLeafStateMismatchFailsRun(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{MismatchState: true})
+	stubSet(t, "a", StubFixture{MismatchState: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -211,8 +205,7 @@ func TestApplyLeafStateMismatchFailsRun(t *testing.T) {
 // also normalizes State to DesiredState so the state-mismatch branch
 // does not re-flag the task.
 func TestApplyFailedWhenFalseClearsStateMismatch(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{MismatchState: true, Changed: true})
+	stubSet(t, "a", StubFixture{MismatchState: true, Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -233,9 +226,8 @@ func TestApplyFailedWhenFalseClearsStateMismatch(t *testing.T) {
 // the run going past an erroring task. The error event is still
 // emitted but the second task runs and the exit code is 0.
 func TestApplyIgnoreErrorsContinuesPastFailure(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{ExecuteError: errors.New("boom")})
-	stubSet("b", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{ExecuteError: errors.New("boom")})
+	stubSet(t, "b", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -261,8 +253,7 @@ func TestApplyIgnoreErrorsContinuesPastFailure(t *testing.T) {
 // successful task is a no-op; the task still renders as [ok] /
 // [changed] and the run exits 0.
 func TestApplyIgnoreErrorsNoOpOnSuccess(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -286,9 +277,8 @@ func TestApplyIgnoreErrorsNoOpOnSuccess(t *testing.T) {
 // accumulates per-iteration states into Results, and the aggregate
 // Changed reflects "any iteration changed."
 func TestApplyLoopRegisterAccumulatesResults(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false})
-	stubSet("b", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: false})
+	stubSet(t, "b", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:

--- a/commands/apply_exitcode_test.go
+++ b/commands/apply_exitcode_test.go
@@ -15,8 +15,7 @@ import (
 // TestApplyDetailedExitCodeChanged: a task that changes state exits 2
 // with the flag and 0 without it.
 func TestApplyDetailedExitCodeChanged(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -34,8 +33,7 @@ func TestApplyDetailedExitCodeChanged(t *testing.T) {
 
 // TestApplyDetailedExitCodeUnchanged: an in-sync task exits 0 either way.
 func TestApplyDetailedExitCodeUnchanged(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: false})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -55,9 +53,8 @@ func TestApplyDetailedExitCodeUnchanged(t *testing.T) {
 // a later task errored, the exit code is 1, not 2. A wrapper must never
 // read a failure as "changed".
 func TestApplyDetailedExitCodeErrorsWinOverChanges(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{ExecuteError: errors.New("boom")})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{ExecuteError: errors.New("boom")})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -79,9 +76,8 @@ func TestApplyDetailedExitCodeErrorsWinOverChanges(t *testing.T) {
 // swallowed by ignore_errors is not an error for exit-code purposes, so
 // a change elsewhere in the run still surfaces as 2.
 func TestApplyDetailedExitCodeIgnoredErrorStillCountsChanges(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{ExecuteError: errors.New("boom")})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{ExecuteError: errors.New("boom")})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -100,8 +96,7 @@ func TestApplyDetailedExitCodeIgnoredErrorStillCountsChanges(t *testing.T) {
 // TestApplyDetailedExitCodeListTasksUnaffected: --list-tasks returns
 // before any task runs, so it cannot report a change.
 func TestApplyDetailedExitCodeListTasksUnaffected(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:

--- a/commands/cancellation_test.go
+++ b/commands/cancellation_test.go
@@ -22,10 +22,10 @@ func runWithCtx(t *testing.T, ctx context.Context, sub, path string, args ...str
 	var exit int
 	switch sub {
 	case "apply":
-		c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
+		c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: withStubFixtures(ctx, stubsFor(t))}
 		exit = c.Run(all)
 	case "plan":
-		c := &PlanCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
+		c := &PlanCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: withStubFixtures(ctx, stubsFor(t))}
 		exit = c.Run(all)
 	default:
 		t.Fatalf("unknown subcommand %q", sub)
@@ -47,14 +47,13 @@ const twoTaskRecipe = `---
 // interrupt could only kill the child process of whichever task was in flight
 // and the loop marched on to the next one.
 func TestApplyStopsAtCancelledContext(t *testing.T) {
-	defer stubReset()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	secondRan := false
-	stubSet("first", StubFixture{Changed: true, Hook: cancel})
-	stubSet("second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
+	stubSet(t, "first", StubFixture{Changed: true, Hook: cancel})
+	stubSet(t, "second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
 
 	path := writeTasksFile(t, twoTaskRecipe)
 	stdout, stderr, exit := runWithCtx(t, ctx, "apply", path)
@@ -76,14 +75,13 @@ func TestApplyStopsAtCancelledContext(t *testing.T) {
 // TestPlanStopsAtCancelledContext is the plan-side mirror. plan probes the
 // server for every task, so it needs the same escape hatch as apply.
 func TestPlanStopsAtCancelledContext(t *testing.T) {
-	defer stubReset()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	secondRan := false
-	stubSet("first", StubFixture{Changed: true, Hook: cancel})
-	stubSet("second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
+	stubSet(t, "first", StubFixture{Changed: true, Hook: cancel})
+	stubSet(t, "second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
 
 	path := writeTasksFile(t, twoTaskRecipe)
 	_, stderr, exit := runWithCtx(t, ctx, "plan", path)
@@ -104,13 +102,12 @@ func TestPlanStopsAtCancelledContext(t *testing.T) {
 // interrupt. A wrapper reads 2 as "the run completed and changed something";
 // an interrupted run completed nothing.
 func TestApplyCancelledRunNeverReportsChanged(t *testing.T) {
-	defer stubReset()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	stubSet("first", StubFixture{Changed: true, Hook: cancel})
-	stubSet("second", StubFixture{Changed: true})
+	stubSet(t, "first", StubFixture{Changed: true, Hook: cancel})
+	stubSet(t, "second", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, twoTaskRecipe)
 	if _, _, exit := runWithCtx(t, ctx, "apply", path, "--detailed-exitcode"); exit != 1 {
@@ -124,17 +121,16 @@ func TestApplyCancelledRunNeverReportsChanged(t *testing.T) {
 // through the error path and never reaches its own cancellation check. Asking
 // about the context once at the exit is what keeps the report honest.
 func TestApplyReportsCancellationWhenTheInterruptedTaskAlsoFails(t *testing.T) {
-	defer stubReset()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	secondRan := false
-	stubSet("first", StubFixture{
+	stubSet(t, "first", StubFixture{
 		ExecuteError: errors.New("interrupted"),
 		Hook:         cancel,
 	})
-	stubSet("second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
+	stubSet(t, "second", StubFixture{Changed: true, Hook: func() { secondRan = true }})
 
 	path := writeTasksFile(t, twoTaskRecipe)
 	_, stderr, exit := runWithCtx(t, ctx, "apply", path)
@@ -156,14 +152,13 @@ func TestApplyReportsCancellationWhenTheInterruptedTaskAlsoFails(t *testing.T) {
 // need interrupting again. This is the behaviour the bats interrupt test
 // exercises end to end against a host that never answers.
 func TestApplyCancellationStopsLaterPlays(t *testing.T) {
-	defer stubReset()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	secondPlayRan := false
-	stubSet("first", StubFixture{ExecuteError: errors.New("interrupted"), Hook: cancel})
-	stubSet("second", StubFixture{Changed: true, Hook: func() { secondPlayRan = true }})
+	stubSet(t, "first", StubFixture{ExecuteError: errors.New("interrupted"), Hook: cancel})
+	stubSet(t, "second", StubFixture{Changed: true, Hook: func() { secondPlayRan = true }})
 
 	path := writeTasksFile(t, `---
 - name: one
@@ -195,9 +190,8 @@ func TestApplyCancellationStopsLaterPlays(t *testing.T) {
 // bare struct literal, as most of these tests and any embedding caller that
 // does not set Ctx do, still runs instead of panicking on a nil context.
 func TestApplyWithoutCtxUsesBackground(t *testing.T) {
-	defer stubReset()
-	stubSet("first", StubFixture{Changed: true})
-	stubSet("second", StubFixture{Changed: true})
+	stubSet(t, "first", StubFixture{Changed: true})
+	stubSet(t, "second", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, twoTaskRecipe)
 	if _, stderr, exit := runApply(t, path); exit != 0 {

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -10,9 +10,8 @@ import (
 // children and no rescue/always reports OK at the group level and
 // each child renders its own line.
 func TestApplyGroupAllChildrenSucceed(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: false})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -41,9 +40,8 @@ func TestApplyGroupAllChildrenSucceed(t *testing.T) {
 // TestApplyGroupBlockErrorTriggersRescue: the first block child errors,
 // rescue runs and clears the failure, group reports OK.
 func TestApplyGroupBlockErrorTriggersRescue(t *testing.T) {
-	defer stubReset()
-	stubSet("bad", StubFixture{ExecuteError: errors.New("block boom")})
-	stubSet("rescue", StubFixture{Changed: true})
+	stubSet(t, "bad", StubFixture{ExecuteError: errors.New("block boom")})
+	stubSet(t, "rescue", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -76,9 +74,8 @@ func TestApplyGroupBlockErrorTriggersRescue(t *testing.T) {
 // TestApplyGroupRescueFailureFailsGroup: when rescue itself errors,
 // the group's verdict is failed and the run exits non-zero.
 func TestApplyGroupRescueFailureFailsGroup(t *testing.T) {
-	defer stubReset()
-	stubSet("blockboom", StubFixture{ExecuteError: errors.New("block boom")})
-	stubSet("rescueboom", StubFixture{ExecuteError: errors.New("rescue boom")})
+	stubSet(t, "blockboom", StubFixture{ExecuteError: errors.New("block boom")})
+	stubSet(t, "rescueboom", StubFixture{ExecuteError: errors.New("rescue boom")})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -97,9 +94,8 @@ func TestApplyGroupRescueFailureFailsGroup(t *testing.T) {
 // TestApplyGroupAlwaysRunsAfterSuccessAndRescue: always children run
 // regardless of block success or rescue failure paths.
 func TestApplyGroupAlwaysRunsAfterSuccess(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("marker", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "marker", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -120,10 +116,9 @@ func TestApplyGroupAlwaysRunsAfterSuccess(t *testing.T) {
 }
 
 func TestApplyGroupAlwaysRunsAfterRescue(t *testing.T) {
-	defer stubReset()
-	stubSet("blockboom", StubFixture{ExecuteError: errors.New("block boom")})
-	stubSet("rescue", StubFixture{Changed: true})
-	stubSet("marker", StubFixture{Changed: true})
+	stubSet(t, "blockboom", StubFixture{ExecuteError: errors.New("block boom")})
+	stubSet(t, "rescue", StubFixture{Changed: true})
+	stubSet(t, "marker", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -149,10 +144,9 @@ func TestApplyGroupAlwaysRunsAfterRescue(t *testing.T) {
 // #210 rule: ignore_errors swallows a child's error and does NOT
 // trigger rescue. The next block child still runs; rescue stays cold.
 func TestApplyGroupIgnoreErrorsOnChildDoesNotTriggerRescue(t *testing.T) {
-	defer stubReset()
-	stubSet("bad", StubFixture{ExecuteError: errors.New("ignored boom")})
-	stubSet("after", StubFixture{Changed: true})
-	stubSet("rescue", StubFixture{Changed: true})
+	stubSet(t, "bad", StubFixture{ExecuteError: errors.New("ignored boom")})
+	stubSet(t, "after", StubFixture{Changed: true})
+	stubSet(t, "rescue", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -184,9 +178,8 @@ func TestApplyGroupIgnoreErrorsOnChildDoesNotTriggerRescue(t *testing.T) {
 // should run because the predicate sees the failing block child's
 // state.
 func TestApplyGroupFailedTaskBoundInRescue(t *testing.T) {
-	defer stubReset()
-	stubSet("bad", StubFixture{ExecuteError: errors.New("triggered boom")})
-	stubSet("cleanup", StubFixture{Changed: true})
+	stubSet(t, "bad", StubFixture{ExecuteError: errors.New("triggered boom")})
+	stubSet(t, "cleanup", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -210,8 +203,7 @@ func TestApplyGroupFailedTaskBoundInRescue(t *testing.T) {
 // TestApplyGroupIgnoreErrorsOnGroup: a residual error after rescue +
 // always is suppressed when the group itself carries ignore_errors.
 func TestApplyGroupIgnoreErrorsOnGroup(t *testing.T) {
-	defer stubReset()
-	stubSet("blockboom", StubFixture{ExecuteError: errors.New("block boom")})
+	stubSet(t, "blockboom", StubFixture{ExecuteError: errors.New("block boom")})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -230,9 +222,8 @@ func TestApplyGroupIgnoreErrorsOnGroup(t *testing.T) {
 // captures the synthesized post-override outcome and exposes it to a
 // later task's predicate.
 func TestApplyGroupRegisterSnapshotsAggregateState(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: false})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -259,9 +250,8 @@ func TestApplyGroupRegisterSnapshotsAggregateState(t *testing.T) {
 // TestApplyGroupNestedFailureReachesOuterRescue: an inner block's
 // error bubbles up and triggers the outer block's rescue.
 func TestApplyGroupNestedFailureReachesOuterRescue(t *testing.T) {
-	defer stubReset()
-	stubSet("inner-boom", StubFixture{ExecuteError: errors.New("inner boom")})
-	stubSet("outer-rescue", StubFixture{Changed: true})
+	stubSet(t, "inner-boom", StubFixture{ExecuteError: errors.New("inner boom")})
+	stubSet(t, "outer-rescue", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -289,9 +279,8 @@ func TestApplyGroupNestedFailureReachesOuterRescue(t *testing.T) {
 // abort the rest of the play, and exit non-zero -- matching the verdict
 // the identical task gets at the top level.
 func TestApplyGroupBlockStateMismatchFailsGroup(t *testing.T) {
-	defer stubReset()
-	stubSet("mismatch", StubFixture{MismatchState: true})
-	stubSet("after", StubFixture{Changed: true})
+	stubSet(t, "mismatch", StubFixture{MismatchState: true})
+	stubSet(t, "after", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -323,8 +312,7 @@ func TestApplyGroupBlockStateMismatchFailsGroup(t *testing.T) {
 // zero-value state (nil error, empty State/DesiredState). A rescue-less
 // group must still surface that as a failure rather than swallowing it.
 func TestApplyGroupBlockRuntimeFailedWhenErrorFailsGroup(t *testing.T) {
-	defer stubReset()
-	stubSet("ok", StubFixture{})
+	stubSet(t, "ok", StubFixture{})
 
 	path := writeTasksFile(t, `---
 - tasks:

--- a/commands/identity_address_quoting_masking_test.go
+++ b/commands/identity_address_quoting_masking_test.go
@@ -36,7 +36,6 @@ const quoteBearingSecret = `quo"tedzzz`
 const maskedStubAddress = `dokku_stub[key="***"]`
 
 func TestListTasksMasksQuotedIdentityValueInName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, quotedIdentityRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--list-tasks")
@@ -52,7 +51,6 @@ func TestListTasksMasksQuotedIdentityValueInName(t *testing.T) {
 }
 
 func TestListTasksJSONMasksQuotedIdentityValueInName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, quotedIdentityRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--list-tasks", "--json")
@@ -69,8 +67,7 @@ func TestListTasksJSONMasksQuotedIdentityValueInName(t *testing.T) {
 }
 
 func TestApplyMasksQuotedIdentityValueInName(t *testing.T) {
-	defer stubReset()
-	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	stubSet(t, quoteBearingSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, quotedIdentityRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret)
@@ -86,8 +83,7 @@ func TestApplyMasksQuotedIdentityValueInName(t *testing.T) {
 }
 
 func TestApplyJSONMasksQuotedIdentityValueInName(t *testing.T) {
-	defer stubReset()
-	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	stubSet(t, quoteBearingSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, quotedIdentityRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--json")
@@ -103,8 +99,7 @@ func TestApplyJSONMasksQuotedIdentityValueInName(t *testing.T) {
 }
 
 func TestPlanMasksQuotedIdentityValueInName(t *testing.T) {
-	defer stubReset()
-	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	stubSet(t, quoteBearingSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, quotedIdentityRecipe)
 
 	stdout, stderr, exit := runPlan(t, path, "--secret_value="+quoteBearingSecret)
@@ -120,8 +115,7 @@ func TestPlanMasksQuotedIdentityValueInName(t *testing.T) {
 }
 
 func TestPlanJSONMasksQuotedIdentityValueInName(t *testing.T) {
-	defer stubReset()
-	stubSet(quoteBearingSecret, StubFixture{Changed: true})
+	stubSet(t, quoteBearingSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, quotedIdentityRecipe)
 
 	stdout, stderr, exit := runPlan(t, path, "--secret_value="+quoteBearingSecret, "--json")
@@ -142,7 +136,6 @@ func TestPlanJSONMasksQuotedIdentityValueInName(t *testing.T) {
 // generated address already carries, so no registered spelling can match the
 // finished message. The hint masks each name before quoting it instead.
 func TestStartAtTaskHintMasksQuotedIdentityValueInName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, quotedIdentityRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+quoteBearingSecret, "--start-at-task", "nozzz")
@@ -165,7 +158,6 @@ func TestStartAtTaskHintMasksQuotedIdentityValueInName(t *testing.T) {
 // address cannot escape-and-mask at generation time, because the registry is
 // not populated yet.
 func TestListTasksMasksQuotedTaskDeclaredIdentityValue(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - dokku_config:
@@ -196,7 +188,6 @@ func TestListTasksMasksQuotedTaskDeclaredIdentityValue(t *testing.T) {
 // merely resemble a secret. `keepzzz` is not registered, so it prints in full
 // alongside the masked task.
 func TestListTasksLeavesUnquotedIdentityValuesAlone(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, required: true, sensitive: true }

--- a/commands/list_tasks_masking_test.go
+++ b/commands/list_tasks_masking_test.go
@@ -26,7 +26,6 @@ const listMasksIdentityRecipe = `---
 `
 
 func TestListTasksMasksSensitiveInputInGeneratedName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, listMasksIdentityRecipe)
 
 	stdout, _, exit := runApply(t, path, "--secret_value=identityzzz", "--list-tasks")
@@ -42,7 +41,6 @@ func TestListTasksMasksSensitiveInputInGeneratedName(t *testing.T) {
 }
 
 func TestListTasksJSONMasksSensitiveInputInGeneratedName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, listMasksIdentityRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value=identityzzz", "--list-tasks", "--json")
@@ -62,7 +60,6 @@ func TestListTasksJSONMasksSensitiveInputInGeneratedName(t *testing.T) {
 // same treatment as apply's - they are separate call sites for the same
 // renderer, and only apply's was covered above.
 func TestPlanListTasksMasksSensitiveInput(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, listMasksIdentityRecipe)
 
 	stdout, _, exit := runPlan(t, path, "--secret_value=identityzzz", "--list-tasks")
@@ -81,7 +78,6 @@ func TestPlanListTasksMasksSensitiveInput(t *testing.T) {
 // sigil-interpolates a secret: the rendered source is what the [skipped] line
 // and the `when` field carry.
 func TestListTasksMasksSensitiveInputInWhen(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, required: true, sensitive: true }
@@ -108,7 +104,6 @@ func TestListTasksMasksSensitiveInputInWhen(t *testing.T) {
 // play / when / reason fields are emitted by a different branch than the
 // per-task ones.
 func TestListTasksMasksSensitivePlayWhen(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - name: play {{ .secret_value }}
   inputs:
@@ -146,7 +141,6 @@ func TestListTasksMasksSensitivePlayWhen(t *testing.T) {
 // contributes: the `(item=<value>)` suffix on the name, and loop_item itself,
 // which is the one listing field that is not a string.
 func TestListTasksMasksSensitiveLoopItem(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, required: true, sensitive: true }
@@ -175,7 +169,6 @@ func TestListTasksMasksSensitiveLoopItem(t *testing.T) {
 // TestListTasksMasksSensitiveTags covers the tags array, which is rendered
 // from the same whole-file template pass as the rest of the recipe.
 func TestListTasksMasksSensitiveTags(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, required: true, sensitive: true }
@@ -215,7 +208,6 @@ func TestListTasksMasksSensitiveTags(t *testing.T) {
 // CollectPlaySensitiveValues. Fails if that call moves back below the
 // --list-tasks branch.
 func TestListTasksMasksTaskDeclaredSensitiveValue(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: configure
@@ -244,7 +236,6 @@ func TestListTasksMasksTaskDeclaredSensitiveValue(t *testing.T) {
 // and already calls MaskString, but before #455 the task-declared values were
 // not registered yet when it ran.
 func TestApplyStartAtTaskUnknownMasksTaskDeclaredSecret(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: configure taskdeclaredzzz
@@ -271,7 +262,6 @@ func TestApplyStartAtTaskUnknownMasksTaskDeclaredSecret(t *testing.T) {
 // its `| <source>` frame, so the formatted error echoes the recipe line - the
 // play name alone is not enough to mask.
 func TestListTasksMasksSensitiveInputInPlayWhenError(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - name: broken
   inputs:
@@ -314,7 +304,6 @@ func TestListTasksMasksSensitiveInputInPlayWhenError(t *testing.T) {
 // end: loop_item is the one listing field that is not a string, and a loop
 // over mappings puts a secret one level down from where MaskString reaches.
 func TestListTasksJSONMasksLoopItemStructure(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, required: true, sensitive: true }
@@ -349,7 +338,6 @@ func TestListTasksJSONMasksLoopItemStructure(t *testing.T) {
 //
 // The secret is chosen to be a substring of every decoration under test.
 func TestListTasksDoesNotMaskStructuralDecorations(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, required: true, sensitive: true }

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -11,7 +11,6 @@ import (
 // unset so a stray Execute() call would render as a [changed] line and
 // trip one of the assertions below.
 func TestApplyListTasksPrintsResolvedPlan(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: create api
@@ -45,7 +44,6 @@ func TestApplyListTasksPrintsResolvedPlan(t *testing.T) {
 // the loader produced `task #1 <hex>` and this display substituted the task
 // type plus one guessed field.
 func TestApplyListTasksUnnamedTasksShowResourceAddress(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - dokku_app: { app: docket-test-list-1 }
@@ -69,7 +67,6 @@ func TestApplyListTasksUnnamedTasksShowResourceAddress(t *testing.T) {
 // heuristic got wrong: it keyed on the first App-like field, so every phase
 // and option of one app's docker options collapsed onto the same label.
 func TestApplyListTasksDistinguishesSameAppTasks(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - dokku_docker_options: { app: api, phase: deploy, option: "--memory=512m" }
@@ -96,7 +93,6 @@ func TestApplyListTasksDistinguishesSameAppTasks(t *testing.T) {
 // things: `(never converges)` is total, `(partial probe)` converges for the
 // fields it does read. A task that probes everything it manages is unmarked.
 func TestApplyListTasksMarksProbeSupport(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: unprobeable
@@ -133,7 +129,6 @@ func TestApplyListTasksMarksProbeSupport(t *testing.T) {
 // listing should omit tasks the tag filter would drop, just like the
 // executor does.
 func TestApplyListTasksHonorsTags(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: api task
@@ -159,7 +154,6 @@ func TestApplyListTasksHonorsTags(t *testing.T) {
 // expanded in the listing - one line per iteration, with the iteration
 // suffix already rendered into the name.
 func TestApplyListTasksLoopExpansion(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: deploy
@@ -181,7 +175,6 @@ func TestApplyListTasksLoopExpansion(t *testing.T) {
 // envelopes whose static when: predicate evaluates false against the
 // inputs context.
 func TestApplyListTasksWhenFalseShowsSkipped(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: gated
@@ -202,7 +195,6 @@ func TestApplyListTasksWhenFalseShowsSkipped(t *testing.T) {
 // that depend on prior task state, so the line renders [unknown]
 // rather than [skipped].
 func TestApplyListTasksWhenRegisteredShowsUnknown(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: first
@@ -228,7 +220,6 @@ func TestApplyListTasksWhenRegisteredShowsUnknown(t *testing.T) {
 // `failed_task` only once a block child has failed. It renders
 // [unknown], not the [when?] that reports a valid recipe as broken.
 func TestApplyListTasksRescueWhenFailedTaskShowsUnknown(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: deploy
@@ -259,7 +250,6 @@ func TestApplyListTasksRescueWhenFailedTaskShowsUnknown(t *testing.T) {
 // run time exactly as it does here. That is a broken predicate, so it
 // renders [when?] and fails the listing.
 func TestApplyListTasksFailedTaskOutsideRescueShowsWhenError(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: misplaced
@@ -280,7 +270,6 @@ func TestApplyListTasksFailedTaskOutsideRescueShowsWhenError(t *testing.T) {
 // each child indented with the [block] / [rescue] / [always] phase
 // label.
 func TestApplyListTasksGroupRendersChildren(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: deploy with rollback
@@ -311,8 +300,7 @@ func TestApplyListTasksGroupRendersChildren(t *testing.T) {
 // listing should appear without any plan-time probe being run. We
 // verify by confirming a stub key's PlanError is never surfaced.
 func TestPlanListTasksWorks(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{PlanError: stubExecError("plan must not run")})
+	stubSet(t, "a", StubFixture{PlanError: stubExecError("plan must not run")})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -338,7 +326,6 @@ func TestPlanListTasksWorks(t *testing.T) {
 // carries `play` where the run stream's carries `name`, and it has no
 // `ts` - which is why it has its own schema file.
 func TestListTasksJSONMatchesSchema(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - name: skipped play
   when: 'false'
@@ -420,7 +407,6 @@ func TestListTasksJSONMatchesSchema(t *testing.T) {
 // --start-at-task pointing at a name that does not exist returns 1
 // with the available-names hint.
 func TestApplyStartAtTaskUnknownErrors(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: first
@@ -470,7 +456,6 @@ const playWhenErrorTasks = `---
 // The rest of the listing still renders: the walk is not short-circuited,
 // only the exit code carries the failure.
 func TestListTasksPlayWhenErrorExitsOne(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, playWhenErrorTasks)
 
 	stdout, stderr, exit := runApply(t, path, "--list-tasks")
@@ -498,7 +483,6 @@ func TestListTasksPlayWhenErrorExitsOne(t *testing.T) {
 // The schema has always documented both forms; only `when: <src>` was
 // reachable from a test before this.
 func TestListTasksPlayWhenErrorJSONExitsOne(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, playWhenErrorTasks)
 
 	stdout, stderr, exit := runApply(t, path, "--list-tasks", "--json")
@@ -528,7 +512,6 @@ func TestListTasksPlayWhenErrorJSONExitsOne(t *testing.T) {
 // As with a play, the walk is not short-circuited: the rest of the play
 // still lists and only the exit code carries the failure.
 func TestListTasksTaskWhenErrorExitsOne(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: broken predicate
@@ -566,7 +549,6 @@ func TestListTasksTaskWhenErrorUnderUnreachableGroupDoesNotAffectExit(t *testing
 		{"unknown group", `'registered.earlier.Changed'`, "[unknown] gate"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			defer stubReset()
 			path := writeTasksFile(t, `---
 - tasks:
     - name: gate
@@ -627,10 +609,9 @@ func TestWhenReferencesRuntimeValue(t *testing.T) {
 // [skipped] for tasks before the target and runs the matched task plus
 // successors. The stub fixtures track which tasks actually execute.
 func TestApplyStartAtTaskSkipsEarlier(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: true})
-	stubSet("c", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: true})
+	stubSet(t, "c", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -662,10 +643,9 @@ func TestApplyStartAtTaskSkipsEarlier(t *testing.T) {
 // / always per normal block semantics. We verify the matched child
 // runs and the earlier child does not.
 func TestApplyStartAtTaskInsideBlock(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: true})
-	stubSet("c", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: true})
+	stubSet(t, "c", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -699,10 +679,9 @@ func TestApplyStartAtTaskInsideBlock(t *testing.T) {
 // silently no-oped. The documented order selects the resume point
 // first, then narrows by tags, so a later tag-matching task runs.
 func TestApplyStartAtTaskThenTags(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: true})
-	stubSet("c", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: true})
+	stubSet(t, "c", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -739,10 +718,9 @@ func TestApplyStartAtTaskThenTags(t *testing.T) {
 // --skip-tags path: the resume target is dropped by --skip-tags but the
 // gate still resumes so a later surviving task runs.
 func TestApplyStartAtTaskThenSkipTags(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: true})
-	stubSet("c", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: true})
+	stubSet(t, "c", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:
@@ -776,9 +754,8 @@ func TestApplyStartAtTaskThenSkipTags(t *testing.T) {
 // fail the filter: descent into the resume-point group bypasses tag
 // filtering so an explicitly named child is never hidden by --tags.
 func TestApplyStartAtTaskGroupChildWithTags(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: true})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: true})
 
 	path := writeTasksFile(t, `---
 - tasks:

--- a/commands/loop_item_whitespace_masking_test.go
+++ b/commands/loop_item_whitespace_masking_test.go
@@ -32,7 +32,6 @@ const whitespaceLoopItemRecipe = `---
 const whitespacePaddedSecret = " whitespacezzz "
 
 func TestListTasksMasksWhitespacePaddedLoopItemInName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, whitespaceLoopItemRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret, "--list-tasks")
@@ -48,7 +47,6 @@ func TestListTasksMasksWhitespacePaddedLoopItemInName(t *testing.T) {
 }
 
 func TestListTasksJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, whitespaceLoopItemRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret, "--list-tasks", "--json")
@@ -65,8 +63,7 @@ func TestListTasksJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
 }
 
 func TestApplyMasksWhitespacePaddedLoopItemInName(t *testing.T) {
-	defer stubReset()
-	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	stubSet(t, whitespacePaddedSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, whitespaceLoopItemRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret)
@@ -82,8 +79,7 @@ func TestApplyMasksWhitespacePaddedLoopItemInName(t *testing.T) {
 }
 
 func TestApplyJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
-	defer stubReset()
-	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	stubSet(t, whitespacePaddedSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, whitespaceLoopItemRecipe)
 
 	stdout, stderr, exit := runApply(t, path, "--secret_value="+whitespacePaddedSecret, "--json")
@@ -99,8 +95,7 @@ func TestApplyJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
 }
 
 func TestPlanMasksWhitespacePaddedLoopItemInName(t *testing.T) {
-	defer stubReset()
-	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	stubSet(t, whitespacePaddedSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, whitespaceLoopItemRecipe)
 
 	stdout, stderr, exit := runPlan(t, path, "--secret_value="+whitespacePaddedSecret)
@@ -116,8 +111,7 @@ func TestPlanMasksWhitespacePaddedLoopItemInName(t *testing.T) {
 }
 
 func TestPlanJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
-	defer stubReset()
-	stubSet(whitespacePaddedSecret, StubFixture{Changed: true})
+	stubSet(t, whitespacePaddedSecret, StubFixture{Changed: true})
 	path := writeTasksFile(t, whitespaceLoopItemRecipe)
 
 	stdout, stderr, exit := runPlan(t, path, "--secret_value="+whitespacePaddedSecret, "--json")
@@ -139,7 +133,6 @@ func TestPlanJSONMasksWhitespacePaddedLoopItemInName(t *testing.T) {
 // CollectPlaySensitiveValues - after the recipe has parsed and already named
 // its expansions. A fix that trimmed at expansion time would still leak here.
 func TestListTasksMasksWhitespacePaddedTaskDeclaredLoopItem(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - name: configure
@@ -168,7 +161,6 @@ func TestListTasksMasksWhitespacePaddedTaskDeclaredLoopItem(t *testing.T) {
 // secret. `keepzzz` is not registered, so it prints in full even though the
 // registered secret trims to a different value entirely.
 func TestListTasksLeavesUnpaddedLoopItemsAlone(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, required: true, sensitive: true }

--- a/commands/play_executor_test.go
+++ b/commands/play_executor_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ func runPlan(t *testing.T, path string, args ...string) (string, string, int) {
 	t.Helper()
 	argv := []string{"docket-test", "plan", "--tasks", path}
 
-	c := &PlanCommand{Argv: argv}
+	c := &PlanCommand{Argv: argv, Ctx: withStubFixtures(context.Background(), stubsFor(t))}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
 	all := append([]string{"--tasks", path}, args...)
 	exit := c.Run(all)
@@ -184,9 +185,8 @@ func TestMultiPlayPlayLevelTagsPropagateToTasks(t *testing.T) {
 // same way it does in apply: the second task's `when:` evaluates
 // against the synthesized TaskOutputState of the first.
 func TestPlanRegisteredVisibleToFollowUp(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: false})
 
 	path := writeMultiPlayTasks(t, `---
 - tasks:
@@ -210,8 +210,7 @@ func TestPlanRegisteredVisibleToFollowUp(t *testing.T) {
 // rewrites the synthesized TaskOutputState's Error so the plan
 // classifier no longer treats the task as a probe error.
 func TestPlanFailedWhenClearsError(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{
+	stubSet(t, "a", StubFixture{
 		PlanError: errors.New("App nonexistent does not exist"),
 		Stderr:    "App nonexistent does not exist",
 	})
@@ -237,8 +236,7 @@ func TestPlanFailedWhenClearsError(t *testing.T) {
 // 1, not 2). This is the end-to-end guard for #328: a probe that could
 // not run must not be reported as absent with an optimistic [+] create.
 func TestPlanProbeErrorRendersMarkerAndExits(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{
+	stubSet(t, "a", StubFixture{
 		PlanError: errors.New(`exec: "dokku": executable file not found in $PATH`),
 	})
 
@@ -271,8 +269,7 @@ func TestPlanProbeErrorRendersMarkerAndExits(t *testing.T) {
 // would-change verdict, not leave the stale [ok] / "status":"ok" the
 // probe returned.
 func TestPlanChangedWhenTrueRecomputesStatus(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false}) // Plan() -> InSync, PlanStatusOK
+	stubSet(t, "a", StubFixture{Changed: false}) // Plan() -> InSync, PlanStatusOK
 
 	path := writeMultiPlayTasks(t, `---
 - tasks:
@@ -321,8 +318,7 @@ func TestPlanChangedWhenTrueRecomputesStatus(t *testing.T) {
 // failed_when clearing a probe error leaves a would-change line marked
 // [~], not the stale [!] the probe returned.
 func TestPlanFailedWhenClearingErrorRecomputesStatus(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{
+	stubSet(t, "a", StubFixture{
 		PlanError: errors.New("App nonexistent does not exist"),
 		Stderr:    "App nonexistent does not exist",
 	})
@@ -352,9 +348,8 @@ func TestPlanFailedWhenClearingErrorRecomputesStatus(t *testing.T) {
 // register name reused across tasks at load time (the same rule validate
 // enforces) instead of silently merging results.
 func TestPlanRejectsDuplicateRegisterName(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: false})
 
 	path := writeMultiPlayTasks(t, `---
 - tasks:
@@ -379,9 +374,8 @@ func TestPlanRejectsDuplicateRegisterName(t *testing.T) {
 // predicate that reads it plans normally instead of failing with an
 // index-out-of-range error.
 func TestPlanSingleIterationLoopRegisterResultsIndex(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: true})
-	stubSet("b", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: true})
+	stubSet(t, "b", StubFixture{Changed: false})
 
 	path := writeMultiPlayTasks(t, `---
 - tasks:

--- a/commands/play_target_test.go
+++ b/commands/play_target_test.go
@@ -27,7 +27,7 @@ func runApplyWithTarget(t *testing.T, path string, args ...string) (map[string][
 		})
 
 	ui := cli.NewMockUi()
-	c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
+	c := &ApplyCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: withStubFixtures(ctx, stubsFor(t))}
 	c.Run(append([]string{"--tasks", path}, args...))
 	return seen, ui.OutputWriter.String()
 }
@@ -126,7 +126,7 @@ func TestApplyPlaySudoInheritsAndDeclines(t *testing.T) {
 			return subprocess.ExecCommandResponse{}, nil
 		})
 
-	c := &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Argv: argv, Ctx: ctx}
+	c := &ApplyCommand{Meta: command.Meta{Ui: cli.NewMockUi()}, Argv: argv, Ctx: withStubFixtures(ctx, stubsFor(t))}
 	c.Run([]string{"--tasks", path, "--sudo"})
 
 	if !sudoByHost["deploy@one.example.com"] {
@@ -153,7 +153,7 @@ func TestPlanRoutesEachPlayToItsOwnHost(t *testing.T) {
 		})
 
 	ui := cli.NewMockUi()
-	c := &PlanCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: ctx}
+	c := &PlanCommand{Meta: command.Meta{Ui: ui}, Argv: argv, Ctx: withStubFixtures(ctx, stubsFor(t))}
 	c.Run([]string{"--tasks", path})
 
 	if !seen[""] || !seen["deploy@remote.example.com"] {

--- a/commands/play_when_test.go
+++ b/commands/play_when_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,8 +24,8 @@ import (
 // outcome we want to assert. With `!=`, `nil != "x"` is true and the
 // play would run regardless of whether the variable was visible.
 
-func newTestPlanCommand(argv []string) *PlanCommand {
-	c := &PlanCommand{Argv: argv}
+func newTestPlanCommand(t *testing.T, argv []string) *PlanCommand {
+	c := &PlanCommand{Argv: argv, Ctx: withStubFixtures(context.Background(), stubsFor(t))}
 	c.Meta = command.Meta{Ui: cli.NewMockUi()}
 	return c
 }
@@ -38,7 +39,7 @@ func playOutput(t *testing.T, path string, args ...string) (string, string, int)
 	t.Helper()
 	argv := []string{"docket-test", "plan", "--tasks", path}
 
-	c := newTestPlanCommand(argv)
+	c := newTestPlanCommand(t, argv)
 	all := append([]string{"--tasks", path}, args...)
 	exit := c.Run(all)
 	ui := c.Ui.(*cli.MockUi)
@@ -259,7 +260,6 @@ func playLines(out string) []string {
 // play names and --list-tasks does not, so a sensitive name would make
 // the two differ by design rather than by drift.
 func TestPlayWhenListTasksMatchesPlan(t *testing.T) {
-	defer stubReset()
 	path := writePlayTasks(t, `---
 - inputs:
     - name: env

--- a/commands/sensitive_default_masking_test.go
+++ b/commands/sensitive_default_masking_test.go
@@ -115,7 +115,6 @@ func TestHelpKeepsNonSensitiveInputDefault(t *testing.T) {
 // is the declared default - which reaches the mask registry through
 // Argument.StringValue() exactly as a --vars-file or CLI value would.
 func TestListTasksMasksSensitiveInputResolvedFromDefault(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - inputs:
     - { name: secret_value, default: defaultsecretzzz, sensitive: true }

--- a/commands/stub_task_test.go
+++ b/commands/stub_task_test.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
+	"testing"
 
 	"github.com/dokku/docket/tasks"
 )
@@ -59,7 +61,7 @@ func (t StubTask) ProbeSupport() tasks.ProbeSupport {
 }
 
 func (t StubTask) Plan(ctx context.Context) tasks.PlanResult {
-	fixture := stubGet(t.Key)
+	fixture := stubFixtureFor(ctx, t.Key)
 	if fixture.Hook != nil {
 		fixture.Hook()
 	}
@@ -93,7 +95,7 @@ func (t StubTask) Plan(ctx context.Context) tasks.PlanResult {
 }
 
 func (t StubTask) Execute(ctx context.Context) tasks.TaskOutputState {
-	fixture := stubGet(t.Key)
+	fixture := stubFixtureFor(ctx, t.Key)
 	if fixture.Hook != nil {
 		fixture.Hook()
 	}
@@ -157,27 +159,69 @@ type StubFixture struct {
 	Hook func()
 }
 
+// stubFixtures is one test's set of stub answers, keyed the way that test
+// chose. It travels to the task on the run context, so two tests can use the
+// same key for different answers.
+type stubFixtures map[string]StubFixture
+
+// stubFixturesKey is the context key a test's fixture set travels under.
+type stubFixturesKey struct{}
+
+// withStubFixtures returns a context carrying f, which is how the stub task
+// finds its answers without a package-level map.
+func withStubFixtures(ctx context.Context, f stubFixtures) context.Context {
+	if len(f) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, stubFixturesKey{}, f)
+}
+
+// stubFixtureFor returns the fixture registered for key on ctx, or the zero
+// fixture when none is - which is the "nothing to do, task is in sync" answer.
+func stubFixtureFor(ctx context.Context, key string) StubFixture {
+	if ctx == nil {
+		return StubFixture{}
+	}
+	f, _ := ctx.Value(stubFixturesKey{}).(stubFixtures)
+	return f[key]
+}
+
+// pendingStubs collects what each test registered before it started a run.
+// Keyed by the test rather than by fixture name, so the names tests pick -
+// "a" appears in 38 of them - cannot collide, and finishing one test cannot
+// wipe another's answers the way the single shared map it replaced did.
 var (
-	stubMu       sync.Mutex
-	stubFixtures = map[string]StubFixture{}
+	pendingMu sync.Mutex
+	pending   = map[*testing.T]stubFixtures{}
 )
 
-func stubSet(key string, f StubFixture) {
-	stubMu.Lock()
-	defer stubMu.Unlock()
-	stubFixtures[key] = f
+// stubSet registers a fixture for this test. The run helpers lift what a test
+// registered onto the context they build, so it reaches the task from there.
+func stubSet(t *testing.T, key string, f StubFixture) {
+	t.Helper()
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	if pending[t] == nil {
+		pending[t] = stubFixtures{}
+		t.Cleanup(func() {
+			pendingMu.Lock()
+			defer pendingMu.Unlock()
+			delete(pending, t)
+		})
+	}
+	pending[t][key] = f
 }
 
-func stubGet(key string) StubFixture {
-	stubMu.Lock()
-	defer stubMu.Unlock()
-	return stubFixtures[key]
-}
-
-func stubReset() {
-	stubMu.Lock()
-	defer stubMu.Unlock()
-	stubFixtures = map[string]StubFixture{}
+// stubsFor returns a copy of what t registered, so the run reads a set nothing
+// can mutate underneath it.
+func stubsFor(t *testing.T) stubFixtures {
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	out := stubFixtures{}
+	for k, v := range pending[t] {
+		out[k] = v
+	}
+	return out
 }
 
 // stubExecError returns an error that, when threaded through the
@@ -189,4 +233,38 @@ func stubExecError(stderr string) error {
 
 func init() {
 	tasks.RegisterTask(&StubTask{})
+}
+
+// TestStubFixturesDoNotCollideAcrossTests is the property #506 exists for.
+// The registry this replaced was a single process-wide map keyed by whatever
+// name each test picked, and the names collide hard - "a" appears in 38 tests.
+// Two of them running at once clobbered each other, and either one finishing
+// wiped the whole map while the other was still running.
+//
+// Both subtests register "a" with opposite answers and run in parallel. Under
+// the old map one of them would have read the other's fixture, or none at all.
+func TestStubFixturesDoNotCollideAcrossTests(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{"changed": true, "unchanged": false}
+	for name, changed := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			stubSet(t, "a", StubFixture{Changed: changed})
+
+			path := writeTasksFile(t, `---
+- tasks:
+    - name: only
+      dokku_stub: { key: a }
+`)
+			stdout, _, exit := runApply(t, path, "--detailed-exitcode")
+			if exit != map[bool]int{true: 2, false: 0}[changed] {
+				t.Errorf("exit = %d for Changed=%v; the other subtest's fixture answered", exit, changed)
+			}
+			want := map[bool]string{true: "[changed]", false: "[ok]"}[changed]
+			if !strings.Contains(stdout, want) {
+				t.Errorf("output should contain %q for Changed=%v:\n%s", want, changed, stdout)
+			}
+		})
+	}
 }

--- a/commands/task_file_url_test.go
+++ b/commands/task_file_url_test.go
@@ -114,8 +114,7 @@ func TestDetectTaskFileFormatURL(t *testing.T) {
 // TestPlanFetchesRecipeFromURL: plan reads a recipe served over HTTP and
 // runs it to completion (a read failure would exit 1 with "read error").
 func TestPlanFetchesRecipeFromURL(t *testing.T) {
-	defer stubReset()
-	stubSet("url-plan", StubFixture{})
+	stubSet(t, "url-plan", StubFixture{})
 
 	srv := serveRecipe(t, `---
 - tasks:
@@ -139,8 +138,7 @@ func TestPlanFetchesRecipeFromURL(t *testing.T) {
 // The stub key resolves to the overridden app value; only the "override"
 // key carries a changed fixture, so a propagated override yields 1 changed.
 func TestApplyURLRecipePreregistersInputFlags(t *testing.T) {
-	defer stubReset()
-	stubSet("override", StubFixture{Changed: true})
+	stubSet(t, "override", StubFixture{Changed: true})
 
 	srv := serveRecipe(t, `---
 - inputs:
@@ -164,8 +162,7 @@ func TestApplyURLRecipePreregistersInputFlags(t *testing.T) {
 // share a single fetch of a --tasks URL, so the recipe is requested once
 // per command rather than twice.
 func TestURLRecipeFetchedOncePerInvocation(t *testing.T) {
-	defer stubReset()
-	stubSet("cache-key", StubFixture{})
+	stubSet(t, "cache-key", StubFixture{})
 
 	var mu sync.Mutex
 	hits := 0

--- a/commands/task_name_test.go
+++ b/commands/task_name_test.go
@@ -40,7 +40,6 @@ func jsonTaskNames(t *testing.T, path string) []string {
 // change an unnamed task carried eight random bytes and a consumer diffing one
 // run against another could line nothing up.
 func TestApplyJSONTaskNamesAreStableAcrossRuns(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - dokku_stub: { key: a }
@@ -65,7 +64,6 @@ func TestApplyJSONTaskNamesAreStableAcrossRuns(t *testing.T) {
 // task could not be named on the command line at all before, because its name
 // was different every run.
 func TestApplyStartAtTaskAcceptsGeneratedName(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - dokku_stub: { key: a }
@@ -91,7 +89,6 @@ func TestApplyStartAtTaskAcceptsGeneratedName(t *testing.T) {
 // is usable: when the name matches nothing, the available names it prints are
 // the addresses the user would have to type.
 func TestApplyStartAtTaskUnknownNameListsGeneratedNames(t *testing.T) {
-	defer stubReset()
 	path := writeTasksFile(t, `---
 - tasks:
     - dokku_stub: { key: a }

--- a/commands/task_warning_test.go
+++ b/commands/task_warning_test.go
@@ -32,8 +32,7 @@ const warningRecipe = `---
 `
 
 func TestPlanSurfacesProbeWarning(t *testing.T) {
-	defer stubReset()
-	stubSet("a", stubWithWarning())
+	stubSet(t, "a", stubWithWarning())
 	path := writeTasksFile(t, warningRecipe)
 
 	stdout, _, _ := runPlan(t, path)
@@ -53,8 +52,7 @@ func TestPlanSurfacesProbeWarning(t *testing.T) {
 }
 
 func TestApplySurfacesProbeWarning(t *testing.T) {
-	defer stubReset()
-	stubSet("a", stubWithWarning())
+	stubSet(t, "a", stubWithWarning())
 	path := writeTasksFile(t, warningRecipe)
 
 	stdout, _, _ := runApply(t, path)
@@ -116,8 +114,7 @@ func stubWithInSyncWarning() StubFixture {
 }
 
 func TestPlanSurfacesWarningOnInSyncTask(t *testing.T) {
-	defer stubReset()
-	stubSet("a", stubWithInSyncWarning())
+	stubSet(t, "a", stubWithInSyncWarning())
 	path := writeTasksFile(t, warningRecipe)
 
 	stdout, _, _ := runPlan(t, path)
@@ -134,8 +131,7 @@ func TestPlanSurfacesWarningOnInSyncTask(t *testing.T) {
 }
 
 func TestApplySurfacesWarningOnInSyncTask(t *testing.T) {
-	defer stubReset()
-	stubSet("a", stubWithInSyncWarning())
+	stubSet(t, "a", stubWithInSyncWarning())
 	path := writeTasksFile(t, warningRecipe)
 
 	stdout, _, _ := runApply(t, path)

--- a/commands/vars_file_mode_test.go
+++ b/commands/vars_file_mode_test.go
@@ -157,8 +157,7 @@ func permissiveVarsRecipe(t *testing.T) (recipe string, vars string) {
 // TestApplyWarnsOnPermissiveVarsFile pins where the warning comes out: stderr,
 // through the same Ui.Warn the ambiguous-task-file notice uses.
 func TestApplyWarnsOnPermissiveVarsFile(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: false})
 
 	recipe, vars := permissiveVarsRecipe(t)
 	stdout, stderr, exit := runApply(t, recipe, "--vars-file", vars)
@@ -178,8 +177,7 @@ func TestApplyWarnsOnPermissiveVarsFile(t *testing.T) {
 // schema's reason field is a closed enum. Routed to stderr it cannot reach the
 // stream at all, so every stdout line still parses.
 func TestApplyJSONKeepsVarsFileWarningOffTheStream(t *testing.T) {
-	defer stubReset()
-	stubSet("a", StubFixture{Changed: false})
+	stubSet(t, "a", StubFixture{Changed: false})
 
 	recipe, vars := permissiveVarsRecipe(t)
 	stdout, stderr, exit := runApply(t, recipe, "--json", "--vars-file", vars)

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -730,6 +730,21 @@ func problemToError(p Problem) error {
 // nil pointer (the historical loader allocation panicked in SetDefaults
 // on `dokku_app:` with no body). Shared by the loader's direct and loop
 // decode paths and by the validator's body checks.
+// go-defaults builds its filler lazily into an unsynchronised package
+// variable, so the first two goroutines to call SetDefaults race on creating
+// it. Every recipe decode goes through SetDefaults, so any two tests that load
+// a recipe at the same time trip the detector on a library global neither of
+// them can see.
+//
+// Warming it here settles the variable on the goroutine that imports the
+// package, before any test has started one of its own. After that first write
+// it is only ever read, and goroutine creation orders those reads behind it.
+func init() {
+	defaults.SetDefaults(&struct {
+		Warm string `default:"warm"`
+	}{})
+}
+
 func decodeTaskBytes(typeKey string, body []byte) (Task, error) {
 	registered, ok := RegisteredTasks[typeKey]
 	if !ok {


### PR DESCRIPTION
The stub task read its answers from one process-wide map keyed by whatever name each test picked, and the names collide hard - `"a"` alone appears in 38 of them. Two tests running at once clobbered each other, and either one finishing called `stubReset` and wiped the whole map while the other was still going. That is the last thing in `commands` blocking `t.Parallel()` that is specific to the test harness rather than to a process global.

A test's fixtures now travel to the task on the run context, the way the exec runner, the target and the masker already do. `stubSet` takes the test it belongs to and collects into a per-test set; the run helpers lift that set onto the context they build; `StubTask` reads it from there. Names cannot collide because no two tests share a set, and `stubReset` is gone entirely - a set is discarded with the test that owns it, so there is nothing to reset.

Adding the regression test for this surfaced a data race nothing had hit before, in `go-defaults` rather than here: it builds its filler lazily into an unsynchronised package variable, and every recipe decode reaches it through `defaults.SetDefaults`. Two tests loading a recipe at the same time race on creating it. The `tasks` package now warms the filler in `init`, which settles the variable on the importing goroutine before any test starts one of its own; after that first write it is only ever read. It was invisible to every `-race` run until something in this package actually ran concurrently, which is the point of the new test.

Fixes #506.
