### PR TITLE
feat: read port mappings from ports:report --ports-map-json

### DIFF
--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -1240,7 +1240,7 @@ func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
 func TestExportPortsUsesStateSet(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		"--quiet ports:report web --ports-map": "https:443:5000 http:80:5000",
+		"--quiet ports:report web --ports-map-json": `[{"container_port":5000,"host_port":443,"scheme":"https"},{"container_port":5000,"host_port":80,"scheme":"http"}]`,
 	}))
 
 	// state:set replaces the whole mapping list, so re-applying an export
@@ -1273,7 +1273,7 @@ func TestExportPortsUsesStateSet(t *testing.T) {
 func TestExportPortsEmitsNoTaskWithoutMappings(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		"--quiet ports:report web --ports-map": "",
+		"--quiet ports:report web --ports-map-json": "null",
 	}))
 
 	bodies, err := PortsTask{}.ExportApp(ctx, "web")

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -2,12 +2,11 @@ package tasks
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/dokku/docket/subprocess"
 	"sort"
-	"strconv"
-	"strings"
 )
 
 // PortsTask manages the ports for a given dokku application
@@ -373,20 +372,63 @@ func (t PortsTask) ExportApp(ctx context.Context, app string) ([]interface{}, er
 	return []interface{}{PortsTask{App: app, PortMappings: list, State: StateSet}}, nil
 }
 
+// portsMapEntry mirrors the shape dokku's ports plugin marshals for
+// `ports:report --ports-map-json` (plugins/ports/proxy.go). It is deliberately
+// separate from PortMapping: that type is the recipe's vocabulary (scheme,
+// host, container), this one is dokku's wire format, and the two are free to
+// drift.
+type portsMapEntry struct {
+	ContainerPort int    `json:"container_port"`
+	HostPort      int    `json:"host_port"`
+	Scheme        string `json:"scheme"`
+}
+
+// portsReportArgs builds the argv for the port-mapping probe.
+func portsReportArgs(appName string) []string {
+	return []string{"--quiet", "ports:report", appName, "--ports-map-json"}
+}
+
+// parsePortsMapReport decodes the payload `ports:report --ports-map-json` emits
+// into the mapping set getPorts hands back, keyed by scheme:host:container.
+//
+// An app with no mappings reports `null` - dokku marshals a nil slice - and a
+// dokku that could not read the property reports `[]`; both decode to no
+// entries. An empty payload is treated the same, since it can only mean the
+// command produced nothing at all. Anything else that is not valid JSON is an
+// error, where the text form this replaced silently dropped the mapping.
+func parsePortsMapReport(raw []byte) (map[string]PortMapping, error) {
+	mappings := map[string]PortMapping{}
+	if len(raw) == 0 {
+		return mappings, nil
+	}
+
+	var entries []portsMapEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("parse ports:report --ports-map-json: %w", err)
+	}
+
+	for _, entry := range entries {
+		mapping := PortMapping{
+			Scheme:    entry.Scheme,
+			Host:      entry.HostPort,
+			Container: entry.ContainerPort,
+		}
+		mappings[mapping.String()] = mapping
+	}
+
+	return mappings, nil
+}
+
 // getPorts gets the ports for a given app. A transport-level failure
 // (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit
-// (e.g. app does not exist) is treated as "no ports configured."
+// (e.g. app does not exist) is treated as "no ports configured." A report
+// that comes back but does not decode is an error: dokku marshals the
+// mappings itself, so a payload it cannot produce means something is wrong
+// rather than that a mapping is missing.
 func getPorts(ctx context.Context, appName string) (map[string]PortMapping, error) {
-	// dokku master has a --ports-map-json that would replace this text parse,
-	// but it is not in a release yet; see #431.
 	result, err := subprocess.CallExecCommand(ctx, subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"ports:report",
-			appName,
-			"--ports-map",
-		},
+		Args:    portsReportArgs(appName),
 	})
 	if err != nil {
 		var sshErr *subprocess.SSHError
@@ -396,32 +438,7 @@ func getPorts(ctx context.Context, appName string) (map[string]PortMapping, erro
 		return map[string]PortMapping{}, nil
 	}
 
-	portMappings := map[string]PortMapping{}
-	for _, mapping := range strings.Fields(result.StdoutContents()) {
-		parts := strings.Split(mapping, ":")
-		if len(parts) != 3 {
-			continue
-		}
-
-		scheme := parts[0]
-		host, err := strconv.Atoi(parts[1])
-		if err != nil {
-			continue
-		}
-
-		container, err := strconv.Atoi(parts[2])
-		if err != nil {
-			continue
-		}
-
-		portMappings[mapping] = PortMapping{
-			Scheme:    scheme,
-			Host:      host,
-			Container: container,
-		}
-	}
-
-	return portMappings, nil
+	return parsePortsMapReport(result.StdoutBytes())
 }
 
 // init registers the PortsTask with the task registry

