### PR TITLE
feat: probe dokku_git_auth with git:auth-status

### DIFF
--- a/commands/list_tasks_masking_test.go
+++ b/commands/list_tasks_masking_test.go
@@ -357,13 +357,14 @@ func TestListTasksDoesNotMaskStructuralDecorations(t *testing.T) {
     - name: gate
       block:
         - name: unprobeable
-          dokku_git_auth:
-            host: github.com
+          dokku_registry_auth:
+            global: true
+            server: docker.io
             username: u
             password: p
 `)
 
-	stdout, stderr, exit := runApply(t, path, "--secret_value=netrc", "--list-tasks", "--json")
+	stdout, stderr, exit := runApply(t, path, "--secret_value=registry", "--list-tasks", "--json")
 	if exit != 0 {
 		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
 	}
@@ -373,7 +374,7 @@ func TestListTasksDoesNotMaskStructuralDecorations(t *testing.T) {
 			t.Errorf("masking must not touch %s; got:\n%s", want, stdout)
 		}
 	}
-	if !strings.Contains(stdout, `"probe_caveat":"*** state has no read command`) {
+	if !strings.Contains(stdout, `"probe_caveat":"*** login state has no read command`) {
 		t.Errorf("expected the prose caveat to be masked; got:\n%s", stdout)
 	}
 

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -100,8 +100,9 @@ func TestApplyListTasksMarksProbeSupport(t *testing.T) {
 	path := writeTasksFile(t, `---
 - tasks:
     - name: unprobeable
-      dokku_git_auth:
-        host: github.com
+      dokku_registry_auth:
+        global: true
+        server: docker.io
         username: deploy-bot
         password: examplepassword
     - name: partially probed

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -404,7 +404,7 @@ running anything:
 $ docket apply --list-tasks
 ==> Play: api
 [0] dokku apps:create api  [tags=core]
-[1] dokku git:auth github.com  (never converges)
+[1] dokku registry:login docker.io  (never converges)
 [2] dokku git:from-image api  (partial probe)
 ```
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -30,7 +30,7 @@ A task marked `(never converges)` cannot read its own state, so it plans as drif
 - [dokku_docker_options](dokku_docker_options.md) - Manages docker-options for a given dokku application
 - [dokku_domains](dokku_domains.md) - Manages the domains for a given dokku application or globally
 - [dokku_domains_toggle](dokku_domains_toggle.md) - Enables or disables the domains plugin for a given dokku application
-- [dokku_git_auth](dokku_git_auth.md) - Manages netrc credentials for a git host (never converges)
+- [dokku_git_auth](dokku_git_auth.md) - Manages netrc credentials for a git host
 - [dokku_git_from_archive](dokku_git_from_archive.md) - Deploys a git repository from an archive URL
 - [dokku_git_from_image](dokku_git_from_image.md) - Deploys a git repository from a docker image
 - [dokku_git_property](dokku_git_property.md) - Manages the git configuration for a given dokku application

--- a/docs/tasks/dokku_git_auth.md
+++ b/docs/tasks/dokku_git_auth.md
@@ -10,7 +10,7 @@ Not supported - netrc credentials are write-only and cannot be read back.
 
 ## Probe support
 
-Not supported - netrc state has no read command, so the task plans as drift on every run.
+Supported.
 
 ## Identity
 
@@ -22,7 +22,7 @@ Keyed by `host`.
 | --- | --- | --- | --- | --- | --- |
 | `host` | string | yes |  |  | Git server hostname (e.g. github.com) |
 | `username` | string | no |  |  | Netrc username. Required when state is present. |
-| `password` | string | no |  |  | Netrc password. Required when state is present. (sensitive) |
+| `password` | string | no |  |  | Netrc password. Required when state is present. Must not contain a newline. (sensitive) |
 | `state` | string | no | present | present, absent | Desired state of the netrc entry |
 
 ## Examples

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -3,17 +3,23 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/dokku/docket/subprocess"
 )
 
 // GitAuthTask manages netrc credentials for a git host via dokku git:auth.
 //
-// Idempotency is intentionally skipped here because dokku has no public way
-// to query the current netrc state (the file lives at $DOKKU_ROOT/.netrc with
-// mode 0600). Tracking upstream support in dokku/dokku#8504; once a
-// no-change exit code is available, this task should switch to using it
-// instead of always reporting Changed=true.
+// The netrc file itself is unreadable (mode 0600 under $DOKKU_ROOT) and there
+// is no report that dumps it, but idempotency does not need one: dokku's
+// git:auth-status compares the stored entry against credentials it is handed
+// and answers with its exit code, which is the only question Plan() asks. See
+// gitAuthMatches for the two shapes that answers.
+//
+// The password never reaches argv on either path. Both git:auth and
+// git:auth-status read it from stdin when the username is supplied and the
+// password argument is omitted, so it stays out of the plan output, the trace
+// log, and the process table on the dokku host.
 type GitAuthTask struct {
 	// Host is the git server hostname (e.g. github.com)
 	Host string `required:"true" identity:"key" yaml:"host" description:"Git server hostname (e.g. github.com)"`
@@ -22,7 +28,7 @@ type GitAuthTask struct {
 	Username string `required:"false" yaml:"username,omitempty" description:"Netrc username. Required when state is present."`
 
 	// Password is the netrc password. Required when state is present.
-	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"Netrc password. Required when state is present."`
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"Netrc password. Required when state is present. Must not contain a newline."`
 
 	// State is the desired state of the netrc entry
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the netrc entry"`
@@ -48,13 +54,18 @@ func (t GitAuthTask) Doc() string {
 }
 
 // ExportSupport reports how docket export handles this task.
+//
+// Probing and exporting ask different questions of the same command:
+// git:auth-status confirms credentials the recipe already holds, but it cannot
+// enumerate the hosts with an entry and never reveals a stored username, so
+// there is still nothing for an exporter to reconstruct.
 func (t GitAuthTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportUnsupported, Caveat: "netrc credentials are write-only and cannot be read back"}
 }
 
 // ProbeSupport reports whether Plan() can read this task's current state.
 func (t GitAuthTask) ProbeSupport() ProbeSupport {
-	return ProbeSupport{Status: ProbeUnsupported, Caveat: "netrc state has no read command, so the task plans as drift on every run"}
+	return ProbeSupport{Status: ProbeSupported}
 }
 
 // Examples returns the examples for the git auth task
@@ -91,26 +102,40 @@ func (t GitAuthTask) Validate() error {
 	if t.State == StatePresent && (t.Username == "" || t.Password == "") {
 		return fmt.Errorf("'username' and 'password' are required when state is 'present'")
 	}
+	// dokku reads the password with `read -r`, which stops at the first
+	// newline, and a .netrc entry is a single line either way. Rejecting it
+	// here is the difference between a clear error and a task that silently
+	// writes a truncated password and then never converges.
+	if strings.ContainsAny(t.Password, "\r\n") {
+		return fmt.Errorf("'password' must not contain a newline")
+	}
 	return nil
 }
 
-// Plan reports the drift the GitAuthTask would produce. dokku has no public
-// way to query netrc state, so the plan reports drift unconditionally.
+// Plan reports the drift the GitAuthTask would produce.
 func (t GitAuthTask) Plan(ctx context.Context) PlanResult {
 	if err := t.Validate(); err != nil {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
+			matches, err := gitAuthMatches(ctx, t.Host, t.Username, t.Password)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if matches {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
+				Args:    []string{"--quiet", "git:auth", t.Host, t.Username},
+				Stdin:   strings.NewReader(t.Password),
 			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    "netrc state not probed",
-				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " " + t.Password},
+				Reason:    "netrc entry does not match",
+				Mutations: []string{"git:auth " + t.Host + " as " + t.Username},
 				Commands:  resolveCommands(ctx, inputs),
 				apply: func(ctx context.Context) TaskOutputState {
 					return runExecInputs(ctx, TaskOutputState{State: StateAbsent}, StatePresent, inputs)
@@ -118,6 +143,13 @@ func (t GitAuthTask) Plan(ctx context.Context) PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
+			cleared, err := gitAuthMatches(ctx, t.Host, "", "")
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if cleared {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
 				Args:    []string{"--quiet", "git:auth", t.Host},
@@ -125,7 +157,7 @@ func (t GitAuthTask) Plan(ctx context.Context) PlanResult {
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
-				Reason:    "netrc state not probed",
+				Reason:    "netrc entry present",
 				Mutations: []string{"git:auth " + t.Host + " (clear)"},
 				Commands:  resolveCommands(ctx, inputs),
 				apply: func(ctx context.Context) TaskOutputState {
@@ -134,6 +166,34 @@ func (t GitAuthTask) Plan(ctx context.Context) PlanResult {
 			}
 		},
 	})
+}
+
+// gitAuthMatches reports whether the netrc entry for host already matches the
+// requested state. git:auth-status is a comparator rather than a dump: it
+// prints nothing and exits 0 when the stored entry equals what it was handed.
+// Handed no username it answers the absent-state question instead - exit 0
+// when the host has no entry at all.
+//
+// The password goes over stdin, where dokku's fn-git-auth-read-password picks
+// it up, so it never reaches the argv of the dokku process on the server.
+//
+// Returns (false, err) when the probe could not run - a transport failure, a
+// missing dokku binary, or a cancellation; (true, nil) when the server is
+// already in the requested state; (false, nil) otherwise. A "no" is one answer
+// and not two: git:auth-status exits non-zero both for a host with no entry
+// and for a host whose entry differs, so the present-state plan reports a
+// modify rather than telling a create apart from a replacement. Tracking
+// distinct exit codes upstream in dokku/dokku#8995.
+func gitAuthMatches(ctx context.Context, host, username, password string) (bool, error) {
+	input := subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "git:auth-status", host},
+	}
+	if username != "" {
+		input.Args = append(input.Args, username)
+		input.Stdin = strings.NewReader(password)
+	}
+	return subprocess.Probe(ctx, input)
 }
 
 // init registers the GitAuthTask with the task registry

--- a/tasks/git_auth_task_integration_test.go
+++ b/tasks/git_auth_task_integration_test.go
@@ -34,6 +34,30 @@ func TestIntegrationGitAuth(t *testing.T) {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
 
+	// re-applying the same credentials is a no-op. This is the end-to-end
+	// proof that git:auth-status compared what git:auth wrote, password
+	// included - both of which travelled on stdin.
+	result = setTask.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed to re-apply git auth: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false when the netrc entry already matches")
+	}
+
+	// a rotated password is drift even though the host and username are
+	// unchanged, so the probe has to be comparing the secret and not just
+	// the entry's existence.
+	rotateTask := setTask
+	rotateTask.Password = "rotated-token"
+	result = rotateTask.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed to rotate git auth: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true when the password changed")
+	}
+
 	// remove credentials
 	unsetTask := GitAuthTask{Host: host, State: StateAbsent}
 	result = unsetTask.Execute(testCtx())
@@ -45,5 +69,14 @@ func TestIntegrationGitAuth(t *testing.T) {
 	}
 	if result.State != StateAbsent {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+
+	// removing an entry that is already gone is a no-op
+	result = unsetTask.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed to re-unset git auth: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false when the host has no netrc entry")
 	}
 }

--- a/tasks/git_auth_task_test.go
+++ b/tasks/git_auth_task_test.go
@@ -1,8 +1,14 @@
 package tasks
 
 import (
+	"context"
+	"errors"
+	"io"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestGitAuthTaskInvalidState(t *testing.T) {
@@ -85,5 +91,254 @@ func TestGetTasksGitAuthTaskParsedCorrectly(t *testing.T) {
 	}
 	if authTask.State != StatePresent {
 		t.Errorf("State = %q, want %q", authTask.State, StatePresent)
+	}
+}
+
+func TestGitAuthTaskPasswordWithNewline(t *testing.T) {
+	task := GitAuthTask{Host: "github.com", Username: "u", Password: "line1\nline2", State: StatePresent}
+	result := task.Execute(testCtx())
+	if result.Error == nil {
+		t.Fatal("Execute with a multi-line password should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'password' must not contain a newline") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+// TestGitAuthTaskRejectsNewlineBeforeProbing pins the point of the newline
+// rule: dokku's `read -r` would stop at the first line, so the probe would
+// compare a truncated password and the task would never converge. Validate()
+// runs first, so the recipe is rejected before a secret leaves the machine.
+func TestGitAuthTaskRejectsNewlineBeforeProbing(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	ctx := subprocess.ContextWithRunner(testCtx(), recordingDokku(nil, &calls))
+
+	plan := GitAuthTask{Host: "github.com", Username: "u", Password: "a\nb", State: StatePresent}.Plan(ctx)
+	if plan.Error == nil {
+		t.Fatal("expected a plan error for a multi-line password")
+	}
+	if len(calls) != 0 {
+		t.Errorf("expected no dokku calls, got %v", calls)
+	}
+}
+
+// gitAuthDrifted stubs every dokku call as a clean non-zero exit, which is how
+// subprocess.Probe reports git:auth-status saying "the stored entry is not what
+// you handed me". fakeDokku always exits 0, so it can only express the in-sync
+// case.
+func gitAuthDrifted() func(context.Context, subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	return func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 1}, nil
+	}
+}
+
+func TestGitAuthTaskPresentInSync(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(nil))
+
+	plan := GitAuthTask{
+		Host:     "github.com",
+		Username: "deploy-bot",
+		Password: "ghp_examplepat",
+		State:    StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want an in-sync ok", plan.InSync, plan.Status)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("an in-sync plan must issue no commands, got %v", plan.Commands)
+	}
+}
+
+func TestGitAuthTaskPresentDrifts(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), gitAuthDrifted())
+
+	plan := GitAuthTask{
+		Host:     "github.com",
+		Username: "deploy-bot",
+		Password: "ghp_examplepat",
+		State:    StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusModify {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want a modify", plan.InSync, plan.Status)
+	}
+	if plan.Reason != "netrc entry does not match" {
+		t.Errorf("Reason = %q, want %q", plan.Reason, "netrc entry does not match")
+	}
+	if !reflect.DeepEqual(plan.Mutations, []string{"git:auth github.com as deploy-bot"}) {
+		t.Errorf("Mutations = %v, want [git:auth github.com as deploy-bot]", plan.Mutations)
+	}
+	if len(plan.Commands) != 1 || !strings.HasSuffix(plan.Commands[0], "git:auth github.com deploy-bot") {
+		t.Fatalf("expected a single git:auth command, got %v", plan.Commands)
+	}
+	// The password rides on stdin, so neither the rendered command nor the
+	// itemized mutations may carry it.
+	for _, s := range append(append([]string{}, plan.Commands...), plan.Mutations...) {
+		if strings.Contains(s, "ghp_examplepat") {
+			t.Errorf("password leaked into plan output: %q", s)
+		}
+	}
+}
+
+func TestGitAuthTaskAbsentInSync(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(nil))
+
+	plan := GitAuthTask{Host: "github.com", State: StateAbsent}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want an in-sync ok", plan.InSync, plan.Status)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("an in-sync plan must issue no commands, got %v", plan.Commands)
+	}
+}
+
+func TestGitAuthTaskAbsentDrifts(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), gitAuthDrifted())
+
+	plan := GitAuthTask{Host: "github.com", State: StateAbsent}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusDestroy {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want a destroy", plan.InSync, plan.Status)
+	}
+	if plan.Reason != "netrc entry present" {
+		t.Errorf("Reason = %q, want %q", plan.Reason, "netrc entry present")
+	}
+	if len(plan.Commands) != 1 || !strings.HasSuffix(plan.Commands[0], "git:auth github.com") {
+		t.Fatalf("expected a single git:auth command, got %v", plan.Commands)
+	}
+}
+
+// TestGitAuthTaskProbeArgs pins the argv of both probe shapes. The present-state
+// probe has to name the username for git:auth-status to compare anything, and
+// it must stop there: a third positional would put the password in the dokku
+// host's process table, which is the whole reason it goes over stdin.
+func TestGitAuthTaskProbeArgs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		task GitAuthTask
+		want string
+	}{
+		{
+			name: "present compares the credentials",
+			task: GitAuthTask{Host: "github.com", Username: "deploy-bot", Password: "ghp_examplepat", State: StatePresent},
+			want: "--quiet git:auth-status github.com deploy-bot",
+		},
+		{
+			name: "absent asks whether any entry exists",
+			task: GitAuthTask{Host: "github.com", State: StateAbsent},
+			want: "--quiet git:auth-status github.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var calls []string
+			ctx := subprocess.ContextWithRunner(testCtx(), recordingDokku(nil, &calls))
+
+			tc.task.Plan(ctx)
+			if len(calls) != 1 {
+				t.Fatalf("expected exactly one probe call, got %v", calls)
+			}
+			if calls[0] != tc.want {
+				t.Errorf("probe args = %q, want %q", calls[0], tc.want)
+			}
+		})
+	}
+}
+
+// TestGitAuthTaskStreamsPasswordToProbeAndApply asserts the payload that never
+// appears in plan output: resolveCommands ignores Stdin, so the only way to see
+// what git:auth-status and git:auth receive is to read the reader off each exec
+// input. Both readers are collected because they must be distinct - an
+// io.Reader is single-use, so a probe sharing the apply's reader would leave
+// the apply with an empty stream and dokku would fail on a missing password.
+func TestGitAuthTaskStreamsPasswordToProbeAndApply(t *testing.T) {
+	t.Parallel()
+	var payloads []string
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		if in.Stdin != nil {
+			b, err := io.ReadAll(in.Stdin)
+			if err != nil {
+				t.Fatalf("read stdin: %v", err)
+			}
+			payloads = append(payloads, string(b))
+		}
+		// A non-zero exit from the probe is what drives the plan on to the
+		// apply, so both stdin payloads are observed in one Execute.
+		return subprocess.ExecCommandResponse{ExitCode: 1}, nil
+	})
+
+	GitAuthTask{
+		Host:     "github.com",
+		Username: "deploy-bot",
+		Password: "ghp_examplepat",
+		State:    StatePresent,
+	}.Execute(ctx)
+
+	want := []string{"ghp_examplepat", "ghp_examplepat"}
+	if !reflect.DeepEqual(payloads, want) {
+		t.Errorf("stdin payloads = %q, want %q", payloads, want)
+	}
+}
+
+// TestGitAuthTaskAbsentSendsNoStdin keeps the absent probe from handing dokku a
+// password it has no username to compare it against, which would make
+// git:auth-status fail on "Missing password" instead of answering.
+func TestGitAuthTaskAbsentSendsNoStdin(t *testing.T) {
+	t.Parallel()
+	sawStdin := false
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		if in.Stdin != nil {
+			sawStdin = true
+		}
+		return subprocess.ExecCommandResponse{}, nil
+	})
+
+	GitAuthTask{Host: "github.com", Username: "deploy-bot", Password: "ghp_examplepat", State: StateAbsent}.Plan(ctx)
+	if sawStdin {
+		t.Error("the absent-state probe must not stream a password")
+	}
+}
+
+// TestGitAuthTaskProbeTransportFailure keeps an unreachable host from reading
+// as drift. subprocess.Probe only folds a command that ran and exited non-zero
+// into a false verdict; an *SSHError has to reach the plan so it renders [!]
+// rather than optimistically predicting a change.
+func TestGitAuthTaskProbeTransportFailure(t *testing.T) {
+	t.Parallel()
+	for _, st := range []State{StatePresent, StateAbsent} {
+		ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+			return subprocess.ExecCommandResponse{}, &subprocess.SSHError{Host: "dokku@example.com", Err: errors.New("connection refused")}
+		})
+
+		plan := GitAuthTask{
+			Host:     "github.com",
+			Username: "deploy-bot",
+			Password: "ghp_examplepat",
+			State:    st,
+		}.Plan(ctx)
+		if plan.Error == nil {
+			t.Fatalf("state=%s: expected the transport failure to surface as a plan error", st)
+		}
+		if plan.Status != PlanStatusError {
+			t.Errorf("state=%s: Status = %q, want %q", st, plan.Status, PlanStatusError)
+		}
 	}
 }

