### PR TITLE
feat: probe certificate material with certs:show

### DIFF
--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -246,7 +246,7 @@ dokku plugin the row needs; blank means dokku core.
 | `dokku_app` | `dokku_app` | | Direct. |
 | `dokku_builder` | `dokku_builder_property` | | Direct; both wrap `builder:set`. |
 | `dokku_buildpacks` | `dokku_buildpacks` | | Direct. |
-| `dokku_certs` | `dokku_certs` | | docket adds `cert_content` / `key_content` for inline PEM. |
+| `dokku_certs` | `dokku_certs` | | docket adds `cert_content` / `key_content` for inline PEM, and replaces an installed certificate whose material differs where the module leaves it alone. |
 | `dokku_checks` | `dokku_checks_toggle` | | `checks:enable` / `checks:disable`. |
 | `dokku_clone` | `dokku_app` and `dokku_git_sync` | | The module runs core `git:sync`, and creates the app first. Emit both tasks. `version` becomes `git_ref`. |
 | `dokku_config` | `dokku_config` | | docket also supports `state: absent` (`config:unset`). |

--- a/docs/remote-execution.md
+++ b/docs/remote-execution.md
@@ -110,6 +110,12 @@ Some tasks offer an inline alternative that sidesteps this constraint. `dokku_ce
 instance, accepts `cert_content` and `key_content` strings; docket streams the PEM material to
 dokku as a tarball over stdin, so the bytes never have to live as files on the remote.
 
+The same constraint narrows what `plan` can tell you. `dokku_certs` compares the certificate a
+recipe pins against the one the server holds, so a renewal shows up as drift - but over SSH the
+`cert` path names a file docket cannot read, leaving nothing to compare it against, and the task
+reports in sync as long as some certificate is installed. The inline form carries its own material,
+so it is compared on every transport.
+
 ## See also
 
 - [Command reference](command-reference.md) - the commands you run over SSH

--- a/docs/tasks/dokku_certs.md
+++ b/docs/tasks/dokku_certs.md
@@ -14,7 +14,7 @@ Partial - app and global certificate PEM material is exported (via certs:show an
 
 ## Probe support
 
-Partial - only whether a certificate is installed is probed; the certificate material is never read back, so replacing an existing certificate plans as in sync.
+Partial - the installed certificate is compared against the desired one via certs:show, but the private key is never read back, so a key rotated under an unchanged certificate plans as in sync; a cert file path is only compared when docket can read the file from the machine it runs on, which a run against --host cannot; and a letsencrypt-managed certificate is left uncompared.
 
 ## Identity
 

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -4,8 +4,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -64,7 +66,7 @@ func (t CertsTask) ExportSupport() ExportSupport {
 
 // ProbeSupport reports whether Plan() can read this task's current state.
 func (t CertsTask) ProbeSupport() ProbeSupport {
-	return ProbeSupport{Status: ProbePartial, Caveat: "only whether a certificate is installed is probed; the certificate material is never read back, so replacing an existing certificate plans as in sync"}
+	return ProbeSupport{Status: ProbePartial, Caveat: "the installed certificate is compared against the desired one via certs:show, but the private key is never read back, so a key rotated under an unchanged certificate plans as in sync; a cert file path is only compared when docket can read the file from the machine it runs on, which a run against --host cannot; and a letsencrypt-managed certificate is left uncompared"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
@@ -156,8 +158,15 @@ func (t CertsTask) Plan(ctx context.Context) PlanResult {
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
+			drifted := false
 			if enabled {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
+				drifted, err = certsMaterialDrifted(ctx, t)
+				if err != nil {
+					return PlanResult{Status: PlanStatusError, Error: err}
+				}
+				if !drifted {
+					return PlanResult{InSync: true, Status: PlanStatusOK}
+				}
 			}
 			target := t.App
 			if t.Global {
@@ -183,6 +192,21 @@ func (t CertsTask) Plan(ctx context.Context) PlanResult {
 				}
 			}
 			inputs := []subprocess.ExecCommandInput{input}
+			if drifted {
+				// certs:add and certs:update are the same command in dokku, and
+				// both fn-certs-set and fn-global-cert-set overwrite what is
+				// there, so replacing a certificate needs no command of its own.
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    "certificate material drift",
+					Mutations: []string{fmt.Sprintf("replace certificate for %s", target)},
+					Commands:  resolveCommands(ctx, inputs),
+					apply: func(ctx context.Context) TaskOutputState {
+						return runExecInputs(ctx, TaskOutputState{State: StatePresent}, StatePresent, inputs)
+					},
+				}
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
@@ -295,6 +319,115 @@ func certsEnabled(ctx context.Context, t CertsTask) (bool, error) {
 	}
 
 	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
+// certsMaterialDrifted reports whether the certificate installed for the task's
+// scope is a different one from the certificate the recipe pins. It answers true
+// only on positive evidence: material read back from the server that does not
+// match the desired material. Everything it cannot see reads as false, so a
+// scope it cannot compare keeps the coarse "a certificate is installed, so we
+// are in sync" answer Plan() gave before it compared anything.
+//
+// Two cases are deliberately not compared. Desired material docket cannot read
+// leaves nothing to compare against - see desiredCertPEM. And a
+// letsencrypt-managed certificate is left alone for the reason `docket export`
+// skips one (#337): it is ephemeral and re-issued on renewal, so treating a
+// fresh one as drift would have docket overwrite it with the recipe's stale pin
+// on every run. A non-SSH error from that probe means the letsencrypt plugin is
+// not installed, which is itself the answer that the certificate is not
+// letsencrypt-managed, so the comparison goes ahead.
+//
+// The private key is never read. Comparing the certificate catches renewal,
+// which is what re-running one of these tasks is almost always about; moving key
+// material off the server to also catch a key rotated under an unchanged
+// certificate is not a trade this makes.
+func certsMaterialDrifted(ctx context.Context, t CertsTask) (bool, error) {
+	desired, ok := desiredCertPEM(ctx, t)
+	if !ok {
+		return false, nil
+	}
+
+	if !t.Global {
+		active, err := letsencryptActive(ctx, t.App)
+		if err != nil {
+			var sshErr *subprocess.SSHError
+			if errors.As(err, &sshErr) {
+				return false, err
+			}
+		} else if active {
+			return false, nil
+		}
+	}
+
+	installed, err := certsShow(ctx, t, "crt")
+	if err != nil {
+		return false, err
+	}
+	return !samePEM(installed, desired), nil
+}
+
+// desiredCertPEM returns the certificate PEM the recipe pins, and whether docket
+// can read it from where it runs. Inline cert_content is always readable. The
+// `cert` field is a path on the dokku server, which is this machine's path only
+// when the run is local, so a run carrying a target host reports false rather
+// than comparing against whatever a local file of that name happens to hold. A
+// file docket's own user cannot read - what `--sudo` against a root-owned key
+// directory looks like - reports false for the same reason: no desired material,
+// nothing to compare.
+func desiredCertPEM(ctx context.Context, t CertsTask) (string, bool) {
+	if t.CertContent != "" {
+		return t.CertContent, true
+	}
+	if t.Cert == "" || subprocess.TargetFromContext(ctx).Host != "" {
+		return "", false
+	}
+	data, err := os.ReadFile(t.Cert)
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// samePEM reports whether two PEM documents carry the same certificate chain.
+// The comparison is over each block's type and decoded DER, in order, so a
+// trailing newline, CRLF line endings or different line wrapping between what a
+// recipe pins and what certs:show hands back - StdoutContents trims it - do not
+// read as drift. Bytes outside the blocks are ignored, which is what makes an
+// openssl text dump printed ahead of the certificate harmless.
+//
+// A document holding no PEM block at all is not something this can normalise, so
+// such a pair falls back to a whitespace-trimmed string comparison rather than
+// comparing equal on the strength of two empty block lists.
+func samePEM(a, b string) bool {
+	blocksA, okA := pemBlocks(a)
+	blocksB, okB := pemBlocks(b)
+	if !okA || !okB {
+		return strings.TrimSpace(a) == strings.TrimSpace(b)
+	}
+	if len(blocksA) != len(blocksB) {
+		return false
+	}
+	for i := range blocksA {
+		if blocksA[i].Type != blocksB[i].Type || !bytes.Equal(blocksA[i].Bytes, blocksB[i].Bytes) {
+			return false
+		}
+	}
+	return true
+}
+
+// pemBlocks decodes every PEM block in s, reporting false when it holds none.
+func pemBlocks(s string) ([]*pem.Block, bool) {
+	var blocks []*pem.Block
+	rest := []byte(s)
+	for {
+		block, remainder := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		blocks = append(blocks, block)
+		rest = remainder
+	}
+	return blocks, len(blocks) > 0
 }
 
 // ExportApp reconstructs an app's SSL certificate via certs:show. The cert and

--- a/tasks/certs_task_integration_test.go
+++ b/tasks/certs_task_integration_test.go
@@ -111,7 +111,8 @@ func TestIntegrationCertsApp(t *testing.T) {
 		t.Errorf("expected cert to be enabled after add")
 	}
 
-	// add again - should be idempotent (does not update; matches ansible-dokku semantics)
+	// add again with the same material - the probe compares the installed
+	// certificate and finds nothing to do
 	result = addTask.Execute(testCtx())
 	if result.Error != nil {
 		t.Fatalf("failed second add: %v", result.Error)
@@ -325,4 +326,164 @@ func TestIntegrationCertsGlobal(t *testing.T) {
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent global remove")
 	}
+}
+
+// TestIntegrationCertsAppRotation covers the case the probe was added for: an
+// app already holding a certificate, and a recipe pinning a different one. The
+// path form doubles as coverage of the local-file read, since a local run
+// resolves `cert:` on this machine.
+func TestIntegrationCertsAppRotation(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-certs-rotate"
+	oldCert, oldKey := generateSelfSignedCert(t, appName+".example.com")
+	newCert, newKey := generateSelfSignedCert(t, appName+".example.net")
+
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
+
+	install := CertsTask{App: appName, Cert: oldCert, Key: oldKey, State: StatePresent}
+	if result := install.Execute(testCtx()); result.Error != nil {
+		t.Fatalf("failed to add cert: %v", result.Error)
+	}
+
+	rotate := CertsTask{App: appName, Cert: newCert, Key: newKey, State: StatePresent}
+	plan := rotate.Plan(testCtx())
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusModify {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want drift with %q", plan.InSync, plan.Status, PlanStatusModify)
+	}
+
+	result := rotate.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed to rotate cert: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true when the pinned certificate differs")
+	}
+
+	installed, err := certsShow(testCtx(), CertsTask{App: appName}, "crt")
+	if err != nil {
+		t.Fatalf("certsShow failed: %v", err)
+	}
+	wantPEM, err := os.ReadFile(newCert)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	if !samePEM(installed, string(wantPEM)) {
+		t.Errorf("installed certificate is not the one the recipe pinned")
+	}
+
+	// The rotation settles: a second run of the same recipe is a no-op.
+	result = rotate.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed second rotate: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false once the pinned certificate is installed")
+	}
+}
+
+// TestIntegrationCertsAppInlineRotation is the same rotation through inline PEM,
+// the form that works over any transport.
+func TestIntegrationCertsAppInlineRotation(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-certs-inline-rotate"
+	oldCert, oldKey := generateSelfSignedCert(t, appName+".example.com")
+	newCert, newKey := generateSelfSignedCert(t, appName+".example.net")
+
+	destroyApp(testCtx(), appName)
+	createApp(testCtx(), appName)
+	defer destroyApp(testCtx(), appName)
+
+	install := CertsTask{App: appName, CertContent: readFileT(t, oldCert), KeyContent: readFileT(t, oldKey), State: StatePresent}
+	if result := install.Execute(testCtx()); result.Error != nil {
+		t.Fatalf("failed to add cert inline: %v", result.Error)
+	}
+
+	rotate := CertsTask{App: appName, CertContent: readFileT(t, newCert), KeyContent: readFileT(t, newKey), State: StatePresent}
+	plan := rotate.Plan(testCtx())
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusModify {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want drift with %q", plan.InSync, plan.Status, PlanStatusModify)
+	}
+
+	result := rotate.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed to rotate cert inline: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true when the pinned certificate differs")
+	}
+
+	result = rotate.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed second inline rotate: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false once the pinned certificate is installed")
+	}
+}
+
+// TestIntegrationCertsGlobalRotation covers the same rotation for the global
+// scope, which reads back through global-cert:show.
+func TestIntegrationCertsGlobalRotation(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "global-cert")
+
+	oldCert, oldKey := generateSelfSignedCert(t, "global-rotate.example.com")
+	newCert, newKey := generateSelfSignedCert(t, "global-rotate.example.net")
+
+	cleanup := func() {
+		(CertsTask{Global: true, State: StateAbsent}).Execute(testCtx())
+	}
+	cleanup()
+	defer cleanup()
+
+	install := CertsTask{Global: true, Cert: oldCert, Key: oldKey, State: StatePresent}
+	if result := install.Execute(testCtx()); result.Error != nil {
+		t.Fatalf("failed to add global cert: %v", result.Error)
+	}
+
+	rotate := CertsTask{Global: true, Cert: newCert, Key: newKey, State: StatePresent}
+	plan := rotate.Plan(testCtx())
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusModify {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want drift with %q", plan.InSync, plan.Status, PlanStatusModify)
+	}
+
+	result := rotate.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed to rotate global cert: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true when the pinned global certificate differs")
+	}
+
+	result = rotate.Execute(testCtx())
+	if result.Error != nil {
+		t.Fatalf("failed second global rotate: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false once the pinned global certificate is installed")
+	}
+}
+
+// readFileT reads a generated fixture, failing the test rather than returning an
+// error the caller has to thread through a struct literal.
+func readFileT(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
 }

--- a/tasks/certs_task_test.go
+++ b/tasks/certs_task_test.go
@@ -4,7 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/pem"
+	"errors"
 	"io"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -256,5 +261,371 @@ func TestCertsEnabledGlobalUsesGlobalScope(t *testing.T) {
 	want := "--quiet global-cert:report --global --global-cert-enabled"
 	if got := strings.Join(gotArgs, " "); got != want {
 		t.Errorf("global certsEnabled args = %q, want %q", got, want)
+	}
+}
+
+// certPEM renders a PEM block whose DER payload is the given marker, which is
+// all samePEM and the plan comparison read - neither parses X.509. Building the
+// fixture with encoding/pem rather than pasting a literal keeps the tests fast
+// and makes the line wrapping the real thing.
+func certPEM(body string) string {
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte(body)}))
+}
+
+// certsAppFixture answers the three reads the app-scope present branch makes:
+// a certificate is installed, letsencrypt does not manage it, and certs:show
+// hands back installed.
+func certsAppFixture(app, installed string) map[string]string {
+	return map[string]string{
+		"--quiet certs:report " + app + " --ssl-enabled": "true",
+		"--quiet letsencrypt:active " + app:              "false",
+		"--quiet certs:show " + app + " crt":             installed,
+	}
+}
+
+// assertNoCertMaterial fails when any plan-visible string carries PEM material.
+// The cert and key are sensitive and ride to dokku on stdin, so neither the
+// rendered commands, the itemized mutations nor the reason may name them.
+func assertNoCertMaterial(t *testing.T, plan PlanResult) {
+	t.Helper()
+	for _, s := range append(append([]string{plan.Reason}, plan.Mutations...), plan.Commands...) {
+		if strings.Contains(s, "BEGIN CERTIFICATE") || strings.Contains(s, "BEGIN PRIVATE KEY") {
+			t.Errorf("certificate material leaked into plan output: %q", s)
+		}
+	}
+}
+
+func TestCertsTaskPlanInlineMatchingCertInSync(t *testing.T) {
+	t.Parallel()
+	installed := certPEM("cert-a")
+	var calls []string
+	ctx := subprocess.ContextWithRunner(testCtx(), recordingDokku(certsAppFixture("test-app", installed), &calls))
+
+	plan := CertsTask{
+		App:         "test-app",
+		CertContent: installed,
+		KeyContent:  "-----BEGIN PRIVATE KEY-----\nkey-a\n-----END PRIVATE KEY-----\n",
+		State:       StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want an in-sync ok", plan.InSync, plan.Status)
+	}
+	// The certificate answers the question on its own; reading the key back
+	// would move private material off the server for nothing.
+	for _, call := range calls {
+		if strings.HasSuffix(call, "certs:show test-app key") {
+			t.Errorf("plan read the private key back: %q", call)
+		}
+	}
+}
+
+func TestCertsTaskPlanInlineRotatedCertPlansModify(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(certsAppFixture("test-app", certPEM("cert-old"))))
+
+	plan := CertsTask{
+		App:         "test-app",
+		CertContent: certPEM("cert-renewed"),
+		KeyContent:  "-----BEGIN PRIVATE KEY-----\nkey-renewed\n-----END PRIVATE KEY-----\n",
+		State:       StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusModify {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want drift with %q", plan.InSync, plan.Status, PlanStatusModify)
+	}
+	if plan.Reason != "certificate material drift" {
+		t.Errorf("Reason = %q, want %q", plan.Reason, "certificate material drift")
+	}
+	if !reflect.DeepEqual(plan.Mutations, []string{"replace certificate for test-app"}) {
+		t.Errorf("Mutations = %v, want [replace certificate for test-app]", plan.Mutations)
+	}
+	// certs:add is also certs:update in dokku, so replacing needs no second command.
+	if len(plan.Commands) != 1 || !strings.HasSuffix(plan.Commands[0], "certs:add test-app") {
+		t.Errorf("Commands = %v, want one command ending in certs:add test-app", plan.Commands)
+	}
+	assertNoCertMaterial(t, plan)
+}
+
+// TestCertsTaskPlanNormalizesPEM locks the comparison to the decoded blocks.
+// certs:show is a plain cat of server.crt and StdoutContents trims it, so an
+// inline cert_content that ends in a newline - which every PEM file does - would
+// otherwise plan as drift forever against the certificate it just installed.
+func TestCertsTaskPlanNormalizesPEM(t *testing.T) {
+	t.Parallel()
+	installed := strings.TrimSpace(certPEM("cert-a"))
+
+	tests := []struct {
+		name    string
+		desired string
+	}{
+		{name: "trailing newline", desired: installed + "\n"},
+		{name: "trailing blank lines", desired: installed + "\n\n\n"},
+		{name: "crlf line endings", desired: strings.ReplaceAll(installed, "\n", "\r\n") + "\r\n"},
+		{name: "leading text dump", desired: "Certificate:\n    Serial Number: 1\n" + installed + "\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(certsAppFixture("test-app", installed)))
+
+			plan := CertsTask{
+				App:         "test-app",
+				CertContent: tc.desired,
+				KeyContent:  "-----BEGIN PRIVATE KEY-----\nkey-a\n-----END PRIVATE KEY-----\n",
+				State:       StatePresent,
+			}.Plan(ctx)
+			if plan.Error != nil {
+				t.Fatalf("unexpected plan error: %v", plan.Error)
+			}
+			if !plan.InSync {
+				t.Errorf("plan reported drift for whitespace-only differences (status %q)", plan.Status)
+			}
+		})
+	}
+}
+
+// TestCertsTaskPlanGlobalComparesGlobalCertShow locks the global scope to
+// global-cert:show, the twin of certs:show the export path already uses, and to
+// leaving the letsencrypt probe alone - that plugin manages per-app
+// certificates, so there is no global certificate for it to own.
+func TestCertsTaskPlanGlobalComparesGlobalCertShow(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	ctx := subprocess.ContextWithRunner(testCtx(), recordingDokku(map[string]string{
+		"--quiet global-cert:report --global --global-cert-enabled": "true",
+		"--quiet global-cert:show crt":                              certPEM("global-old"),
+	}, &calls))
+
+	plan := CertsTask{
+		Global:      true,
+		CertContent: certPEM("global-renewed"),
+		KeyContent:  "-----BEGIN PRIVATE KEY-----\nglobal-key\n-----END PRIVATE KEY-----\n",
+		State:       StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusModify {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want drift with %q", plan.InSync, plan.Status, PlanStatusModify)
+	}
+	if !reflect.DeepEqual(plan.Mutations, []string{"replace certificate for (global)"}) {
+		t.Errorf("Mutations = %v, want [replace certificate for (global)]", plan.Mutations)
+	}
+	if len(plan.Commands) != 1 || !strings.HasSuffix(plan.Commands[0], "global-cert:set") {
+		t.Errorf("Commands = %v, want one command ending in global-cert:set", plan.Commands)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "letsencrypt:active") {
+			t.Errorf("global plan probed letsencrypt: %q", call)
+		}
+	}
+	assertNoCertMaterial(t, plan)
+}
+
+// TestCertsTaskPlanPathFormComparesLocalFile covers the `cert:` form on a local
+// run, where the path dokku resolves is this machine's path too, so the file is
+// the desired material.
+func TestCertsTaskPlanPathFormComparesLocalFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "server.crt")
+	keyPath := filepath.Join(dir, "server.key")
+	if err := os.WriteFile(certPath, []byte(certPEM("cert-on-disk")), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----\n"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		installed  string
+		wantInSync bool
+		wantStatus PlanStatus
+	}{
+		{name: "same certificate", installed: certPEM("cert-on-disk"), wantInSync: true, wantStatus: PlanStatusOK},
+		{name: "renewed certificate", installed: certPEM("cert-superseded"), wantStatus: PlanStatusModify},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(certsAppFixture("test-app", tc.installed)))
+
+			plan := CertsTask{App: "test-app", Cert: certPath, Key: keyPath, State: StatePresent}.Plan(ctx)
+			if plan.Error != nil {
+				t.Fatalf("unexpected plan error: %v", plan.Error)
+			}
+			if plan.InSync != tc.wantInSync || plan.Status != tc.wantStatus {
+				t.Fatalf("plan = {InSync:%v Status:%q}, want {InSync:%v Status:%q}",
+					plan.InSync, plan.Status, tc.wantInSync, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestCertsTaskPlanPathFormRemoteSkipsComparison locks the one case the probe
+// must not guess at: `cert:` names a file on the dokku host, so under --host the
+// desired material is not readable here and a same-named local file is a
+// different file. The task keeps its coarse "installed means in sync" answer
+// rather than planning drift against a server that may well match.
+func TestCertsTaskPlanPathFormRemoteSkipsComparison(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "server.crt")
+	if err := os.WriteFile(certPath, []byte(certPEM("a-different-local-file")), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+
+	var calls []string
+	ctx := subprocess.ContextWithRunner(testCtx(), recordingDokku(certsAppFixture("test-app", certPEM("cert-on-server")), &calls))
+	ctx = subprocess.ContextWithTarget(ctx, subprocess.Target{Host: "dokku.example.com"})
+
+	plan := CertsTask{
+		App:   "test-app",
+		Cert:  certPath,
+		Key:   filepath.Join(dir, "server.key"),
+		State: StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want an in-sync ok", plan.InSync, plan.Status)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "certs:show") {
+			t.Errorf("plan read the certificate back with nothing to compare it to: %q", call)
+		}
+	}
+}
+
+// TestCertsTaskPlanLetsencryptManagedSkipsComparison mirrors the export skip
+// (#337): a letsencrypt certificate is re-issued on renewal, so comparing it
+// against a pinned one would have docket overwrite a fresh certificate with a
+// stale one on every run.
+func TestCertsTaskPlanLetsencryptManagedSkipsComparison(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	ctx := subprocess.ContextWithRunner(testCtx(), recordingDokku(map[string]string{
+		"--quiet certs:report test-app --ssl-enabled": "true",
+		"--quiet letsencrypt:active test-app":         "true",
+		"--quiet certs:show test-app crt":             certPEM("letsencrypt-issued"),
+	}, &calls))
+
+	plan := CertsTask{
+		App:         "test-app",
+		CertContent: certPEM("pinned"),
+		KeyContent:  "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----\n",
+		State:       StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want an in-sync ok", plan.InSync, plan.Status)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "certs:show") {
+			t.Errorf("plan compared a letsencrypt-managed certificate: %q", call)
+		}
+	}
+}
+
+func TestCertsTaskPlanNotInstalledPlansCreate(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	ctx := subprocess.ContextWithRunner(testCtx(), recordingDokku(map[string]string{
+		"--quiet certs:report test-app --ssl-enabled": "false",
+	}, &calls))
+
+	plan := CertsTask{
+		App:         "test-app",
+		CertContent: certPEM("cert-a"),
+		KeyContent:  "-----BEGIN PRIVATE KEY-----\nkey-a\n-----END PRIVATE KEY-----\n",
+		State:       StatePresent,
+	}.Plan(ctx)
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync || plan.Status != PlanStatusCreate {
+		t.Fatalf("plan = {InSync:%v Status:%q}, want drift with %q", plan.InSync, plan.Status, PlanStatusCreate)
+	}
+	if !reflect.DeepEqual(plan.Mutations, []string{"install certificate for test-app"}) {
+		t.Errorf("Mutations = %v, want [install certificate for test-app]", plan.Mutations)
+	}
+	// Nothing is installed, so there is nothing to read back.
+	for _, call := range calls {
+		if strings.Contains(call, "certs:show") || strings.Contains(call, "letsencrypt:active") {
+			t.Errorf("plan probed material for an app with no certificate: %q", call)
+		}
+	}
+	assertNoCertMaterial(t, plan)
+}
+
+// TestCertsTaskPlanShowFailureIsProbeError keeps a failed read-back an error
+// rather than a silent "in sync", matching how the same branch already treats a
+// certs:report failure.
+func TestCertsTaskPlanShowFailureIsProbeError(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		joined := strings.Join(in.Args, " ")
+		if strings.Contains(joined, "certs:show") {
+			return subprocess.ExecCommandResponse{ExitCode: 1}, errors.New("test-app doesn't have an SSL endpoint defined")
+		}
+		if strings.Contains(joined, "certs:report") {
+			return subprocess.ExecCommandResponse{Stdout: "true"}, nil
+		}
+		return subprocess.ExecCommandResponse{Stdout: "false"}, nil
+	})
+
+	plan := CertsTask{
+		App:         "test-app",
+		CertContent: certPEM("cert-a"),
+		KeyContent:  "-----BEGIN PRIVATE KEY-----\nkey-a\n-----END PRIVATE KEY-----\n",
+		State:       StatePresent,
+	}.Plan(ctx)
+	if plan.Error == nil {
+		t.Fatal("expected a probe error when certs:show fails")
+	}
+	if plan.Status != PlanStatusError {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
+	}
+}
+
+func TestSamePEM(t *testing.T) {
+	t.Parallel()
+	certA := certPEM("cert-a")
+	certB := certPEM("cert-b")
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{name: "identical", a: certA, b: certA, want: true},
+		{name: "trailing newline", a: certA, b: strings.TrimSpace(certA), want: true},
+		{name: "crlf endings", a: certA, b: strings.ReplaceAll(certA, "\n", "\r\n"), want: true},
+		{name: "text outside the block", a: certA, b: "subject=/CN=example.com\n" + certA, want: true},
+		{name: "different certificate", a: certA, b: certB},
+		{name: "chain against leaf", a: certA, b: certA + certB},
+		{name: "chain order", a: certA + certB, b: certB + certA},
+		{name: "different block type", a: certA, b: string(pem.EncodeToMemory(&pem.Block{Type: "TRUSTED CERTIFICATE", Bytes: []byte("cert-a")}))},
+		{name: "neither is pem", a: "not a certificate\n", b: "not a certificate", want: true},
+		{name: "one side is not pem", a: certA, b: "not a certificate"},
+		{name: "both empty", a: "", b: "", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := samePEM(tc.a, tc.b); got != tc.want {
+				t.Errorf("samePEM = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -295,3 +295,67 @@ EOF
   assert_output --partial "records path"
   assert_output --partial "destroy and re-create the entry"
 }
+
+# generate_cert writes a self-signed cert/key pair named "$1.crt"/"$1.key" under
+# BATS_TEST_TMPDIR. The material only has to parse as a certificate; dokku's
+# certs:add validates it with openssl before installing it.
+generate_cert() {
+  local name="$1"
+  openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -subj "/CN=$name.docket-test.example.com" \
+    -keyout "$BATS_TEST_TMPDIR/$name.key" \
+    -out "$BATS_TEST_TMPDIR/$name.crt" >/dev/null 2>/dev/null
+}
+
+# write_certs_tasks_file writes a recipe installing the named pair on
+# docket-test-plan as inline PEM, indented into the block scalars. write_tasks_file
+# is called directly rather than through a pipe so the TASKS_FILE it exports
+# survives - a pipeline would run it in a subshell.
+write_certs_tasks_file() {
+  local name="$1"
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+    - name: ensure the certificate
+      dokku_certs:
+        app: docket-test-plan
+        cert_content: |
+$(sed 's/^/          /' "$BATS_TEST_TMPDIR/$name.crt")
+        key_content: |
+$(sed 's/^/          /' "$BATS_TEST_TMPDIR/$name.key")
+EOF
+}
+
+@test "docket plan reports drift when a pinned certificate is renewed" {
+  generate_cert original
+  generate_cert renewed
+
+  write_certs_tasks_file original
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "0 would change"
+
+  # Pinning a different certificate against an app that already holds one is
+  # drift, not a silent no-op, and applying it settles.
+  write_certs_tasks_file renewed
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[~]"
+  assert_output --partial "certificate material drift"
+  assert_output --partial "replace certificate for docket-test-plan"
+  assert_output --partial "1 would change"
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[ok]"
+  assert_output --partial "0 would change"
+}


### PR DESCRIPTION
`Plan()` now reads the installed certificate back with `certs:show` and compares its normalised PEM against the certificate the recipe pins, so a renewed certificate is reported as drift and applied rather than planning as in sync. The private key is never read back, a `cert` file path is only compared when docket can read the file from the machine it runs on rather than from the dokku host that path names, and a letsencrypt-managed certificate is left uncompared for the same reason `docket export` skips one, so the task stays a partial probe with a narrower caveat.

The comparison is over the decoded PEM blocks rather than the raw bytes, because `certs:show` is a plain `cat` of `server.crt` whose stdout docket trims, so an inline `cert_content` ending in a newline would otherwise plan as drift forever against the certificate it had just installed. No new mutation is needed: `certs:add` and `certs:update` are the same command in dokku and both it and `global-cert:set` overwrite what is already there.

Reading a digest instead of the whole certificate is left to #533, since `certs:report --ssl-fingerprint` is not in a dokku release yet and `global-cert:report` has no equivalent.

Closes #525