--- a/tasks/ports_task_integration_test.go
+++ b/tasks/ports_task_integration_test.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -9,17 +11,27 @@ import (
 )
 
 // getReportedPorts queries dokku ports:report to get the current mappings for
-// an app, so assertions do not lean on the task's own probe.
+// an app, so assertions do not lean on the task's own probe. It decodes the
+// report itself rather than calling getPorts or parsePortsMapReport: a bug in
+// either would otherwise be masked by the assertion that is meant to catch it.
 func getReportedPorts(appName string) []string {
 	result, err := subprocess.CallExecCommand(testCtx(), subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    []string{"--quiet", "ports:report", appName, "--ports-map"},
+		Args:    []string{"--quiet", "ports:report", appName, "--ports-map-json"},
 	})
 	if err != nil {
 		return nil
 	}
 
-	mappings := strings.Fields(result.StdoutContents())
+	var entries []portsMapEntry
+	if err := json.Unmarshal(result.StdoutBytes(), &entries); err != nil {
+		return nil
+	}
+
+	mappings := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		mappings = append(mappings, fmt.Sprintf("%s:%d:%d", entry.Scheme, entry.HostPort, entry.ContainerPort))
+	}
 	sort.Strings(mappings)
 	return mappings
 }

--- a/tasks/ports_task_test.go
+++ b/tasks/ports_task_test.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -148,12 +150,12 @@ func TestPortsTaskValidatePerItem(t *testing.T) {
 }
 
 // portsReportKey is the fakeDokku key for the probe getPorts runs.
-const portsReportKey = "--quiet ports:report web --ports-map"
+const portsReportKey = "--quiet ports:report web --ports-map-json"
 
 func TestPortsSetPlansFullReplacement(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "http:80:5000 https:443:5000",
+		portsReportKey: `[{"container_port":5000,"host_port":80,"scheme":"http"},{"container_port":5000,"host_port":443,"scheme":"https"}]`,
 	}))
 
 	plan := PortsTask{
@@ -186,7 +188,7 @@ func TestPortsSetPlansFullReplacement(t *testing.T) {
 func TestPortsSetOnAppWithNoMappingsIsACreate(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "",
+		portsReportKey: "null",
 	}))
 
 	plan := PortsTask{
@@ -205,7 +207,7 @@ func TestPortsSetOnAppWithNoMappingsIsACreate(t *testing.T) {
 func TestPortsSetConvergesWhenReportMatches(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "https:443:5000 http:80:5000",
+		portsReportKey: `[{"container_port":5000,"host_port":443,"scheme":"https"},{"container_port":5000,"host_port":80,"scheme":"http"}]`,
 	}))
 
 	plan := PortsTask{
@@ -230,7 +232,7 @@ func TestPortsSetConvergesWhenReportMatches(t *testing.T) {
 func TestPortsClearPlansEveryMapping(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "http:80:5000 https:443:5000",
+		portsReportKey: `[{"container_port":5000,"host_port":80,"scheme":"http"},{"container_port":5000,"host_port":443,"scheme":"https"}]`,
 	}))
 
 	plan := PortsTask{App: "web", State: StateClear}.Plan(ctx)