--- a/tasks/probe_support_test.go
+++ b/tasks/probe_support_test.go
@@ -40,12 +40,12 @@ func TestTaskProbeSupportSupported(t *testing.T) {
 }
 
 func TestTaskProbeSupportUnsupportedCarriesCaveat(t *testing.T) {
-	support, ok := TaskProbeSupport(&GitAuthTask{})
+	support, ok := TaskProbeSupport(&RegistryAuthTask{})
 	if !ok {
-		t.Fatal("expected GitAuthTask to declare ProbeSupport()")
+		t.Fatal("expected RegistryAuthTask to declare ProbeSupport()")
 	}
 	if support.Status != ProbeUnsupported {
-		t.Errorf("expected GitAuthTask to be %q, got %q", ProbeUnsupported, support.Status)
+		t.Errorf("expected RegistryAuthTask to be %q, got %q", ProbeUnsupported, support.Status)
 	}
 	if !contains(support.Caveat, "no read command") {
 		t.Errorf("expected the caveat to explain the missing read command, got %q", support.Caveat)

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -17,7 +17,7 @@ import (
 // <service>:backup-schedule-cat. The auth and encryption pieces have no
 // read command, so when those fields are provided they are applied
 // unconditionally and the task reports Changed=true, mirroring the
-// no-probe pattern used by dokku_git_auth and dokku_registry_auth.
+// no-probe pattern used by dokku_registry_auth.
 type ServiceBackupTask struct {
 	// Service is the type of service to back up (e.g. redis, postgres, mysql)
 	Service string `required:"true" identity:"key" yaml:"service" description:"Type of service to back up (e.g. redis, postgres, mysql)"`

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -325,9 +325,10 @@ EOF
   write_tasks_file <<EOF
 ---
 - tasks:
-    - name: git auth
-      dokku_git_auth:
-        host: github.com
+    - name: registry auth
+      dokku_registry_auth:
+        global: true
+        server: docker.io
         username: deploy-bot
         password: examplepassword
     - name: create app
@@ -335,7 +336,7 @@ EOF
 EOF
   run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
   assert_success
-  assert_output --partial "git auth  (never converges)"
+  assert_output --partial "registry auth  (never converges)"
   refute_output --partial "create app  (never converges)"
 }
 
@@ -357,9 +358,10 @@ EOF
   write_tasks_file <<EOF
 ---
 - tasks:
-    - name: git auth
-      dokku_git_auth:
-        host: github.com
+    - name: registry auth
+      dokku_registry_auth:
+        global: true
+        server: docker.io
         username: deploy-bot
         password: examplepassword
 EOF

--- a/tests/bats/ssh.bats
+++ b/tests/bats/ssh.bats
@@ -2,15 +2,21 @@
 
 load test_helper
 
+# SSH_GIT_AUTH_HOST is a hostname docket never contacts; it only ever names a
+# netrc entry on the dokku server.
+SSH_GIT_AUTH_HOST="docket-test-ssh.example.com"
+
 setup() {
   require_remote_dokku
   docket_build
   ssh_clean_app
+  ssh_clean_git_auth
 }
 
 teardown() {
   if [ -n "${DOCKET_TEST_REMOTE_HOST:-}" ]; then
     ssh_clean_app || true
+    ssh_clean_git_auth || true
   fi
 }
 
@@ -22,6 +28,14 @@ ssh_clean_app() {
   if ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku apps:exists $app" >/dev/null 2>&1; then
     ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku --force apps:destroy $app" >/dev/null 2>&1 || true
   fi
+}
+
+# ssh_clean_git_auth drops the per-test netrc entry on the remote host.
+# git:auth with no username clears the host, and is a no-op when there is
+# nothing to clear.
+ssh_clean_git_auth() {
+  ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" \
+    "dokku --quiet git:auth $SSH_GIT_AUTH_HOST" >/dev/null 2>&1 || true
 }
 
 @test "DOKKU_HOST routes apply through ssh" {
@@ -143,6 +157,37 @@ EOF
   run ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku ps:report docket-test-ssh --format json"
   assert_success
   assert_output --partial "npm run start"
+}
+
+# The netrc password reaches dokku on stdin rather than on argv, and dokku only
+# reads it when stdin is a pipe. Locally that is guaranteed by os/exec; over ssh
+# it depends on how sshd wires the remote command's stdin, which nothing else in
+# the suite exercises. A converging re-plan is the proof: the probe could only
+# have matched if git:auth-status received the same password git:auth stored.
+@test "dokku_git_auth converges over ssh with the password on stdin" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: configure git auth
+      dokku_git_auth:
+        host: $SSH_GIT_AUTH_HOST
+        username: deploy-bot
+        password: ghp_examplepat
+EOF
+  DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[changed]"
+
+  DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "0 would change"
+  refute_output --partial "[~]"
+
+  # The password is masked in the run's own output, but it must not be on the
+  # remote argv either - that is what stdin buys.
+  DOKKU_TRACE=1 DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  refute_output --partial "ghp_examplepat"
 }
 
 # argv_recipe is the one-task recipe the transport-argv cases below plan


### PR DESCRIPTION
`git:auth-status` compares the stored netrc entry against the credentials it is handed and answers with its exit code, which is exactly the question `Plan()` asks, so the task now converges instead of reporting drift on every run and a recipe containing one can reach `plan --detailed-exitcode` exit 0. The password moves from argv to stdin on both the probe and the apply so it stays out of the process table on the dokku host, and a password containing a newline is rejected up front because that transport cannot carry one. `docket export` is unchanged: `git:auth-status` can neither enumerate the hosts with an entry nor reveal a stored username, so there is still nothing to reconstruct.

A drifted host reports a modify rather than distinguishing "no entry yet" from "the stored credentials differ", because `git:auth-status` answers both the same way and telling them apart would cost a second round trip on every drifted task. dokku/dokku#8995 tracks giving those cases distinct exit codes upstream.

Closes #524
