### PR TITLE
feat: make the export machinery usable from Go

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,5 +21,6 @@ Complete documentation for docket, a declarative way to pre-package and ship app
 - [Migration](migration.md) -- move a Dokku setup to a new server
 - [JSON output](json-output.md) -- the `--json` event schema for `apply` and `plan`
 - [Wrapping docket from ansible-dokku](ansible-dokku.md) -- the contract for driving docket from another tool
+- [Embedding docket in Go](embedding.md) -- reading a server back as structured data from Go
 - [Writing tasks](writing-tasks.md) -- contribute a new task type
 - [Roadmap](roadmap.md) -- ideas for where docket could go next

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,121 @@
+# Embedding docket in Go
+
+docket's engine is a Go package, not only a CLI. This page covers the parts that are stable enough
+to build on: reading a server back as structured data, building tasks, and the per-invocation state
+every call needs.
+
+Import path is `github.com/dokku/docket/tasks`.
+
+## The run context
+
+Everything takes a `context.Context`, and that context carries the state a run needs. Nothing is
+read from process globals, so two runs in one process can target different servers, mask different
+values, and be cancelled independently.
+
+```go
+ctx := context.Background()
+
+// Where dokku commands go. The zero Target runs locally.
+ctx = subprocess.ContextWithTarget(ctx, subprocess.Target{
+    Host: "deploy@dokku.example.com",
+    Sudo: true,
+})
+
+// What gets masked in anything you render for a human.
+ctx = subprocess.ContextWithMasker(ctx, subprocess.NewMasker("s3cr3t"))
+```
+
+Cancel the context and in-flight dokku commands stop; give it a deadline and they are bounded by it.
+A signal handler is the caller's business - docket's own is installed in `main.go`, not in the
+engine.
+
+## Reading a server
+
+`tasks.ExportRecipe` enumerates the server and returns the recipe that describes it, along with the
+values it had to lift out of task bodies and any warnings it collected.
+
+```go
+res, err := tasks.ExportRecipe(ctx, tasks.ExportOptions{Inline: true})
+if err != nil {
+    return err
+}
+
+for _, play := range res.Plays() {
+    for _, task := range play.Tasks {
+        cfg, ok := task.Body.(tasks.ConfigTask)
+        if !ok {
+            continue
+        }
+        fmt.Println(play.Name, cfg.App, cfg.Config)
+    }
+}
+```
+
+`Plays()` returns the same values `MarshalRecipe` renders, so the structured view and the recipe
+file can never describe different exports. Each task body is the task's own type - `dokku_config`
+comes back as a `ConfigTask` - so there is no marshalling to YAML and parsing it straight back.
+
+Bodies are values, not pointers, because that is what an exporter returns. Type-assert the concrete
+type (`tasks.ConfigTask`), not the `Task` interface.
+
+### Narrowing the read
+
+`ExportOptions` narrows what is read:
+
+| Field | Effect |
+| --- | --- |
+| `Apps` | Only these apps. The leading global play is skipped unless an address asks for it. |
+| `Resources` | Only these addresses, parsed by `tasks.ParseResourceSelectors`. |
+| `Inline` | Keep sensitive values in the bodies instead of lifting them into `Vars`. |
+| `Redact` | Replace sensitive values with a placeholder. |
+
+An address is `type[key=value]`, so a single global resource is readable without exporting the whole
+server:
+
+```go
+sel, err := tasks.ParseResourceSelectors([]string{"dokku_plugin[name=redis]"})
+res, err := tasks.ExportRecipe(ctx, tasks.ExportOptions{Resources: sel, Inline: true})
+```
+
+### Secrets
+
+An export is the one read path with no recipe to collect a sensitive set from ahead of time: the
+values needing masking are the ones its own exporters just read back. Register them before printing
+anything, including the warnings.
+
+```go
+masker := subprocess.NewMasker(res.SensitiveValues()...)
+for _, w := range res.Report.Warnings {
+    fmt.Fprintln(os.Stderr, masker.String(w))
+}
+```
+
+`res.Report` also carries `MissingApps` and `MissingResources` - names that were asked for and not
+found. An export that finds nothing is not an error, so check them rather than relying on `err`.
+
+## Building tasks
+
+Use `tasks.NewTask` rather than a struct literal. A literal skips the `default:` tags the loader
+applies, so a task with no `State` gets `""`, which is an invalid state rather than the `present`
+the field documents.
+
+```go
+task, err := tasks.NewTask("dokku_app")
+if err != nil {
+    return err
+}
+app := task.(*tasks.AppTask)
+app.App = "api"
+
+plan := app.Plan(ctx)      // reports drift, never mutates
+state := app.Execute(ctx)  // plans, then applies
+```
+
+`tasks.DecodeTask` is the same thing from a YAML task body, for a caller that already holds a recipe
+fragment.
+
+## What is not stable
+
+The engine is exported, not frozen. Task struct fields follow the recipe format and change with it;
+`RegisteredTasks` is a live map and writing to it is not supported. Treat anything not on this page
+as internal.

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -229,10 +229,39 @@ type ExportReport struct {
 	MissingResources []string
 }
 