@@ -259,7 +261,7 @@ func TestPortsClearPlansEveryMapping(t *testing.T) {
 func TestPortsClearIsInSyncWithoutMappings(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "",
+		portsReportKey: "null",
 	}))
 
 	plan := PortsTask{App: "web", State: StateClear}.Plan(ctx)
@@ -277,7 +279,7 @@ func TestPortsClearIsInSyncWithoutMappings(t *testing.T) {
 func TestPortsPresentPlansOnlyTheMissingMappings(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "http:80:5000",
+		portsReportKey: `[{"container_port":5000,"host_port":80,"scheme":"http"}]`,
 	}))
 
 	plan := PortsTask{
@@ -309,7 +311,7 @@ func TestPortsPresentPlansOnlyTheMissingMappings(t *testing.T) {
 func TestPortsPresentRejectsCollisionWithAnExistingMapping(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "http:80:5000",
+		portsReportKey: `[{"container_port":5000,"host_port":80,"scheme":"http"}]`,
 	}))
 
 	plan := PortsTask{
@@ -331,7 +333,7 @@ func TestPortsPresentRejectsCollisionWithAnExistingMapping(t *testing.T) {
 func TestPortsPresentAllowsTheSameHostPortUnderAnotherScheme(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "http:80:5000",
+		portsReportKey: `[{"container_port":5000,"host_port":80,"scheme":"http"}]`,
 	}))
 
 	plan := PortsTask{
@@ -353,7 +355,7 @@ func TestPortsPresentAllowsTheSameHostPortUnderAnotherScheme(t *testing.T) {
 func TestPortsAbsentPlansOnlyThePresentMappings(t *testing.T) {
 	t.Parallel()
 	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
-		portsReportKey: "http:80:5000",
+		portsReportKey: `[{"container_port":5000,"host_port":80,"scheme":"http"}]`,
 	}))
 
 	plan := PortsTask{
@@ -495,5 +497,188 @@ func TestGetTasksPortsTaskClearWithoutMappings(t *testing.T) {
 	}
 	if err := portsTask.Validate(); err != nil {
 		t.Errorf("clear without port_mappings should validate, got: %v", err)
+	}
+}
+
+// TestPortsReportArgs pins the probe's argv. fakeDokku keys on the joined
+// args, so a flag change that slipped through here would turn every ports
+// fixture lookup into a miss and leave the "no mappings" tests passing for the
+// wrong reason.
+func TestPortsReportArgs(t *testing.T) {
+	t.Parallel()
+	want := []string{"--quiet", "ports:report", "web", "--ports-map-json"}
+	if got := portsReportArgs("web"); !reflect.DeepEqual(got, want) {
+		t.Errorf("portsReportArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestParsePortsMapReport(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		raw     string
+		want    map[string]PortMapping
+		wantErr string
+	}{
+		{
+			name: "single mapping",
+			raw:  `[{"container_port":5000,"host_port":80,"scheme":"http"}]`,
+			want: map[string]PortMapping{
+				"http:80:5000": {Scheme: "http", Host: 80, Container: 5000},
+			},
+		},
+		{
+			name: "several mappings",
+			raw:  `[{"container_port":5000,"host_port":80,"scheme":"http"},{"container_port":5000,"host_port":443,"scheme":"https"}]`,
+			want: map[string]PortMapping{
+				"http:80:5000":   {Scheme: "http", Host: 80, Container: 5000},
+				"https:443:5000": {Scheme: "https", Host: 443, Container: 5000},
+			},
+		},
+		{
+			// dokku marshals a nil slice for an app with no mappings.
+			name: "null is no mappings",
+			raw:  "null",
+			want: map[string]PortMapping{},
+		},
+		{
+			// dokku reports [] when it could not read the map property.
+			name: "empty array is no mappings",
+			raw:  "[]",
+			want: map[string]PortMapping{},
+		},
+		{
+			name: "empty payload is no mappings",
+			raw:  "",
+			want: map[string]PortMapping{},
+		},
+		{
+			// dokku records a bare host port under the __internal__ scheme with
+			// no container port. It round-trips unchanged, as it did under the
+			// scheme:host:container text form this replaced.
+			name: "internal scheme round-trips",
+			raw:  `[{"container_port":0,"host_port":5000,"scheme":"__internal__"}]`,
+			want: map[string]PortMapping{
+				"__internal__:5000:0": {Scheme: "__internal__", Host: 5000, Container: 0},
+			},
+		},
+		{
+			name: "duplicate entries collapse on the mapping key",
+			raw:  `[{"container_port":5000,"host_port":80,"scheme":"http"},{"container_port":5000,"host_port":80,"scheme":"http"}]`,
+			want: map[string]PortMapping{
+				"http:80:5000": {Scheme: "http", Host: 80, Container: 5000},
+			},
+		},
+		{
+			// The text parse dropped every token it could not read; the decode
+			// says so instead.
+			name:    "malformed payload errors",
+			raw:     "not json",
+			wantErr: "parse ports:report --ports-map-json",
+		},
+		{
+			// A report polluted by a banner is rejected whole rather than
+			// having the banner silently skipped and the mappings kept.
+			name:    "banner-prefixed payload errors",
+			raw:     "Deprecated: use something else\n[{\"container_port\":5000,\"host_port\":80,\"scheme\":\"http\"}]",
+			wantErr: "parse ports:report --ports-map-json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePortsMapReport([]byte(tt.raw))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error %q, got: %v", tt.wantErr, err)
+				}
+				if got != nil {
+					t.Errorf("expected no mappings alongside the error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parsePortsMapReport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPortsProbeSurfacesSSHError pins that an unreachable host is a plan error
+// rather than an app that happens to have no mappings, which would have
+// state 'clear' and 'absent' report in sync against a server never contacted.
+func TestPortsProbeSurfacesSSHError(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
+			Host:   "dokku@unreachable",
+			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
+		}
+	})
+
+	plan := PortsTask{App: "web", State: StateClear}.Plan(ctx)
+	if plan.Error == nil {
+		t.Fatal("expected a plan error when the transport fails")
+	}
+	var sshErr *subprocess.SSHError
+	if !errors.As(plan.Error, &sshErr) {
+		t.Errorf("expected the SSHError to survive, got %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Error("expected drift rather than in-sync when the probe could not run")
+	}
+}
+
+// TestPortsProbeTreatsDokkuFailureAsNoMappings pins the deliberate other half
+// of the split: a dokku-level non-zero exit means the app does not exist yet,
+// so plan reports the full list as an add rather than failing outright.
+func TestPortsProbeTreatsDokkuFailureAsNoMappings(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 1}, &subprocess.ExecError{
+			Response: subprocess.ExecCommandResponse{ExitCode: 1, Stderr: "App web does not exist"},
+			Err:      errors.New("exit status 1"),
+			Ran:      true,
+		}
+	})
+
+	plan := PortsTask{
+		App:          "web",
+		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}},
+		State:        StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusCreate)
+	}
+	want := []string{"add http:80:5000"}
+	if !reflect.DeepEqual(plan.Mutations, want) {
+		t.Errorf("Mutations = %v, want %v", plan.Mutations, want)
+	}
+}
+
+// TestPortsProbeSurfacesMalformedReport is the behaviour the JSON report buys:
+// a report dokku could not have produced is an error, where the text parse
+// dropped the unreadable mappings and reported the rest as the whole truth.
+func TestPortsProbeSurfacesMalformedReport(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(map[string]string{
+		portsReportKey: "not json",
+	}))
+
+	plan := PortsTask{App: "web", State: StateClear}.Plan(ctx)
+	if plan.Error == nil {
+		t.Fatal("expected a plan error when the report does not decode")
+	}
+	if !strings.Contains(plan.Error.Error(), "parse ports:report --ports-map-json") {
+		t.Errorf("unexpected error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Error("expected drift rather than in-sync when the report could not be read")
 	}
 }


### PR DESCRIPTION
The text form silently dropped any mapping it could not read, so a malformed report surfaced as drift that never converged, or as an export quietly missing a port, rather than as an error. dokku emits the mappings as JSON as of `0.38.27`, which docket's documented floor already requires.

Closes #431