+// ExportedTask is one task in an exported play: the registry type-key it is
+// emitted under, and the task's own struct populated from the server.
+//
+// Body is the task value, not a marshalled form of it - `dokku_config` comes
+// back as a ConfigTask - so a Go caller can type-assert it and read fields
+// rather than parsing YAML the export just produced. It is `interface{}`
+// rather than Task because an exporter returns bodies by value and Task is
+// implemented on the pointer for most types; assert the concrete type.
+type ExportedTask struct {
+	Type string      `yaml:"-"`
+	Body interface{} `yaml:"-"`
+}
+
+// MarshalYAML emits the task the way a recipe spells it: a single-key mapping
+// from type-key to body. The exported fields are what a Go caller reads; this
+// is what the recipe file gets, and having one type produce both is what keeps
+// Plays() and MarshalRecipe from drifting apart.
+func (t ExportedTask) MarshalYAML() (interface{}, error) {
+	return map[string]interface{}{t.Type: t.Body}, nil
+}
+
+// ExportedPlay is one play of an exported recipe. Name is the app it describes,
+// or "global" for the leading play of not-app-scoped resources.
+type ExportedPlay struct {
+	Name   string                   `yaml:"name"`
+	Inputs []map[string]interface{} `yaml:"inputs,omitempty"`
+	Tasks  []ExportedTask           `yaml:"tasks"`
+}
+
 // ExportResult is the outcome of ExportRecipe: the assembled recipe (as a list
 // of plays), the companion vars map (empty in inline mode), and any warnings.
 type ExportResult struct {
-	plays  []map[string]interface{}
+	plays  []ExportedPlay
 	Vars   map[string]string
 	Report ExportReport
 
@@ -273,6 +302,20 @@ func (res *ExportResult) noteSensitive(values ...string) {
 	res.sensitive = append(res.sensitive, values...)
 }
 
+// Plays returns the exported recipe as structured values: the same plays
+// MarshalRecipe renders, with each task body still its own Go type.
+//
+// It exists because the only ways out of an export used to be MarshalRecipe
+// and MarshalVars, so a caller wanting data had to marshal to YAML and parse
+// it straight back - or call ExportApp on a task directly and reimplement the
+// ordering, warning collection and sensitive-value handling the engine already
+// does (#425).
+//
+// The slice is the result's own and must not be modified.
+func (res *ExportResult) Plays() []ExportedPlay {
+	return res.plays
+}
+
 // SensitiveValues returns the literal values this export read off the server
 // that must be masked in user-facing output. The caller registers them; the
 // slice is the result's own and must not be modified.
@@ -300,9 +343,15 @@ func ExportRecipe(ctx context.Context, opts ExportOptions) (*ExportResult, error
 	// Global resources come first, in a leading "global" play. Skipped when
 	// the export is narrowed to specific apps with --app, and when every
 	// --resource address is app-scoped.
-	if len(opts.Apps) == 0 && res.filter.wantsGlobalScope(inGlobal) {
+	//
+	// An explicit global address outranks --app (#518). `--app foo` on its own
+	// means "this app, not the server", but naming `dokku_plugin[name=redis]`
+	// alongside it asks for that resource by name, and the global play is the
+	// only place it can come from - skipping it exported nothing and reported
+	// the address as missing from a server that had it.
+	if res.filter.wantsGlobalScope(inGlobal) && (len(opts.Apps) == 0 || res.filter.hasGlobalAddress(inGlobal)) {
 		if global := res.exportGlobalPlay(ctx, opts); global != nil {
-			res.plays = append(res.plays, global)
+			res.plays = append(res.plays, *global)
 		}
 	}
 
@@ -314,6 +363,10 @@ func ExportRecipe(ctx context.Context, opts ExportOptions) (*ExportResult, error
 	selectedApps, restricted := res.filter.appNames(inApp)
 	if restricted {
 		if len(selectedApps) == 0 {
+			// No app-scoped address selected an app. That is a finished export
+			// rather than a failed one when the addresses were global and the
+			// global play has already answered them; only then does an
+			// unmatched address mean the server does not have it.
 			res.Report.MissingResources = res.filter.unmatchedAddresses()
 			return res, nil
 		}
@@ -336,7 +389,7 @@ func ExportRecipe(ctx context.Context, opts ExportOptions) (*ExportResult, error
 	for _, app := range apps {
 		play := res.exportAppPlay(ctx, app, opts)
 		if play != nil {
-			res.plays = append(res.plays, play)
+			res.plays = append(res.plays, *play)
 		}
 	}
 
@@ -347,8 +400,8 @@ func ExportRecipe(ctx context.Context, opts ExportOptions) (*ExportResult, error
 
 // exportGlobalPlay builds the leading global play by running every registered
 // GlobalExporter. Returns nil when there are no global resources.
-func (res *ExportResult) exportGlobalPlay(ctx context.Context, opts ExportOptions) map[string]interface{} {
-	var taskList []map[string]interface{}
+func (res *ExportResult) exportGlobalPlay(ctx context.Context, opts ExportOptions) *ExportedPlay {
+	var taskList []ExportedTask
 	var inputs []map[string]interface{}
 
 	for _, typeKey := range globalExportOrder {
@@ -388,7 +441,7 @@ func (res *ExportResult) exportGlobalPlay(ctx context.Context, opts ExportOption
 				continue
 			}
 			body, ins := res.processBody("global", body, opts)
-			taskList = append(taskList, map[string]interface{}{typeKey: body})
+			taskList = append(taskList, ExportedTask{Type: typeKey, Body: body})
 			inputs = append(inputs, ins...)
 		}
 	}
@@ -397,18 +450,13 @@ func (res *ExportResult) exportGlobalPlay(ctx context.Context, opts ExportOption
 		return nil
 	}
 
-	play := map[string]interface{}{"name": "global"}
-	if len(inputs) > 0 {
-		play["inputs"] = inputs
-	}
-	play["tasks"] = taskList
-	return play
+	return &ExportedPlay{Name: "global", Inputs: inputs, Tasks: taskList}
 }
 
 // exportAppPlay builds one play for a single app by running each app-scoped
 // exporter in appExportOrder. Returns nil when the app yields no tasks.
-func (res *ExportResult) exportAppPlay(ctx context.Context, app string, opts ExportOptions) map[string]interface{} {
-	var taskList []map[string]interface{}
+func (res *ExportResult) exportAppPlay(ctx context.Context, app string, opts ExportOptions) *ExportedPlay {
+	var taskList []ExportedTask
 	var inputs []map[string]interface{}
 
 	for _, typeKey := range appExportOrder {
@@ -448,7 +496,7 @@ func (res *ExportResult) exportAppPlay(ctx context.Context, app string, opts Exp
 				continue
 			}
 			body, ins := res.processBody(app, body, opts)
-			taskList = append(taskList, map[string]interface{}{typeKey: body})
+			taskList = append(taskList, ExportedTask{Type: typeKey, Body: body})
 			inputs = append(inputs, ins...)
 		}
 	}
@@ -457,12 +505,7 @@ func (res *ExportResult) exportAppPlay(ctx context.Context, app string, opts Exp
 		return nil
 	}
 
-	play := map[string]interface{}{"name": app}
-	if len(inputs) > 0 {
-		play["inputs"] = inputs
-	}
-	play["tasks"] = taskList
-	return play
+	return &ExportedPlay{Name: app, Inputs: inputs, Tasks: taskList}
 }
 
 // processBody applies vars-extraction (file mode) or redaction (inline mode) to
@@ -875,10 +918,8 @@ func (res *ExportResult) PlayCount() int {
 // accurately.
 func (res *ExportResult) AppCount() int {
 	n := len(res.plays)
-	if n > 0 {
-		if name, _ := res.plays[0]["name"].(string); name == "global" {
-			n--
-		}
+	if n > 0 && res.plays[0].Name == "global" {
+		n--
 	}
 	return n
 }

--- a/tasks/export_plays_test.go
+++ b/tasks/export_plays_test.go
@@ -1,0 +1,157 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// export_plays_test.go covers ExportResult.Plays, the structured way out of an
+// export that #425 asks for. Before it, the only exits were MarshalRecipe and
+// MarshalVars, so a Go caller had to marshal to YAML and parse it straight
+// back - or call ExportApp on a task directly and reimplement the ordering,
+// warning collection and sensitive-value handling the engine already does.
+
+// TestExportPlaysReturnsTypedTaskBodies is the point of the accessor: a caller
+// reads fields off the task's own type rather than off a decoded map.
+func TestExportPlaysReturnsTypedTaskBodies(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
+
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	plays := res.Plays()
+	if len(plays) == 0 {
+		t.Fatal("expected at least one play")
+	}
+
+	var found bool
+	for _, play := range plays {
+		if play.Name != "app-one" {
+			continue
+		}
+		for _, task := range play.Tasks {
+			if task.Type != "dokku_config" {
+				continue
+			}
+			cfg, ok := task.Body.(ConfigTask)
+			if !ok {
+				t.Fatalf("dokku_config body is %T, want ConfigTask", task.Body)
+			}
+			if cfg.App != "app-one" {
+				t.Errorf("ConfigTask.App = %q, want %q", cfg.App, "app-one")
+			}
+			if got := cfg.Config["SECRET_KEY"]; got != "s3cr3t" {
+				t.Errorf("ConfigTask.Config[SECRET_KEY] = %q, want the value read off the server", got)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no dokku_config task found on the app-one play; got %+v", plays)
+	}
+}
+
+// TestExportPlaysMatchTheMarshalledRecipe is the reason the plays are stored as
+// these values rather than converted into them: MarshalRecipe renders the same
+// slice Plays returns, so the two cannot describe different exports.
+func TestExportPlaysMatchTheMarshalledRecipe(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
+
+	res, err := ExportRecipe(ctx, ExportOptions{Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+
+	var fromRecipe []struct {
+		Name  string                   `yaml:"name"`
+		Tasks []map[string]interface{} `yaml:"tasks"`
+	}
+	if err := yaml.Unmarshal(recipe, &fromRecipe); err != nil {
+		t.Fatalf("unmarshal recipe: %v", err)
+	}
+
+	plays := res.Plays()
+	if len(plays) != len(fromRecipe) {
+		t.Fatalf("Plays has %d plays, the recipe has %d", len(plays), len(fromRecipe))
+	}
+	for i, play := range plays {
+		if play.Name != fromRecipe[i].Name {
+			t.Errorf("play %d: name = %q, recipe says %q", i, play.Name, fromRecipe[i].Name)
+		}
+		if len(play.Tasks) != len(fromRecipe[i].Tasks) {
+			t.Errorf("play %q: %d tasks, the recipe has %d", play.Name, len(play.Tasks), len(fromRecipe[i].Tasks))
+			continue
+		}
+		for j, task := range play.Tasks {
+			if _, ok := fromRecipe[i].Tasks[j][task.Type]; !ok {
+				t.Errorf("play %q task %d: type %q is not the key the recipe used (%v)",
+					play.Name, j, task.Type, keysOf(fromRecipe[i].Tasks[j]))
+			}
+		}
+	}
+}
+
+// TestExportPlaysKeepsVarsLiftingOutOfTheBodies pins that the structured view
+// shows what the recipe shows: in file mode a lifted value is an interpolation
+// in the body, not the secret, and the secret lives in Vars.
+func TestExportPlaysKeepsVarsLiftingOutOfTheBodies(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
+
+	res, err := ExportRecipe(ctx, ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	for _, play := range res.Plays() {
+		for _, task := range play.Tasks {
+			cfg, ok := task.Body.(ConfigTask)
+			if !ok {
+				continue
+			}
+			for key, value := range cfg.Config {
+				if value == "s3cr3t" {
+					t.Errorf("%s: %s holds the literal secret; file mode lifts it into Vars", play.Name, key)
+				}
+			}
+		}
+	}
+	if len(res.Vars) == 0 {
+		t.Error("expected the lifted value in Vars")
+	}
+	var lifted bool
+	for _, v := range res.Vars {
+		if v == "s3cr3t" {
+			lifted = true
+		}
+	}
+	if !lifted {
+		t.Errorf("expected the secret in Vars; got %v", keysOfStrings(res.Vars))
+	}
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func keysOfStrings(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tasks/export_resource.go
+++ b/tasks/export_resource.go
@@ -167,6 +167,27 @@ func (f *resourceFilter) wantsGlobalScope(inGlobal map[string]bool) bool {
 	return false
 }
 
+// hasGlobalAddress reports whether any selector names a not-app-scoped type
+// without pinning an app. It is the narrower question wantsGlobalScope answers
+// for an unrestricted run: not "should globals be emitted" but "did the caller
+// ask for one by name", which is what lets an explicit address keep the global
+// play that --app would otherwise skip (#518).
+func (f *resourceFilter) hasGlobalAddress(inGlobal map[string]bool) bool {
+	if f == nil {
+		return false
+	}
+	for _, sel := range f.selectors {
+		if !inGlobal[sel.TypeKey] {
+			continue
+		}
+		if _, pinned := sel.Keys["app"]; pinned {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // appNames returns the app names the selectors pin, and whether that set is a
 // restriction at all. An app-scoped selector that names no app - `dokku_config`
 // on its own - means every app, so no restriction applies.

--- a/tasks/export_resource_test.go
+++ b/tasks/export_resource_test.go
@@ -222,3 +222,44 @@ func TestExportedRecipeLoadsWithoutNameCollisions(t *testing.T) {
 		}
 	}
 }
+
+// TestExportResourceGlobalAddressSurvivesAppNarrowing is the regression lock on
+// #518. `--app foo` alone means "this app, not the server", so the global play
+// is skipped - but an address that names a global resource is asking for it by
+// name, and the global play is the only place it can come from. The two
+// together used to export nothing and report the address as missing from a
+// server that had it.
+func TestExportResourceGlobalAddressSurvivesAppNarrowing(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
+		"--quiet apps:list": "app-one",
+		"--quiet plugin:list --format json": `[
+			{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"","branch":""}
+		]`,
+	}))
+	selectors, err := ParseResourceSelectors([]string{"dokku_plugin[name=redis]"})
+	if err != nil {
+		t.Fatalf("ParseResourceSelectors: %v", err)
+	}
+
+	res, err := ExportRecipe(ctx, ExportOptions{Apps: []string{"app-one"}, Resources: selectors, Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+
+	if !strings.Contains(string(recipe), "dokku_plugin") {
+		t.Errorf("the addressed global resource is missing from the recipe; got:\n%s", recipe)
+	}
+	if len(res.Report.MissingResources) > 0 {
+		t.Errorf("address reported as unmatched against a server that has it: %v", res.Report.MissingResources)
+	}
+	// --app still keeps the run off other apps: the address named no app-scoped
+	// resource, so no app play should be emitted at all.
+	if strings.Contains(string(recipe), "name: app-one") {
+		t.Errorf("a global-only address must not emit app plays; got:\n%s", recipe)
+	}
+}

--- a/tasks/new_task_test.go
+++ b/tasks/new_task_test.go
@@ -1,0 +1,89 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+// new_task_test.go covers the constructors #425 asks for. Building a task by
+// struct literal is the documented way to drive the engine from Go, and it
+// skips the `default:` tags the loader applies - so a literal with no State
+// gets "" and falls into the `invalid state: ""` branch of DispatchPlan rather
+// than behaving as present. NewTask is that allocation without needing YAML.
+
+// TestNewTaskAppliesFieldDefaults is the foot-gun the issue names: the
+// difference between a struct literal and a task the loader built.
+func TestNewTaskAppliesFieldDefaults(t *testing.T) {
+	t.Parallel()
+	task, err := NewTask("dokku_app")
+	if err != nil {
+		t.Fatalf("NewTask: %v", err)
+	}
+	app, ok := task.(*AppTask)
+	if !ok {
+		t.Fatalf("NewTask returned %T, want *AppTask", task)
+	}
+	if app.State != StatePresent {
+		t.Errorf("State = %q, want %q; the default: tag was not applied", app.State, StatePresent)
+	}
+
+	// The contrast, so the test says what it is protecting against.
+	if (AppTask{}).State == StatePresent {
+		t.Error("a bare struct literal already defaults its State; this test no longer means anything")
+	}
+}
+
+// TestNewTaskRejectsAnUnknownType keeps the error a caller sees on a typo
+// close to the loader's.
+func TestNewTaskRejectsAnUnknownType(t *testing.T) {
+	t.Parallel()
+	if _, err := NewTask("dokku_not_a_task"); err == nil {
+		t.Fatal("NewTask should reject an unregistered type key")
+	} else if !strings.Contains(err.Error(), "unknown task type") {
+		t.Errorf("error = %q, want it to name the unknown type", err)
+	}
+}
+
+// TestNewTaskReturnsADistinctValue pins that the constructor allocates rather
+// than handing back the registry prototype, which every later caller shares.
+func TestNewTaskReturnsADistinctValue(t *testing.T) {
+	t.Parallel()
+	first, err := NewTask("dokku_app")
+	if err != nil {
+		t.Fatalf("NewTask: %v", err)
+	}
+	second, err := NewTask("dokku_app")
+	if err != nil {
+		t.Fatalf("NewTask: %v", err)
+	}
+	if first == second {
+		t.Fatal("NewTask returned the same value twice; it must allocate")
+	}
+	first.(*AppTask).App = "api"
+	if got := second.(*AppTask).App; got != "" {
+		t.Errorf("second task saw the first's App = %q; the prototype is being shared", got)
+	}
+	if proto := RegisteredTasks["dokku_app"]; proto == first || proto == second {
+		t.Error("NewTask handed back the registry prototype itself")
+	}
+}
+
+// TestDecodeTaskAppliesDefaultsAndFields is the YAML-bearing form, exported so
+// a caller holding a recipe fragment does not reimplement the loader's path.
+func TestDecodeTaskAppliesDefaultsAndFields(t *testing.T) {
+	t.Parallel()
+	task, err := DecodeTask("dokku_app", []byte("app: api\n"))
+	if err != nil {
+		t.Fatalf("DecodeTask: %v", err)
+	}
+	app, ok := task.(*AppTask)
+	if !ok {
+		t.Fatalf("DecodeTask returned %T, want *AppTask", task)
+	}
+	if app.App != "api" {
+		t.Errorf("App = %q, want %q", app.App, "api")
+	}
+	if app.State != StatePresent {
+		t.Errorf("State = %q, want %q; the default: tag was not applied", app.State, StatePresent)
+	}
+}

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -745,6 +745,44 @@ func init() {
 	}{})
 }
 
+// NewTask allocates a task of the given registry type-key with its `default:`
+// tags applied, ready to have its fields set.
+//
+// Building a task by struct literal is the documented way to drive the engine
+// from Go, and it skips the defaults the loader applies - a literal with no
+// State gets "" rather than "present", which falls into the `invalid state: ""`
+// branch of DispatchPlan instead of behaving the way the field tag says it
+// should. The only code that got this right was decodeTaskBytes, which is
+// unexported and needs YAML to go through. This is the same allocation without
+// the round trip (#425).
+//
+// The returned Task is a pointer to the registered type, so a caller sets
+// fields through a type assertion:
+//
+//	task, err := tasks.NewTask("dokku_app")
+//	app := task.(*tasks.AppTask)
+//	app.App = "api"
+func NewTask(typeKey string) (Task, error) {
+	registered, ok := RegisteredTasks[typeKey]
+	if !ok {
+		return nil, fmt.Errorf("unknown task type %q", typeKey)
+	}
+	v := reflect.New(reflect.TypeOf(registered).Elem())
+	defaults.SetDefaults(v.Interface())
+	task, ok := v.Interface().(Task)
+	if !ok {
+		return nil, fmt.Errorf("registered type for %q does not implement Task", typeKey)
+	}
+	return task, nil
+}
+
+// DecodeTask builds a task of the given type-key from a YAML task body, with
+// defaults applied - the loader's own path, exported so a caller holding a
+// recipe fragment does not have to reimplement it (#425).
+func DecodeTask(typeKey string, body []byte) (Task, error) {
+	return decodeTaskBytes(typeKey, body)
+}
+
 func decodeTaskBytes(typeKey string, body []byte) (Task, error) {
 	registered, ok := RegisteredTasks[typeKey]
 	if !ok {


### PR DESCRIPTION
Closes #425. Closes #518. The export is the only part of docket that reads current server state back as structured data, and three things kept a Go caller from using it.

`ExportResult.plays` was unexported, so the only ways out were `MarshalRecipe` and `MarshalVars` - a caller wanting data had to marshal to YAML and parse it straight back, or call `ExportApp` directly and reimplement the ordering, warnings and sensitive-value handling the engine already does. `Plays()` returns the plays as exported values whose task bodies are still their own Go types, so `dokku_config` comes back as a `ConfigTask`. They are stored that way rather than converted on the way out, so the structured view and the marshalled recipe cannot describe different exports; the recipe output is byte-identical.

An address naming a global resource is now honoured alongside `--app`. Reading one back used to require exporting the whole server, and the combination was worse than absent: the global play was skipped and the address was then reported as missing from a server that had it, so `docket export --app foo --resource 'dokku_plugin[name=redis]'` exported nothing and exited non-zero.

`NewTask` allocates a task from the registry with its `default:` tags applied, and `DecodeTask` does the same from a YAML body. Building a task by struct literal skips those defaults, so one with no `State` got `""` and fell into the invalid-state branch rather than behaving as present - a foot-gun the loader avoided only through an unexported function.

`docs/embedding.md` documents the resulting surface, including the run context, the narrowing options, and the sensitive values a caller has to register before printing anything.
