### PR TITLE
feat: add a codec interface for recipe formats

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -119,7 +119,7 @@ func (c *ApplyCommand) ParsedArguments(args []string) (map[string]command.Argume
 func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "", "task file (YAML or JSON5) containing a task list. Pass - to read the recipe from stdin. When omitted, docket probes tasks.yml -> tasks.yaml -> tasks.json in the current directory. An http(s):// URL is fetched over HTTP.")
-	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "parse the recipe as this format (yaml or json5) instead of detecting it from the file extension. Required only when the extension is absent or wrong; stdin is otherwise sniffed from its first byte.")
+	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "parse the recipe as this format ("+recipeFormatList()+") instead of detecting it from the file extension. Required only when the extension is absent or wrong; stdin is otherwise sniffed from its first byte.")
 	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line. Values from inputs declared `sensitive: true` and from task struct fields tagged `sensitive:\"true\"` are masked as `***`. Ignored when --json is set; the JSON output already includes the resolved commands.")
 	f.BoolVar(&c.json, "json", false, "emit one JSON-lines event per play/task/summary instead of human-readable output. Schema is keyed by `version: 1`; sensitive values mask to `***`.")
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")

--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +14,6 @@ import (
 	"github.com/dokku/docket/tasks"
 
 	flag "github.com/spf13/pflag"
-	yaml "gopkg.in/yaml.v3"
 )
 
 type Argument struct {
@@ -600,49 +598,24 @@ func loadVarsFiles(paths []string) (map[string]interface{}, map[string]string, m
 	return merged, sources, perFile, nil
 }
 
+// parseVarsFile decodes a --vars-file with the codec its extension names,
+// falling back to the default codec for an extension no codec claims -
+// which is every extension a vars-file usually carries, since the file is
+// named after the recipe rather than after a format.
+//
+// This used to be a bare `filepath.Ext(path) == ".json"` compare, which
+// meant a .json5 vars-file was handed to the YAML parser and died on the
+// first comment or trailing comma. A plain .json file decodes to the same
+// Go values it always has: the JSON5 codec reads it with json5.Unmarshal,
+// a superset of encoding/json.
 func parseVarsFile(path string, data []byte) (map[string]interface{}, error) {
-	out := map[string]interface{}{}
-	if strings.EqualFold(filepath.Ext(path), ".json") {
-		if err := json.Unmarshal(data, &out); err != nil {
-			return nil, fmt.Errorf("--vars-file %s: %v", path, err)
-		}
-		return out, nil
-	}
-	// YAML decodes mapping keys as interface{}; convert to string keys and
-	// recursively normalise nested maps so JSON-like consumers see the same
-	// shape regardless of source format.
-	var raw interface{}
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("--vars-file %s: %v", path, err)
-	}
-	if raw == nil {
-		return out, nil
-	}
-	asMap, ok := raw.(map[string]interface{})
+	codec, ok := tasks.CodecForExtension(filepath.Ext(path))
 	if !ok {
-		// yaml.v3 returns map[string]interface{} for the common case but
-		// older fixtures sometimes round-trip as map[interface{}]interface{};
-		// normalise that path too.
-		if generic, ok2 := raw.(map[interface{}]interface{}); ok2 {
-			converted, err := normaliseYAMLMap(generic)
-			if err != nil {
-				return nil, fmt.Errorf("--vars-file %s: %v", path, err)
-			}
-			return converted, nil
-		}
-		return nil, fmt.Errorf("--vars-file %s: top-level document must be a mapping of input names to values", path)
+		codec = tasks.DefaultCodec()
 	}
-	return asMap, nil
-}
-
-func normaliseYAMLMap(in map[interface{}]interface{}) (map[string]interface{}, error) {
-	out := make(map[string]interface{}, len(in))
-	for k, v := range in {
-		ks, ok := k.(string)
-		if !ok {
-			return nil, fmt.Errorf("non-string key %v", k)
-		}
-		out[ks] = v
+	out, err := codec.UnmarshalVars(data)
+	if err != nil {
+		return nil, fmt.Errorf("--vars-file %s: %v", path, err)
 	}
 	return out, nil
 }

--- a/commands/export.go
+++ b/commands/export.go
@@ -115,7 +115,7 @@ func (c *ExportCommand) ParsedArguments(args []string) (map[string]command.Argum
 func (c *ExportCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.output, "output", defaultRecipeOutput, "path to write the recipe to; pass - to stream a self-contained recipe to stdout")
-	f.StringVar(&c.formatFlag, "format", "", "write the recipe and vars-file as this format (yaml or json5) instead of inferring it from the --output extension. Without an explicit --output, json5 writes "+defaultRecipeOutputJSON5+"; this is also the only way to get JSON5 on stdout.")
+	f.StringVar(&c.formatFlag, "format", "", "write the recipe and vars-file as this format ("+recipeFormatList()+") instead of inferring it from the --output extension. Without an explicit --output, json5 writes "+defaultRecipeOutputFor(tasks.FormatNameJSON5)+"; this is also the only way to get JSON5 on stdout.")
 	f.StringVar(&c.varsOutput, "vars-output", "", "path to write the companion vars-file to (defaults to <output-base>.vars.<ext>; --format overrides its format)")
 	f.BoolVar(&c.overwrite, "overwrite", false, "overwrite existing output files without prompting")
 	f.BoolVar(&c.redact, "redact", false, "write placeholder values into the vars-file instead of real secrets")

--- a/commands/fmt.go
+++ b/commands/fmt.go
@@ -111,7 +111,7 @@ func (c *FmtCommand) FlagSet() *flag.FlagSet {
 	f.BoolVar(&c.check, "check", false, "exit non-zero if any file is not canonically formatted; do not write")
 	f.BoolVar(&c.diff, "diff", false, "print a unified diff for any file that is not canonically formatted; do not write")
 	f.StringVar(&c.color, "color", "auto", "when to colorize diff output: auto, always, never")
-	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "format the recipe as this format (yaml or json5) instead of detecting it from the file extension, or from the first byte when reading stdin. Needed for a flow-style YAML recipe, which starts with [ and would otherwise sniff as JSON5.")
+	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "format the recipe as this format ("+recipeFormatList()+") instead of detecting it from the file extension, or from the first byte when reading stdin. Needed for a flow-style YAML recipe, which starts with [ and would otherwise sniff as JSON5.")
 	return f
 }
 
@@ -206,7 +206,7 @@ func (c *FmtCommand) runStdin(formatOverride string) int {
 		c.Ui.Error(fmt.Sprintf("read stdin: %v", err))
 		return 1
 	}
-	formatted, err := formatTaskFileBytes(src, taskFileFormatFor("", formatOverride, src))
+	formatted, err := tasks.CodecFor(taskFileFormatFor("", formatOverride, src)).Format(src)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("format error: %v", err))
 		return 1
@@ -248,7 +248,7 @@ func (c *FmtCommand) formatPath(path, formatOverride string) int {
 		return 1
 	}
 
-	formatted, err := formatTaskFileBytes(src, taskFileFormatFor(detectTaskFileFormat(path), formatOverride, src))
+	formatted, err := tasks.CodecFor(taskFileFormatFor(detectTaskFileFormat(path), formatOverride, src)).Format(src)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("%s: %v", path, err))
 		return 1
@@ -285,39 +285,6 @@ func (c *FmtCommand) formatPath(path, formatOverride string) int {
 	}
 	c.Ui.Output(fmt.Sprintf("==> Formatted %s", path))
 	return 0
-}
-
-// formatTaskFileBytes dispatches to the YAML or JSON5 formatter based
-// on format. Centralised so the in-place and stdin paths stay byte-
-// identical for the same logical operation.
-func formatTaskFileBytes(src []byte, format string) ([]byte, error) {
-	if format == taskFileFormatJSON5 {
-		return tasks.FormatJSON5(src)
-	}
-	return tasks.Format(src)
-}
-
-// sniffStdinFormat picks a format for stdin input. JSON5 input always
-// starts (after optional whitespace and comments) with `[` or `{`;
-// YAML recipes start with `-`, `---`, or a key, none of which collide.
-// On ambiguity the function defaults to YAML so existing pipelines
-// keep their pre-#218 behaviour.
-func sniffStdinFormat(src []byte) string {
-	for i := 0; i < len(src); i++ {
-		c := src[i]
-		if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
-			continue
-		}
-		if c == '/' && i+1 < len(src) && (src[i+1] == '/' || src[i+1] == '*') {
-			// Skip a leading line/block comment - JSON5 idiom.
-			return taskFileFormatJSON5
-		}
-		if c == '[' || c == '{' {
-			return taskFileFormatJSON5
-		}
-		return taskFileFormatYAML
-	}
-	return taskFileFormatYAML
 }
 
 // expandPaths resolves the positional arguments to a sorted, deduped

--- a/commands/fmt_test.go
+++ b/commands/fmt_test.go
@@ -375,7 +375,7 @@ func TestFmtStdinInvalidTasksFormatFails(t *testing.T) {
 
 // TestFmtStdinTasksFormatOverridesSniff is the case sniffing alone
 // cannot get right: a top-level flow sequence is valid YAML but opens
-// with "[", so sniffStdinFormat calls it JSON5 and the JSON5 formatter
+// with "[", so the JSON5 codec's Sniff claims it and that formatter
 // rewrites it into JSON5 syntax. --tasks-format yaml keeps it YAML.
 func TestFmtStdinTasksFormatOverridesSniff(t *testing.T) {
 	t.Parallel()

--- a/commands/init.go
+++ b/commands/init.go
@@ -97,7 +97,7 @@ func (c *InitCommand) ParsedArguments(args []string) (map[string]command.Argumen
 func (c *InitCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.output, "output", defaultRecipeOutput, "path to write the scaffold to; pass - to write to stdout")
-	f.StringVar(&c.formatFlag, "format", "", "write the scaffold as this format (yaml or json5) instead of inferring it from the --output extension. Without an explicit --output, json5 writes "+defaultRecipeOutputJSON5+"; this is also the only way to get JSON5 on stdout.")
+	f.StringVar(&c.formatFlag, "format", "", "write the scaffold as this format ("+recipeFormatList()+") instead of inferring it from the --output extension. Without an explicit --output, json5 writes "+defaultRecipeOutputFor(tasks.FormatNameJSON5)+"; this is also the only way to get JSON5 on stdout.")
 	f.BoolVar(&c.force, "force", false, "overwrite an existing output file")
 	f.BoolVar(&c.minimal, "minimal", false, "emit a minimal one-task scaffold without an inputs block")
 	f.StringVar(&c.name, "name", defaultName(c.baseDir()), "play name and default app input value")
@@ -237,18 +237,18 @@ type initOptions struct {
 	Name    string
 	Repo    string
 	Minimal bool
-	// Format selects the on-disk shape of the rendered scaffold. Valid
-	// values are tasks.FormatYAML (default) and tasks.FormatNameJSON5; the
-	// empty string is treated as YAML so existing callers (and tests
-	// that drive renderInit directly) keep their behaviour.
+	// Format selects the on-disk shape of the rendered scaffold: any
+	// canonical codec name. The empty string resolves to the default
+	// codec, so existing callers (and tests that drive renderInit
+	// directly) keep their behaviour.
 	Format string
 }
 
 // renderInit reads the right embedded template, parses it with custom
 // delimiters so sigil syntax in the body survives untouched, and returns
-// the rendered bytes. YAML scaffolds are prefixed with the `---\n`
-// document marker; JSON5 scaffolds are emitted as a top-level array
-// (the docket recipe shape) with no marker.
+// the rendered bytes. Anything a format needs at the top of the document -
+// the YAML `---` marker, the JSON5 opening bracket - lives in that
+// format's own templates rather than in a branch here.
 //
 // Exposed at package scope so unit tests can drive it directly without
 // going through the cli-skeleton UI plumbing.
@@ -286,25 +286,24 @@ func renderInit(opts initOptions) ([]byte, error) {
 		return nil, fmt.Errorf("render template %s: %w", templateName, err)
 	}
 
-	var out bytes.Buffer
-	if !tasks.IsJSON5Format(opts.Format) {
-		out.WriteString("---\n")
-	}
-	out.Write(body.Bytes())
-	return out.Bytes(), nil
+	return body.Bytes(), nil
 }
 
 // selectInitTemplate returns the embedded template name for (format,
-// minimal). YAML / unknown format -> .yml.tmpl, JSON5 -> .json5.tmpl.
+// minimal). The name is derived from the codec, so a format is scaffolded
+// by dropping default.<name>.tmpl and minimal.<name>.tmpl next to the
+// others - there is no branch to extend. An unknown format resolves to the
+// default codec and gets its templates.
+//
+// The embedded FS is not checked here; a missing template surfaces as the
+// read error in renderInit. TestEveryCodecHasInitTemplates is what stops a
+// codec from shipping without one.
 func selectInitTemplate(format string, minimal bool) string {
-	suffix := "yml"
-	if tasks.IsJSON5Format(format) {
-		suffix = "json5"
-	}
+	base := "default"
 	if minimal {
-		return "minimal." + suffix + ".tmpl"
+		base = "minimal"
 	}
-	return "default." + suffix + ".tmpl"
+	return fmt.Sprintf("%s.%s.tmpl", base, tasks.CodecFor(format).Name())
 }
 
 // defaultName returns the basename of dir, or "app" if it cannot be derived to

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dokku/docket/commands/templates"
 	"github.com/dokku/docket/tasks"
 
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -465,16 +466,39 @@ func TestInitJSON5RoundTripsThroughGetPlays(t *testing.T) {
 func TestSelectInitTemplate(t *testing.T) {
 	t.Parallel()
 	cases := map[[2]string]string{
-		{tasks.FormatYAML, "false"}:      "default.yml.tmpl",
-		{tasks.FormatYAML, "true"}:       "minimal.yml.tmpl",
+		{tasks.FormatYAML, "false"}:      "default.yaml.tmpl",
+		{tasks.FormatYAML, "true"}:       "minimal.yaml.tmpl",
 		{tasks.FormatNameJSON5, "false"}: "default.json5.tmpl",
 		{tasks.FormatNameJSON5, "true"}:  "minimal.json5.tmpl",
-		{"", "false"}:                    "default.yml.tmpl",
+		// An alias and an unknown value both resolve through the codec
+		// registry, the alias to its codec and the unknown to the default.
+		{"json", "false"}: "default.json5.tmpl",
+		{"", "false"}:     "default.yaml.tmpl",
+		{"toml", "true"}:  "minimal.yaml.tmpl",
 	}
 	for key, want := range cases {
 		minimal := key[1] == "true"
 		if got := selectInitTemplate(key[0], minimal); got != want {
 			t.Errorf("selectInitTemplate(%q, %v) = %q, want %q", key[0], minimal, got, want)
+		}
+	}
+}
+
+// TestEveryCodecHasInitTemplates is the guard the open-ended //go:embed
+// glob gave up. selectInitTemplate derives its filename from the codec
+// name, and parseRecipeFormatFlag accepts anything in the registry, so a
+// codec registered without a matching pair of templates compiles fine and
+// then fails at runtime: `docket init --format <new>` dies on "read
+// template default.<new>.tmpl: file does not exist". Catch it here
+// instead.
+func TestEveryCodecHasInitTemplates(t *testing.T) {
+	t.Parallel()
+	for _, codec := range tasks.Codecs() {
+		for _, minimal := range []bool{false, true} {
+			name := selectInitTemplate(codec.Name(), minimal)
+			if _, err := templates.FS.ReadFile(name); err != nil {
+				t.Errorf("codec %q has no init template %s: %v", codec.Name(), name, err)
+			}
 		}
 	}
 }

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -117,7 +117,7 @@ func (c *PlanCommand) ParsedArguments(args []string) (map[string]command.Argumen
 func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "", "task file (YAML or JSON5) containing a task list. Pass - to read the recipe from stdin. When omitted, docket probes tasks.yml -> tasks.yaml -> tasks.json in the current directory. An http(s):// URL is fetched over HTTP.")
-	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "parse the recipe as this format (yaml or json5) instead of detecting it from the file extension. Required only when the extension is absent or wrong; stdin is otherwise sniffed from its first byte.")
+	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "parse the recipe as this format ("+recipeFormatList()+") instead of detecting it from the file extension. Required only when the extension is absent or wrong; stdin is otherwise sniffed from its first byte.")
 	f.BoolVar(&c.json, "json", false, "emit one JSON-lines event per play/task/summary instead of human-readable output. Schema is keyed by `version: 1`; sensitive values mask to `***`.")
 	f.BoolVar(&c.detailedExitCode, "detailed-exitcode", false, "exit 0 when no drift is detected, 2 when drift is detected, 1 on error. Without this flag plan exits 0 regardless of drift.")
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")

--- a/commands/task_file.go
+++ b/commands/task_file.go
@@ -11,18 +11,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dokku/docket/tasks"
+
 	"github.com/mattn/go-isatty"
 	"github.com/posener/complete"
 	flag "github.com/spf13/pflag"
-)
-
-// Task file format identifiers used throughout the commands package and
-// passed through to tasks.GetPlaysWithFormat / tasks.Validate via
-// ValidateOptions.Format. Only these two values are valid; other strings
-// are treated as YAML by the dispatchers.
-const (
-	taskFileFormatYAML  = "yaml"
-	taskFileFormatJSON5 = "json5"
 )
 
 // taskFileStdin is the conventional path meaning "read the recipe from
@@ -38,25 +31,29 @@ const taskFileStdin = "-"
 // fall through to give JSON-native users a no-config setup.
 var defaultTaskFileCandidates = []string{"tasks.yml", "tasks.yaml", "tasks.json"}
 
-// parseRecipeFormatFlag normalises a recipe-format flag value to one of
-// the two canonical format identifiers. An empty value means "not set"
-// and leaves the decision to the caller. Anything else is rejected
-// naming the accepted values, the way an invalid --color is.
+// parseRecipeFormatFlag normalises a recipe-format flag value to a
+// canonical codec name. An empty value means "not set" and leaves the
+// decision to the caller - it is checked before the registry is asked,
+// because tasks.LookupCodec("") is a miss and rejecting it here would
+// fail every command that did not pass the flag. Anything else
+// unrecognised is rejected naming the accepted values, the way an invalid
+// --color is.
 //
 // flagName is the spelling to blame in that rejection: the input side
 // (apply / plan / validate / fmt) passes "--tasks-format", the output
 // side (init / export, #410) passes "--format". One normaliser keeps the
-// two flags accepting exactly the same spellings.
+// two flags accepting exactly the same spellings, and the registry keeps
+// that set in step with what the codecs actually implement.
 func parseRecipeFormatFlag(flagName, value string) (string, error) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "":
+	if strings.TrimSpace(value) == "" {
 		return "", nil
-	case "yaml", "yml":
-		return taskFileFormatYAML, nil
-	case "json", "json5":
-		return taskFileFormatJSON5, nil
 	}
-	return "", fmt.Errorf("invalid %s %q: must be one of yaml, json5", flagName, value)
+	if codec, ok := tasks.LookupCodec(value); ok {
+		return codec.Name(), nil
+	}
+	// The raw value is echoed back, not the trimmed and lowered one, so
+	// the user sees what they typed.
+	return "", fmt.Errorf("invalid %s %q: must be one of %s", flagName, value, strings.Join(tasks.CodecNames(), ", "))
 }
 
 // taskFileFormatFor resolves the format of a recipe from the three
@@ -70,10 +67,10 @@ func parseRecipeFormatFlag(flagName, value string) (string, error) {
 //  3. data - a content sniff, the same one `docket fmt -` has always
 //     used for stdin
 //
-// The return value is never empty. That matters: tasks.IsJSON5Format("")
-// is false, so an empty format silently means YAML downstream, and a
-// caller that skipped the sniff would parse a JSON5 recipe with the YAML
-// parser and report a confusing error instead of an obvious one.
+// The return value is never empty. That matters: an empty format resolves
+// to tasks.DefaultCodec() downstream, so a caller that skipped the sniff
+// would parse a JSON5 recipe with the YAML parser and report a confusing
+// error instead of an obvious one.
 func taskFileFormatFor(detected, override string, data []byte) string {
 	if override != "" {
 		return override
@@ -81,7 +78,7 @@ func taskFileFormatFor(detected, override string, data []byte) string {
 	if detected != "" {
 		return detected
 	}
-	return sniffStdinFormat(data)
+	return tasks.SniffCodec(data).Name()
 }
 
 // taskFileDisplayName renders a recipe source for human output. stdin
@@ -120,9 +117,9 @@ func shellUnsafeRune(r rune) bool {
 	return true
 }
 
-// detectTaskFileFormat returns "json5" when path's extension is .json or
-// .json5 (case-insensitive), and "yaml" otherwise. Unknown extensions
-// default to YAML so explicit paths like `--tasks recipe.txt` keep the
+// detectTaskFileFormat resolves path's extension to a codec name. An
+// extension no codec claims - including none at all - falls back to the
+// default codec, so explicit paths like `--tasks recipe.txt` keep the
 // pre-#218 behaviour. For an http(s) URL the format is taken from the URL
 // path component so a trailing query string or fragment
 // (`tasks.json?ref=main`) does not get glued onto the extension.
@@ -133,24 +130,36 @@ func detectTaskFileFormat(path string) string {
 			ext = filepath.Ext(u.Path)
 		}
 	}
-	switch strings.ToLower(ext) {
-	case ".json", ".json5":
-		return taskFileFormatJSON5
-	default:
-		return taskFileFormatYAML
+	if codec, ok := tasks.CodecForExtension(ext); ok {
+		return codec.Name()
 	}
+	return tasks.DefaultCodec().Name()
 }
 
-// defaultRecipeOutput and defaultRecipeOutputJSON5 are the --output
-// defaults for the two commands that write a recipe (init, export).
-// resolveRecipeOutput swaps in the JSON5 spelling when --format json5 is
-// given without an explicit --output, so the file name matches its
-// contents and a later bare `docket validate` still finds it - both are
-// in defaultTaskFileCandidates.
-const (
-	defaultRecipeOutput      = "tasks.yml"
-	defaultRecipeOutputJSON5 = "tasks.json"
-)
+// defaultRecipeOutput is the --output default for the two commands that
+// write a recipe (init, export). It is the head of the probe list rather
+// than a constant of its own, so a scaffold written without --output is
+// by construction the file a later bare `docket validate` picks up.
+var defaultRecipeOutput = defaultTaskFileCandidates[0]
+
+// defaultRecipeOutputFor returns the --output default for a given format:
+// the first probe candidate that reads back as that format. Deriving it
+// from defaultTaskFileCandidates rather than listing per-format constants
+// is what guarantees the file resolveRecipeOutput swaps in is a file the
+// probe can find again - a default output outside that list would leave
+// the scaffold unreachable by a bare `docket validate`.
+//
+// A codec with no candidate of its own falls back to the head of the list;
+// TestDefaultRecipeOutputForEveryCodec fails if a registered codec ever
+// lands there.
+func defaultRecipeOutputFor(format string) string {
+	for _, candidate := range defaultTaskFileCandidates {
+		if detectTaskFileFormat(candidate) == format {
+			return candidate
+		}
+	}
+	return defaultTaskFileCandidates[0]
+}
 
 // resolveRecipeOutput reconciles an explicit --format with the --output
 // path a recipe-writing command is about to use, returning the path to
@@ -162,27 +171,27 @@ const (
 //     parseRecipeFormatFlag. It always wins, including over an --output
 //     extension that says otherwise.
 //  2. the --output extension, via detectTaskFileFormat.
-//  3. YAML - all that is left for stdout, which has no extension. This is
-//     the gap #410 exists to close: before --format, `--output -` could
-//     only ever emit YAML.
+//  3. the default codec - all that is left for stdout, which has no
+//     extension. This is the gap #410 exists to close: before --format,
+//     `--output -` could only ever emit YAML.
 //
 // outputChanged is flags.Changed("output"), which is only meaningful
-// after flags.Parse. When --format asks for JSON5 and --output was left
-// at its default, the default path moves to defaultRecipeOutputJSON5
-// rather than dropping a JSON5 document into a .yml file. A path the user
-// typed - including "-" - is never rewritten.
+// after flags.Parse. When --format asks for a non-default format and
+// --output was left at its default, the default path moves to that
+// format's own default rather than dropping, say, a JSON5 document into a
+// .yml file. A path the user typed - including "-" - is never rewritten.
 //
 // Callers must run this before their --force / --overwrite existence
 // checks: those have to test the path that will actually be written.
 func resolveRecipeOutput(output, override string, outputChanged bool) (string, string) {
 	if override == "" {
 		if output == taskFileStdin {
-			return output, taskFileFormatYAML
+			return output, tasks.DefaultCodec().Name()
 		}
 		return output, detectTaskFileFormat(output)
 	}
-	if output != taskFileStdin && !outputChanged && override == taskFileFormatJSON5 {
-		output = defaultRecipeOutputJSON5
+	if output != taskFileStdin && !outputChanged && override != tasks.DefaultCodec().Name() {
+		output = defaultRecipeOutputFor(override)
 	}
 	return output, override
 }
@@ -354,21 +363,12 @@ func fetchTaskFileURL(rawURL string) ([]byte, error) {
 	return data, nil
 }
 
-// taskFileExtensions lists the recipe file extensions docket recognises,
-// the single source of truth for hasTaskFileExtension and taskFileAutocomplete.
-var taskFileExtensions = []string{"yml", "yaml", "json", "json5"}
-
 // hasTaskFileExtension reports whether path carries one of the recipe
 // file extensions. Used to spot a positional recipe path in an argv the
 // flag parser has not yet processed.
 func hasTaskFileExtension(path string) bool {
-	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
-	for _, candidate := range taskFileExtensions {
-		if ext == candidate {
-			return true
-		}
-	}
-	return false
+	_, ok := tasks.CodecForExtension(filepath.Ext(path))
+	return ok
 }
 
 // probeDefaultTaskFile stats defaultTaskFileCandidates in order and
@@ -484,7 +484,7 @@ type recipeSource struct {
 	Display string
 	// Data is the recipe bytes.
 	Data []byte
-	// Format is always taskFileFormatYAML or taskFileFormatJSON5, never
+	// Format is always a canonical codec name (tasks.CodecNames()), never
 	// empty. See taskFileFormatFor.
 	Format string
 	// Ambiguous holds the default candidates the probe passed over
@@ -602,19 +602,26 @@ func predictFilesByExtension(extensions []string) complete.Predictor {
 	})
 }
 
-// recipeFormatAutocomplete offers the two canonical values shared by
+// recipeFormatAutocomplete offers the canonical values shared by
 // --tasks-format on the reading side and --format on the writing side.
-// The yml / json aliases parseRecipeFormatFlag also accepts are
-// deliberately left out so completion suggests one spelling per format.
+// The aliases parseRecipeFormatFlag also accepts are deliberately left
+// out so completion suggests one spelling per format.
 func recipeFormatAutocomplete() complete.Predictor {
-	return complete.PredictSet(taskFileFormatYAML, taskFileFormatJSON5)
+	return complete.PredictSet(tasks.CodecNames()...)
+}
+
+// recipeFormatList renders the accepted formats for flag help text, so a
+// new codec reaches --help without anyone remembering to edit six
+// strings.
+func recipeFormatList() string {
+	return strings.Join(tasks.CodecNames(), " or ")
 }
 
 // taskFileAutocomplete is the file-completion predictor shared by the
 // --tasks / --output / --vars-output flags and `docket fmt`'s positional
 // argument across apply / plan / validate / fmt / init / export.
 func taskFileAutocomplete() complete.Predictor {
-	return predictFilesByExtension(taskFileExtensions)
+	return predictFilesByExtension(tasks.CodecExtensions())
 }
 
 // commandArgv returns the argv a command should resolve its pre-parse flags

--- a/commands/task_file_test.go
+++ b/commands/task_file_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dokku/docket/tasks"
+
 	"github.com/posener/complete"
 	flag "github.com/spf13/pflag"
 )
@@ -14,18 +16,18 @@ import (
 func TestDetectTaskFileFormat(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{
-		"tasks.yml":         taskFileFormatYAML,
-		"tasks.yaml":        taskFileFormatYAML,
-		"tasks.YML":         taskFileFormatYAML,
-		"tasks.json":        taskFileFormatJSON5,
-		"tasks.JSON":        taskFileFormatJSON5,
-		"tasks.json5":       taskFileFormatJSON5,
-		"path/to/tasks.yml": taskFileFormatYAML,
-		"recipe.txt":        taskFileFormatYAML,
-		"":                  taskFileFormatYAML,
+		"tasks.yml":         tasks.FormatYAML,
+		"tasks.yaml":        tasks.FormatYAML,
+		"tasks.YML":         tasks.FormatYAML,
+		"tasks.json":        tasks.FormatNameJSON5,
+		"tasks.JSON":        tasks.FormatNameJSON5,
+		"tasks.json5":       tasks.FormatNameJSON5,
+		"path/to/tasks.yml": tasks.FormatYAML,
+		"recipe.txt":        tasks.FormatYAML,
+		"":                  tasks.FormatYAML,
 		// stdin has no extension; detection defaults to YAML here and
 		// the caller sniffs instead. See taskFileFormatFor.
-		taskFileStdin: taskFileFormatYAML,
+		taskFileStdin: tasks.FormatYAML,
 	}
 	for path, want := range cases {
 		if got := detectTaskFileFormat(path); got != want {
@@ -38,13 +40,13 @@ func TestParseRecipeFormatFlag(t *testing.T) {
 	t.Parallel()
 	valid := map[string]string{
 		"":      "",
-		"yaml":  taskFileFormatYAML,
-		"YAML":  taskFileFormatYAML,
-		"yml":   taskFileFormatYAML,
-		"json":  taskFileFormatJSON5,
-		"json5": taskFileFormatJSON5,
-		"JSON5": taskFileFormatJSON5,
-		" yaml": taskFileFormatYAML,
+		"yaml":  tasks.FormatYAML,
+		"YAML":  tasks.FormatYAML,
+		"yml":   tasks.FormatYAML,
+		"json":  tasks.FormatNameJSON5,
+		"json5": tasks.FormatNameJSON5,
+		"JSON5": tasks.FormatNameJSON5,
+		" yaml": tasks.FormatYAML,
 	}
 	for value, want := range valid {
 		got, err := parseRecipeFormatFlag("--tasks-format", value)
@@ -57,11 +59,32 @@ func TestParseRecipeFormatFlag(t *testing.T) {
 		}
 	}
 
+	// The rejection enumerates the registry, so a new codec becomes an
+	// accepted value and reaches this message without anyone editing it.
+	wantList := strings.Join(tasks.CodecNames(), ", ")
+	if wantList != "yaml, json5" {
+		t.Errorf("CodecNames() renders as %q; docs/command-reference.md and the bats suites spell it \"yaml, json5\"", wantList)
+	}
 	for _, value := range []string{"toml", "hcl", "ini", "yamlish"} {
 		if _, err := parseRecipeFormatFlag("--tasks-format", value); err == nil {
 			t.Errorf("parseRecipeFormatFlag(%q) = nil error, want a rejection", value)
-		} else if !strings.Contains(err.Error(), "yaml, json5") {
-			t.Errorf("parseRecipeFormatFlag(%q) error %q should name the valid values", value, err)
+		} else if !strings.Contains(err.Error(), wantList) {
+			t.Errorf("parseRecipeFormatFlag(%q) error %q should name the valid values %q", value, err, wantList)
+		}
+	}
+
+	// Every canonical name and alias the registry advertises must parse.
+	for _, codec := range tasks.Codecs() {
+		spellings := append([]string{codec.Name()}, codec.Aliases()...)
+		for _, spelling := range spellings {
+			got, err := parseRecipeFormatFlag("--tasks-format", spelling)
+			if err != nil {
+				t.Errorf("parseRecipeFormatFlag(%q) returned error: %v", spelling, err)
+				continue
+			}
+			if got != codec.Name() {
+				t.Errorf("parseRecipeFormatFlag(%q) = %q, want %q", spelling, got, codec.Name())
+			}
 		}
 	}
 
@@ -80,8 +103,8 @@ func TestParseRecipeFormatFlag(t *testing.T) {
 
 // TestTaskFileFormatFor pins the precedence rule: an explicit
 // --tasks-format beats extension detection, which beats a content
-// sniff. The return value must never be empty - tasks.IsJSON5Format("")
-// is false, so an empty format silently means YAML downstream.
+// sniff. The return value must never be empty - an empty format resolves
+// to tasks.DefaultCodec() downstream, so it would silently mean YAML.
 func TestTaskFileFormatFor(t *testing.T) {
 	t.Parallel()
 	jsonish := []byte("[{tasks: []}]")
@@ -94,12 +117,12 @@ func TestTaskFileFormatFor(t *testing.T) {
 		data     []byte
 		want     string
 	}{
-		{name: "override beats detection", detected: taskFileFormatYAML, override: taskFileFormatJSON5, data: yamlish, want: taskFileFormatJSON5},
-		{name: "override beats sniff", detected: "", override: taskFileFormatYAML, data: jsonish, want: taskFileFormatYAML},
-		{name: "detection beats sniff", detected: taskFileFormatYAML, data: jsonish, want: taskFileFormatYAML},
-		{name: "sniff picks json5 for stdin", detected: "", data: jsonish, want: taskFileFormatJSON5},
-		{name: "sniff picks yaml for stdin", detected: "", data: yamlish, want: taskFileFormatYAML},
-		{name: "empty stdin defaults to yaml", detected: "", data: nil, want: taskFileFormatYAML},
+		{name: "override beats detection", detected: tasks.FormatYAML, override: tasks.FormatNameJSON5, data: yamlish, want: tasks.FormatNameJSON5},
+		{name: "override beats sniff", detected: "", override: tasks.FormatYAML, data: jsonish, want: tasks.FormatYAML},
+		{name: "detection beats sniff", detected: tasks.FormatYAML, data: jsonish, want: tasks.FormatYAML},
+		{name: "sniff picks json5 for stdin", detected: "", data: jsonish, want: tasks.FormatNameJSON5},
+		{name: "sniff picks yaml for stdin", detected: "", data: yamlish, want: tasks.FormatYAML},
+		{name: "empty stdin defaults to yaml", detected: "", data: nil, want: tasks.FormatYAML},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -126,17 +149,17 @@ func TestResolveRecipeOutput(t *testing.T) {
 		wantPath      string
 		wantFormat    string
 	}{
-		{name: "default with no override", output: defaultRecipeOutput, wantPath: defaultRecipeOutput, wantFormat: taskFileFormatYAML},
-		{name: "default with json5 moves the path", output: defaultRecipeOutput, override: taskFileFormatJSON5, wantPath: defaultRecipeOutputJSON5, wantFormat: taskFileFormatJSON5},
-		{name: "default with yaml stays put", output: defaultRecipeOutput, override: taskFileFormatYAML, wantPath: defaultRecipeOutput, wantFormat: taskFileFormatYAML},
-		{name: "explicit path is never rewritten", output: "deploy/prod.yml", override: taskFileFormatJSON5, outputChanged: true, wantPath: "deploy/prod.yml", wantFormat: taskFileFormatJSON5},
-		{name: "explicit default path is never rewritten", output: defaultRecipeOutput, override: taskFileFormatJSON5, outputChanged: true, wantPath: defaultRecipeOutput, wantFormat: taskFileFormatJSON5},
-		{name: "override beats a json extension", output: "tasks.json", override: taskFileFormatYAML, outputChanged: true, wantPath: "tasks.json", wantFormat: taskFileFormatYAML},
-		{name: "extension decides with no override", output: "tasks.json5", outputChanged: true, wantPath: "tasks.json5", wantFormat: taskFileFormatJSON5},
-		{name: "unknown extension falls back to yaml", output: "recipe.txt", outputChanged: true, wantPath: "recipe.txt", wantFormat: taskFileFormatYAML},
-		{name: "stdin with no override is yaml", output: taskFileStdin, outputChanged: true, wantPath: taskFileStdin, wantFormat: taskFileFormatYAML},
-		{name: "stdin honours the override", output: taskFileStdin, override: taskFileFormatJSON5, outputChanged: true, wantPath: taskFileStdin, wantFormat: taskFileFormatJSON5},
-		{name: "stdin is never rewritten to a path", output: taskFileStdin, override: taskFileFormatJSON5, wantPath: taskFileStdin, wantFormat: taskFileFormatJSON5},
+		{name: "default with no override", output: defaultRecipeOutput, wantPath: defaultRecipeOutput, wantFormat: tasks.FormatYAML},
+		{name: "default with json5 moves the path", output: defaultRecipeOutput, override: tasks.FormatNameJSON5, wantPath: "tasks.json", wantFormat: tasks.FormatNameJSON5},
+		{name: "default with yaml stays put", output: defaultRecipeOutput, override: tasks.FormatYAML, wantPath: defaultRecipeOutput, wantFormat: tasks.FormatYAML},
+		{name: "explicit path is never rewritten", output: "deploy/prod.yml", override: tasks.FormatNameJSON5, outputChanged: true, wantPath: "deploy/prod.yml", wantFormat: tasks.FormatNameJSON5},
+		{name: "explicit default path is never rewritten", output: defaultRecipeOutput, override: tasks.FormatNameJSON5, outputChanged: true, wantPath: defaultRecipeOutput, wantFormat: tasks.FormatNameJSON5},
+		{name: "override beats a json extension", output: "tasks.json", override: tasks.FormatYAML, outputChanged: true, wantPath: "tasks.json", wantFormat: tasks.FormatYAML},
+		{name: "extension decides with no override", output: "tasks.json5", outputChanged: true, wantPath: "tasks.json5", wantFormat: tasks.FormatNameJSON5},
+		{name: "unknown extension falls back to yaml", output: "recipe.txt", outputChanged: true, wantPath: "recipe.txt", wantFormat: tasks.FormatYAML},
+		{name: "stdin with no override is yaml", output: taskFileStdin, outputChanged: true, wantPath: taskFileStdin, wantFormat: tasks.FormatYAML},
+		{name: "stdin honours the override", output: taskFileStdin, override: tasks.FormatNameJSON5, outputChanged: true, wantPath: taskFileStdin, wantFormat: tasks.FormatNameJSON5},
+		{name: "stdin is never rewritten to a path", output: taskFileStdin, override: tasks.FormatNameJSON5, wantPath: taskFileStdin, wantFormat: tasks.FormatNameJSON5},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -149,22 +172,25 @@ func TestResolveRecipeOutput(t *testing.T) {
 	}
 }
 
-// TestResolveRecipeOutputDefaultsAreProbeCandidates is what makes the
-// path swap safe: init tells the user to run a bare `docket validate`
-// next, and that probes defaultTaskFileCandidates. A default output that
-// is not in that list would leave the scaffold unreachable.
-func TestResolveRecipeOutputDefaultsAreProbeCandidates(t *testing.T) {
+// TestDefaultRecipeOutputForEveryCodec is what makes the path swap safe:
+// init tells the user to run a bare `docket validate` next, and that
+// probes defaultTaskFileCandidates. A default output that is not in that
+// list would leave the scaffold unreachable.
+//
+// defaultRecipeOutputFor now derives its answer from that same list, so
+// membership is true by construction and no longer worth asserting. What
+// is still worth asserting - and is what the old membership check was
+// really guarding - is that every registered codec has a candidate of its
+// own. A codec with none silently falls back to the head of the list, and
+// `docket init --format <it>` would write a scaffold under a name that
+// reads back as some other format.
+func TestDefaultRecipeOutputForEveryCodec(t *testing.T) {
 	t.Parallel()
-	for _, want := range []string{defaultRecipeOutput, defaultRecipeOutputJSON5} {
-		found := false
-		for _, candidate := range defaultTaskFileCandidates {
-			if candidate == want {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("%q is a default --output but not in defaultTaskFileCandidates %v", want, defaultTaskFileCandidates)
+	for _, codec := range tasks.Codecs() {
+		got := defaultRecipeOutputFor(codec.Name())
+		if detectTaskFileFormat(got) != codec.Name() {
+			t.Errorf("defaultRecipeOutputFor(%q) = %q, which reads back as %q; %q has no candidate in defaultTaskFileCandidates %v",
+				codec.Name(), got, detectTaskFileFormat(got), codec.Name(), defaultTaskFileCandidates)
 		}
 	}
 }
@@ -177,11 +203,11 @@ func TestRecipeOutputFormatMismatch(t *testing.T) {
 	t.Parallel()
 	quiet := [][2]string{
 		{"tasks.yml", ""},
-		{taskFileStdin, taskFileFormatJSON5},
-		{"tasks.json", taskFileFormatJSON5},
-		{"tasks.json5", taskFileFormatJSON5},
-		{"tasks.yml", taskFileFormatYAML},
-		{"recipe.txt", taskFileFormatYAML},
+		{taskFileStdin, tasks.FormatNameJSON5},
+		{"tasks.json", tasks.FormatNameJSON5},
+		{"tasks.json5", tasks.FormatNameJSON5},
+		{"tasks.yml", tasks.FormatYAML},
+		{"recipe.txt", tasks.FormatYAML},
 	}
 	for _, c := range quiet {
 		if got := recipeOutputFormatMismatch(c[0], c[1]); got != "" {
@@ -189,7 +215,7 @@ func TestRecipeOutputFormatMismatch(t *testing.T) {
 		}
 	}
 
-	got := recipeOutputFormatMismatch("tasks.yml", taskFileFormatJSON5)
+	got := recipeOutputFormatMismatch("tasks.yml", tasks.FormatNameJSON5)
 	if got == "" {
 		t.Fatal("recipeOutputFormatMismatch(tasks.yml, json5) = no warning, want one")
 	}
@@ -391,8 +417,8 @@ func TestResolveTaskFilePathExplicit(t *testing.T) {
 	if gotPath != path {
 		t.Errorf("path = %q, want %q", gotPath, path)
 	}
-	if gotFormat != taskFileFormatJSON5 {
-		t.Errorf("format = %q, want %q", gotFormat, taskFileFormatJSON5)
+	if gotFormat != tasks.FormatNameJSON5 {
+		t.Errorf("format = %q, want %q", gotFormat, tasks.FormatNameJSON5)
 	}
 	if len(ambiguous) != 0 {
 		t.Errorf("ambiguous = %v, want none; an explicit path never runs the probe", ambiguous)
@@ -415,7 +441,7 @@ func TestResolveTaskFilePathDefaultPrefersYAML(t *testing.T) {
 	if path != "tasks.yml" {
 		t.Errorf("path = %q, want tasks.yml", path)
 	}
-	if format != taskFileFormatYAML {
+	if format != tasks.FormatYAML {
 		t.Errorf("format = %q, want yaml", format)
 	}
 	if !slices.Equal(ambiguous, []string{"tasks.json"}) {
@@ -436,7 +462,7 @@ func TestResolveTaskFilePathDefaultFallsThroughToJSON(t *testing.T) {
 	if path != "tasks.json" {
 		t.Errorf("path = %q, want tasks.json", path)
 	}
-	if format != taskFileFormatJSON5 {
+	if format != tasks.FormatNameJSON5 {
 		t.Errorf("format = %q, want json5", format)
 	}
 	if len(ambiguous) != 0 {
@@ -588,7 +614,7 @@ func TestResolveTaskFileFromArgsUsesExplicitFlag(t *testing.T) {
 	if path != "custom.json" {
 		t.Errorf("path = %q, want custom.json", path)
 	}
-	if format != taskFileFormatJSON5 {
+	if format != tasks.FormatNameJSON5 {
 		t.Errorf("format = %q, want json5", format)
 	}
 
@@ -596,7 +622,7 @@ func TestResolveTaskFileFromArgsUsesExplicitFlag(t *testing.T) {
 	if path != "other.yml" {
 		t.Errorf("path = %q, want other.yml", path)
 	}
-	if format != taskFileFormatYAML {
+	if format != tasks.FormatYAML {
 		t.Errorf("format = %q, want yaml", format)
 	}
 }
@@ -689,7 +715,15 @@ func TestTasksFormatFromArgs(t *testing.T) {
 func TestTaskFileAutocompleteMatchesRecipeExtensions(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	recipes := []string{"tasks.yml", "config.yaml", "data.json", "recipe.json5"}
+	// Seeded from the registry rather than a fixed list, so a codec that
+	// claims a new extension is covered without editing this test.
+	var recipes []string
+	for _, ext := range tasks.CodecExtensions() {
+		recipes = append(recipes, "recipe."+ext)
+	}
+	if len(recipes) == 0 {
+		t.Fatal("no codec claims any extension; completion would offer nothing")
+	}
 	for _, name := range recipes {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("---\n"), 0o644); err != nil {
 			t.Fatalf("seed %s: %v", name, err)

--- a/commands/task_file_url_test.go
+++ b/commands/task_file_url_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/dokku/docket/tasks"
 )
 
 // serveRecipe starts an httptest server that returns body for any GET and
@@ -101,13 +103,13 @@ func TestDetectTaskFileFormatURL(t *testing.T) {
 		path string
 		want string
 	}{
-		{"http://h/docket/example.yml", taskFileFormatYAML},
-		{"https://h/recipes/tasks.yaml", taskFileFormatYAML},
-		{"http://h/tasks.json", taskFileFormatJSON5},
-		{"http://h/tasks.json5", taskFileFormatJSON5},
-		{"http://h/tasks.json?ref=main", taskFileFormatJSON5},
-		{"https://h/a/b/tasks.yml?token=abc#frag", taskFileFormatYAML},
-		{"http://h/tasks.json?download=recipe.yml", taskFileFormatJSON5},
+		{"http://h/docket/example.yml", tasks.FormatYAML},
+		{"https://h/recipes/tasks.yaml", tasks.FormatYAML},
+		{"http://h/tasks.json", tasks.FormatNameJSON5},
+		{"http://h/tasks.json5", tasks.FormatNameJSON5},
+		{"http://h/tasks.json?ref=main", tasks.FormatNameJSON5},
+		{"https://h/a/b/tasks.yml?token=abc#frag", tasks.FormatYAML},
+		{"http://h/tasks.json?download=recipe.yml", tasks.FormatNameJSON5},
 	}
 	for _, tc := range cases {
 		if got := detectTaskFileFormat(tc.path); got != tc.want {

--- a/commands/templates/default.yaml.tmpl
+++ b/commands/templates/default.yaml.tmpl
@@ -1,3 +1,4 @@
+---
 - name: <<yamlStr .Name>>
   inputs:
     - name: app

--- a/commands/templates/minimal.yaml.tmpl
+++ b/commands/templates/minimal.yaml.tmpl
@@ -1,3 +1,4 @@
+---
 - name: <<yamlStr .Name>>
   tasks:
     - name: create app

--- a/commands/templates/templates.go
+++ b/commands/templates/templates.go
@@ -7,5 +7,12 @@ package templates
 
 import "embed"
 
-//go:embed *.yml.tmpl *.json5.tmpl
+// Names follow default.<codec>.tmpl / minimal.<codec>.tmpl, where <codec>
+// is a canonical recipe format name, so init picks a template without
+// branching on the format. The glob is deliberately open-ended to let a
+// new format add its pair without touching this file;
+// TestEveryCodecHasInitTemplates is what turns a missing pair into a test
+// failure rather than a runtime error at `docket init --format <new>`.
+//
+//go:embed *.tmpl
 var FS embed.FS

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -107,7 +107,7 @@ func (c *ValidateCommand) ParsedArguments(args []string) (map[string]command.Arg
 func (c *ValidateCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "", "task file (YAML or JSON5) containing a task list. Pass - to read the recipe from stdin. When omitted, docket probes tasks.yml -> tasks.yaml -> tasks.json in the current directory.")
-	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "parse the recipe as this format (yaml or json5) instead of detecting it from the file extension. Required only when the extension is absent or wrong; stdin is otherwise sniffed from its first byte.")
+	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "parse the recipe as this format ("+recipeFormatList()+") instead of detecting it from the file extension. Required only when the extension is absent or wrong; stdin is otherwise sniffed from its first byte.")
 	f.BoolVar(&c.json, "json", false, "emit one JSON-lines problem event per finding")
 	f.BoolVar(&c.strict, "strict", false, "additionally flag required inputs that have no default and no CLI override, and check that --play / --start-at-task references resolve to real names in the file")
 	f.StringArrayVar(&c.varsFiles, "vars-file", nil, "load input values from a YAML or JSON file (repeatable; later files override earlier; CLI --name=value flags always win). A .json extension parses as JSON; otherwise YAML.")

--- a/commands/vars_file_format_test.go
+++ b/commands/vars_file_format_test.go
@@ -1,0 +1,167 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+)
+
+// vars_file_format_test.go covers how a --vars-file picks its decoder.
+//
+// That used to be a bare `filepath.Ext(path) == ".json"` compare sitting
+// outside the format stack, so it never learned about .json5: a vars-file
+// written in JSON5 - or simply named after a .json5 recipe, which is what
+// deriveVarsOutput does - reached the YAML parser and died on the first
+// comment or trailing comma. It now resolves through the codec registry
+// (#519).
+
+// TestParseVarsFileJSON5 is the behaviour change: a .json5 vars-file
+// decodes as JSON5 instead of being handed to the YAML parser.
+func TestParseVarsFileJSON5(t *testing.T) {
+	t.Parallel()
+	got, err := parseVarsFile("vars.json5", []byte("{\n  // the app to deploy\n  app: 'web',\n  replicas: 3,\n}\n"))
+	if err != nil {
+		t.Fatalf("parseVarsFile(.json5): %v", err)
+	}
+	if got["app"] != "web" {
+		t.Errorf("app = %#v, want \"web\"", got["app"])
+	}
+	if got["replicas"] != float64(3) {
+		t.Errorf("replicas = %#v, want 3", got["replicas"])
+	}
+}
+
+// TestParseVarsFileJSONUnchanged pins what a plain .json vars-file has
+// always decoded to. json5.Unmarshal is a superset of encoding/json, so
+// the values - including the float64 a JSON number lands as - must not
+// have moved.
+func TestParseVarsFileJSONUnchanged(t *testing.T) {
+	t.Parallel()
+	got, err := parseVarsFile("vars.json", []byte(`{"app": "web", "replicas": 3, "debug": true}`))
+	if err != nil {
+		t.Fatalf("parseVarsFile(.json): %v", err)
+	}
+	want := map[string]interface{}{"app": "web", "replicas": float64(3), "debug": true}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %#v (%T), want %#v (%T)", k, got[k], got[k], v, v)
+		}
+	}
+}
+
+// TestParseVarsFileUnknownExtensionIsYAML pins the fallback. A vars-file
+// is normally named after its recipe rather than after a format, so most
+// of them carry an extension no codec claims - and every one of those has
+// always been read as YAML.
+func TestParseVarsFileUnknownExtensionIsYAML(t *testing.T) {
+	t.Parallel()
+	for _, path := range []string{"vars.yml", "vars.yaml", "vars.txt", "vars", "tasks.vars.yml"} {
+		got, err := parseVarsFile(path, []byte("app: web\nreplicas: 3\n"))
+		if err != nil {
+			t.Errorf("parseVarsFile(%q): %v", path, err)
+			continue
+		}
+		if got["app"] != "web" || got["replicas"] != 3 {
+			t.Errorf("parseVarsFile(%q) = %#v, want the YAML decoding", path, got)
+		}
+	}
+}
+
+// TestParseVarsFileErrorsNameThePath keeps the message shape: whatever the
+// codec says, the user is told which --vars-file it was about.
+func TestParseVarsFileErrorsNameThePath(t *testing.T) {
+	t.Parallel()
+	cases := map[string][]byte{
+		"broken.json": []byte("{not: valid"),
+		"broken.yml":  []byte("- one\n- two\n"),
+	}
+	for path, data := range cases {
+		_, err := parseVarsFile(path, data)
+		if err == nil {
+			t.Errorf("parseVarsFile(%q) = nil error, want a rejection", path)
+			continue
+		}
+		if !strings.Contains(err.Error(), "--vars-file "+path) {
+			t.Errorf("error %q should name the flag and the path", err)
+		}
+	}
+}
+
+// TestVarsFileFollowsEveryCodec walks the registry so a new format's
+// vars-file is exercised the moment it is registered, rather than whenever
+// someone remembers to add a case here.
+func TestVarsFileFollowsEveryCodec(t *testing.T) {
+	t.Parallel()
+	vars := map[string]interface{}{"app": "web"}
+	for _, codec := range tasks.Codecs() {
+		for _, ext := range codec.Extensions() {
+			data, err := codec.MarshalVars(vars)
+			if err != nil {
+				t.Fatalf("%s MarshalVars: %v", codec.Name(), err)
+			}
+			got, err := parseVarsFile("vars."+ext, data)
+			if err != nil {
+				t.Errorf("parseVarsFile(vars.%s) written by %q: %v", ext, codec.Name(), err)
+				continue
+			}
+			if got["app"] != "web" {
+				t.Errorf("vars.%s written by %q read back as %#v", ext, codec.Name(), got)
+			}
+		}
+	}
+}
+
+// TestVarsFileDerivedFromRecipeIsReadable closes the loop deriveVarsOutput
+// opens: export names the vars-file after the recipe, so the extension it
+// splices in has to be one parseVarsFile can decode with the same codec
+// MarshalVars wrote it with.
+func TestVarsFileDerivedFromRecipeIsReadable(t *testing.T) {
+	t.Parallel()
+	vars := map[string]interface{}{"app": "web"}
+	for _, codec := range tasks.Codecs() {
+		for _, ext := range codec.Extensions() {
+			derived := deriveVarsOutput("tasks." + ext)
+			data, err := codec.MarshalVars(vars)
+			if err != nil {
+				t.Fatalf("%s MarshalVars: %v", codec.Name(), err)
+			}
+			got, err := parseVarsFile(derived, data)
+			if err != nil {
+				t.Errorf("%q derived from tasks.%s is not readable: %v", derived, ext, err)
+				continue
+			}
+			if got["app"] != "web" {
+				t.Errorf("%q read back as %#v", derived, got)
+			}
+		}
+	}
+}
+
+// TestVarsFileJSON5RecipePairEndToEnd is the reason the change is not just
+// tidying: `docket export --format json5 --output tasks.json5` derives
+// tasks.vars.json5, and reading that pair back must work.
+func TestVarsFileJSON5RecipePairEndToEnd(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.json5")
+	recipe := []byte("[\n  {\n    // deploy the app\n    inputs: [{ name: 'app', default: 'web' }],\n    tasks: [{ dokku_app: { app: '{{ .app }}' } }],\n  },\n]\n")
+	if err := os.WriteFile(path, recipe, 0o644); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+
+	varsPath := filepath.Join(dir, deriveVarsOutput("tasks.json5"))
+	if err := os.WriteFile(varsPath, []byte("{\n  // override the default\n  app: 'api',\n}\n"), 0o644); err != nil {
+		t.Fatalf("write vars: %v", err)
+	}
+
+	stdout, stderr, exit := runApply(t, path, "--list-tasks", "--vars-file", varsPath)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "dokku_app[app=api]") {
+		t.Errorf("the JSON5 vars-file did not reach the listing; got:\n%s", stdout)
+	}
+}

--- a/tasks/codec.go
+++ b/tasks/codec.go
@@ -1,0 +1,198 @@
+package tasks
+
+import "strings"
+
+// Codec is everything docket needs to know about one recipe surface
+// syntax. A recipe's format is a string on the wire - the --tasks-format /
+// --format flags, recipeSource.Format, ValidateOptions.Format - and every
+// place that used to branch on that string now resolves it to a Codec and
+// calls a method.
+//
+// Adding a format means writing one implementation and adding it to the
+// codecs slice below. Nothing else in the tree should compare a format
+// string against a literal; TestCodecConformance enforces what a new
+// implementation has to satisfy.
+type Codec interface {
+	// Name is the canonical identifier for the format: what
+	// --tasks-format / --format resolve to, and what every format string
+	// downstream holds.
+	Name() string
+
+	// Aliases are the other spellings the flags accept - "yml" for YAML,
+	// "json" for JSON5. They resolve to Name but are deliberately left
+	// out of shell completion so it suggests one spelling per format.
+	Aliases() []string
+
+	// Extensions are the file extensions, without the leading dot, that
+	// select this codec. Order matters: it is the order shell completion
+	// offers files in, so the canonical spelling comes first.
+	Extensions() []string
+
+	// Sniff reports whether data is written in this format. It is the
+	// last resort for a source with no name to key off, which in practice
+	// means stdin. The default codec is never asked - it is what
+	// SniffCodec falls back to when no other codec claims the bytes.
+	Sniff(data []byte) bool
+
+	// ToYAML converts data from this surface syntax to the YAML bytes
+	// every downstream stage reads, so the loader, the validator and
+	// flag registration all agree on how a scalar lands in a Go field.
+	//
+	// A failure comes back as this format's parse diagnostic rather than
+	// a bare error because the validator reports it to the user by Code
+	// (docs/json-output.md documents those codes as a stable machine
+	// key). Note the "yaml_parse" code is not one of these: it belongs to
+	// the yaml.v3 parse that runs after normalisation, for every format.
+	ToYAML(data []byte) ([]byte, *Problem)
+
+	// Lint reports findings only this format can raise, reading the
+	// ORIGINAL bytes rather than ToYAML's output - a duplicated JSON5 key
+	// has already been deduped by the time the conversion is done.
+	//
+	// Kept separate from ToYAML on purpose: normalizeRecipeBytes runs
+	// both, UnmarshalRecipe runs only the conversion. Folding Lint into
+	// ToYAML would make parseInputDocument and countTasks start rejecting
+	// duplicate-keyed JSON5 that they accept today.
+	Lint(data []byte) []Problem
+
+	// Format returns the canonical rendering of data - what `docket fmt`
+	// writes back.
+	Format(data []byte) ([]byte, error)
+
+	// Marshal renders v as a canonically formatted recipe document, the
+	// same bytes Format would produce for it.
+	Marshal(v interface{}) ([]byte, error)
+
+	// MarshalVars renders v as a companion vars-file: a flat mapping of
+	// input name to value, not a recipe, so it gets no canonical-form
+	// pass.
+	MarshalVars(v interface{}) ([]byte, error)
+
+	// UnmarshalVars reads a vars-file back, the other half of MarshalVars.
+	UnmarshalVars(data []byte) (map[string]interface{}, error)
+}
+
+// codecs is every recipe format docket understands, in priority order.
+//
+// The order is load-bearing three times over: codecs[0] is the default
+// codec (what an empty or unrecognised format string means), SniffCodec
+// walks the rest in order, and CodecNames drives both shell completion
+// and the "must be one of ..." rejection an invalid --tasks-format gets.
+//
+// This is an ordered literal rather than a RegisterCodec function on
+// purpose. Nothing outside this package adds a codec, so registration
+// would buy nothing and cost determinism: any init() in the package - a
+// _test.go file included - could move what DefaultCodec returns out from
+// under a package that leans on t.Parallel() throughout, and there would
+// be no way to put it back. tasks/export.go's globalExportOrder is the
+// same shape for the same reason.
+var codecs = []Codec{yamlCodec{}, json5Codec{}}
+
+// Codecs returns every registered codec in priority order.
+func Codecs() []Codec {
+	out := make([]Codec, len(codecs))
+	copy(out, codecs)
+	return out
+}
+
+// DefaultCodec is the codec a recipe is read with when nothing says
+// otherwise: an empty format string, an unrecognised one, an unknown file
+// extension, or bytes no other codec claims.
+//
+// This is the explicit default that replaced IsJSON5Format(""), which
+// decided the same question by returning false.
+func DefaultCodec() Codec {
+	return codecs[0]
+}
+
+// LookupCodec resolves a user-typed format spelling - a canonical name or
+// an alias, case-insensitive and space-tolerant - to its codec. The second
+// return is false for anything unrecognised, including the empty string;
+// callers that treat "" as "not set" must check for it first.
+func LookupCodec(spelling string) (Codec, bool) {
+	want := strings.ToLower(strings.TrimSpace(spelling))
+	if want == "" {
+		return nil, false
+	}
+	for _, codec := range codecs {
+		if codec.Name() == want {
+			return codec, true
+		}
+		for _, alias := range codec.Aliases() {
+			if alias == want {
+				return codec, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// CodecFor resolves a format string to its codec, falling back to
+// DefaultCodec for the empty string and for anything unrecognised. It is
+// the lenient lookup every dispatch site uses; the CLI has already
+// rejected a bad spelling via LookupCodec by the time a format reaches
+// here, and an embedder passing no format keeps getting YAML.
+func CodecFor(format string) Codec {
+	if codec, ok := LookupCodec(format); ok {
+		return codec
+	}
+	return DefaultCodec()
+}
+
+// CodecForExtension resolves a file extension - without the leading dot,
+// case-insensitive - to its codec. The second return is false when no
+// codec claims it, which the caller turns into DefaultCodec so an
+// explicit path like `--tasks recipe.txt` still reads as YAML.
+func CodecForExtension(ext string) (Codec, bool) {
+	want := strings.ToLower(strings.TrimPrefix(ext, "."))
+	if want == "" {
+		return nil, false
+	}
+	for _, codec := range codecs {
+		for _, candidate := range codec.Extensions() {
+			if candidate == want {
+				return codec, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// SniffCodec picks a codec from the recipe bytes themselves, for a source
+// with no name to key off. The default codec is skipped rather than asked:
+// it is the answer when nobody else claims the bytes, so letting it match
+// first would stop any other codec from ever being reached.
+func SniffCodec(data []byte) Codec {
+	fallback := DefaultCodec()
+	for _, codec := range codecs {
+		if codec.Name() == fallback.Name() {
+			continue
+		}
+		if codec.Sniff(data) {
+			return codec
+		}
+	}
+	return fallback
+}
+
+// CodecNames returns the canonical format names in priority order. It
+// backs shell completion for --tasks-format / --format and the list an
+// invalid value is rejected against, so those two can never disagree.
+func CodecNames() []string {
+	out := make([]string, 0, len(codecs))
+	for _, codec := range codecs {
+		out = append(out, codec.Name())
+	}
+	return out
+}
+
+// CodecExtensions returns every recognised recipe file extension, without
+// leading dots, in codec order and then in each codec's own order. It
+// backs file-completion and the positional-recipe-path check.
+func CodecExtensions() []string {
+	var out []string
+	for _, codec := range codecs {
+		out = append(out, codec.Extensions()...)
+	}
+	return out
+}

--- a/tasks/codec_json5.go
+++ b/tasks/codec_json5.go
@@ -1,0 +1,116 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	json5 "github.com/titanous/json5"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// FormatNameJSON5 is the canonical name of the JSON5 codec. It is spelled
+// with "Name" because FormatJSON5 is already the JSON5 formatter.
+const FormatNameJSON5 = "json5"
+
+// json5Codec reads and writes recipes as JSON5, a strict superset of JSON
+// that adds comments, trailing commas and unquoted keys. Every existing
+// JSON file is already valid JSON5, which is why "json" is an alias rather
+// than a codec of its own.
+type json5Codec struct{}
+
+func (json5Codec) Name() string { return FormatNameJSON5 }
+
+func (json5Codec) Aliases() []string { return []string{"json"} }
+
+func (json5Codec) Extensions() []string { return []string{"json", "json5"} }
+
+// Sniff claims bytes that open like a JSON5 document. After optional
+// whitespace, JSON5 always starts with `[`, `{`, or a comment; YAML
+// recipes start with `-`, `---`, or a key, none of which collide. Anything
+// else is left to the default codec, so an ambiguous stream stays YAML.
+func (json5Codec) Sniff(data []byte) bool {
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+		if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+			continue
+		}
+		if c == '/' && i+1 < len(data) && (data[i+1] == '/' || data[i+1] == '*') {
+			// A leading line/block comment - JSON5 idiom.
+			return true
+		}
+		return c == '[' || c == '{'
+	}
+	return false
+}
+
+// ToYAML parses the JSON5 document and re-emits it as YAML so the rest of
+// the pipeline (sigil render, yaml.Node walk, line/column reporting) keeps
+// a single implementation. Sigil templates inside string values survive
+// verbatim, being just text to both parsers.
+func (json5Codec) ToYAML(data []byte) ([]byte, *Problem) {
+	converted, err := json5ToYAMLBytes(data)
+	if err != nil {
+		return nil, &Problem{Code: "json5_parse", Message: err.Error()}
+	}
+	return converted, nil
+}
+
+// Lint rejects a duplicated key. json5.Unmarshal silently keeps the last
+// of a repeated pair, so the scan runs over the original bytes to catch
+// what the conversion has already thrown away - the way yaml.v3 rejects a
+// duplicate YAML key (#318).
+func (json5Codec) Lint(data []byte) []Problem {
+	dup := detectJSON5DuplicateKeys(data)
+	if dup == nil {
+		return nil
+	}
+	return []Problem{{
+		Code:    "duplicate_key",
+		Line:    dup.Line,
+		Column:  dup.Column,
+		Message: fmt.Sprintf("duplicate key %q", dup.Key),
+	}}
+}
+
+func (json5Codec) Format(data []byte) ([]byte, error) { return FormatJSON5(data) }
+
+// Marshal renders v as a canonically formatted JSON5 recipe.
+//
+// It round-trips through YAML first so the struct yaml tags drive the key
+// names - the same tags Plays() and the YAML codec use - and only then
+// re-encodes as JSON for the JSON5 formatter. Marshalling v straight to
+// JSON would key the document off json tags the task structs do not carry.
+func (json5Codec) Marshal(v interface{}) ([]byte, error) {
+	raw, err := yaml.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var generic interface{}
+	if err := yaml.Unmarshal(raw, &generic); err != nil {
+		return nil, err
+	}
+	jsonRaw, err := json.Marshal(generic)
+	if err != nil {
+		return nil, err
+	}
+	return FormatJSON5(jsonRaw)
+}
+
+// MarshalVars emits the vars mapping as indented plain JSON, which is
+// valid JSON5 and also valid YAML - so a vars-file written here still
+// loads even if it ends up named .yml.
+func (json5Codec) MarshalVars(v interface{}) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}
+
+// UnmarshalVars reads a vars-file back. json5.Unmarshal is a superset of
+// encoding/json, so a plain .json vars-file decodes to the same Go values
+// it always has, and a .json5 one carrying comments or a trailing comma
+// now decodes too instead of falling through to the YAML parser.
+func (json5Codec) UnmarshalVars(data []byte) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	if err := json5.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/tasks/codec_test.go
+++ b/tasks/codec_test.go
@@ -1,0 +1,344 @@
+package tasks
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// codecTestRecipe is a minimal well-formed recipe used to exercise a
+// codec's Marshal / Format / ToYAML round trip.
+var codecTestRecipe = []map[string]interface{}{
+	{
+		"name": "web",
+		"tasks": []map[string]interface{}{
+			{"name": "create app", "dokku_app": map[string]interface{}{"app": "web", "state": "present"}},
+		},
+	},
+}
+
+// TestCodecConformance is the contract a new codec has to satisfy. It runs
+// over the registry rather than over a hardcoded pair, so adding a format
+// is checked the moment it joins the codecs slice - which is the whole
+// point of the seam.
+func TestCodecConformance(t *testing.T) {
+	t.Parallel()
+
+	seenName := map[string]string{}
+	seenExt := map[string]string{}
+	for _, codec := range Codecs() {
+		name := codec.Name()
+		if strings.TrimSpace(name) == "" {
+			t.Fatalf("codec %T has an empty Name()", codec)
+		}
+		if prior, dup := seenName[name]; dup {
+			t.Errorf("codec %T claims the name %q already taken by %s", codec, name, prior)
+		}
+		seenName[name] = name
+
+		for _, alias := range codec.Aliases() {
+			if prior, dup := seenName[alias]; dup {
+				t.Errorf("codec %q claims the alias %q already taken by %s", name, alias, prior)
+			}
+			seenName[alias] = name
+		}
+
+		if len(codec.Extensions()) == 0 {
+			t.Errorf("codec %q claims no file extensions, so no path can ever select it", name)
+		}
+		for _, ext := range codec.Extensions() {
+			if prior, dup := seenExt[ext]; dup {
+				t.Errorf("codec %q claims the extension %q already taken by %q", name, ext, prior)
+			}
+			seenExt[ext] = name
+		}
+
+		t.Run(name+" round trip", func(t *testing.T) {
+			marshalled, err := codec.Marshal(codecTestRecipe)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			// What Marshal emits must already be canonical, or `docket
+			// export` would write a file `docket fmt --check` rejects.
+			formatted, err := codec.Format(marshalled)
+			if err != nil {
+				t.Fatalf("Format of Marshal output: %v", err)
+			}
+			if string(formatted) != string(marshalled) {
+				t.Errorf("Marshal output is not canonical:\nmarshalled:\n%s\nformatted:\n%s", marshalled, formatted)
+			}
+
+			// And it must read back, or the format could be written but
+			// never applied.
+			if _, problem := codec.ToYAML(marshalled); problem != nil {
+				t.Fatalf("ToYAML of Marshal output: %s", problem.Message)
+			}
+			if problems := codec.Lint(marshalled); len(problems) > 0 {
+				t.Errorf("Lint of Marshal output = %v, want none", problems)
+			}
+
+			recipe, err := UnmarshalRecipe(marshalled, name)
+			if err != nil {
+				t.Fatalf("UnmarshalRecipe: %v", err)
+			}
+			if len(recipe) != 1 {
+				t.Errorf("round-tripped recipe = %d plays, want 1", len(recipe))
+			}
+		})
+	}
+}
+
+// TestLookupCodec pins the spellings the --tasks-format / --format flags
+// accept. The empty string is a miss on purpose: it means "flag not set",
+// and parseRecipeFormatFlag has to answer that before it asks here.
+func TestLookupCodec(t *testing.T) {
+	t.Parallel()
+	hits := map[string]string{
+		"yaml":  FormatYAML,
+		"yml":   FormatYAML,
+		"YAML":  FormatYAML,
+		"YML":   FormatYAML,
+		" yaml": FormatYAML,
+		"yaml ": FormatYAML,
+		"json":  FormatNameJSON5,
+		"json5": FormatNameJSON5,
+		"JSON5": FormatNameJSON5,
+	}
+	for spelling, want := range hits {
+		codec, ok := LookupCodec(spelling)
+		if !ok {
+			t.Errorf("LookupCodec(%q) = miss, want %q", spelling, want)
+			continue
+		}
+		if codec.Name() != want {
+			t.Errorf("LookupCodec(%q) = %q, want %q", spelling, codec.Name(), want)
+		}
+	}
+
+	for _, spelling := range []string{"", "   ", "toml", "hcl", "ini", "yamlish", "js"} {
+		if codec, ok := LookupCodec(spelling); ok {
+			t.Errorf("LookupCodec(%q) = %q, want a miss", spelling, codec.Name())
+		}
+	}
+}
+
+// TestCodecForFallsBackToDefault pins the explicit default that replaced
+// the IsJSON5Format("") fallthrough: an absent or unrecognised format is
+// read as the default codec rather than deciding anything by accident.
+func TestCodecForFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	for _, format := range []string{"", "toml", "hcl", "nonsense"} {
+		if got := CodecFor(format).Name(); got != DefaultCodec().Name() {
+			t.Errorf("CodecFor(%q) = %q, want the default codec %q", format, got, DefaultCodec().Name())
+		}
+	}
+	if got := CodecFor("json").Name(); got != FormatNameJSON5 {
+		t.Errorf("CodecFor(\"json\") = %q, want %q; the lenient lookup must still resolve aliases", got, FormatNameJSON5)
+	}
+}
+
+func TestCodecForExtension(t *testing.T) {
+	t.Parallel()
+	hits := map[string]string{
+		"yml":   FormatYAML,
+		"yaml":  FormatYAML,
+		".yml":  FormatYAML,
+		".YML":  FormatYAML,
+		"json":  FormatNameJSON5,
+		"json5": FormatNameJSON5,
+		".JSON": FormatNameJSON5,
+	}
+	for ext, want := range hits {
+		codec, ok := CodecForExtension(ext)
+		if !ok {
+			t.Errorf("CodecForExtension(%q) = miss, want %q", ext, want)
+			continue
+		}
+		if codec.Name() != want {
+			t.Errorf("CodecForExtension(%q) = %q, want %q", ext, codec.Name(), want)
+		}
+	}
+
+	for _, ext := range []string{"", ".", "txt", ".txt", "toml"} {
+		if codec, ok := CodecForExtension(ext); ok {
+			t.Errorf("CodecForExtension(%q) = %q, want a miss so the caller can fall back", ext, codec.Name())
+		}
+	}
+}
+
+// TestSniffCodec covers the content sniff that decides the format of a
+// recipe with no filename - stdin. The comment and end-of-input cases are
+// the ones a careless implementation gets wrong: a lone "/" must not be
+// read as the start of a comment.
+func TestSniffCodec(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "array opens json5", data: "[{tasks: []}]", want: FormatNameJSON5},
+		{name: "object opens json5", data: `{"a": 1}`, want: FormatNameJSON5},
+		{name: "line comment opens json5", data: "// a recipe\n[]", want: FormatNameJSON5},
+		{name: "block comment opens json5", data: "/* a recipe */\n[]", want: FormatNameJSON5},
+		{name: "leading whitespace before array", data: "  \n\t[]", want: FormatNameJSON5},
+		{name: "leading whitespace before comment", data: "\r\n  // hi\n[]", want: FormatNameJSON5},
+		{name: "document marker is yaml", data: "---\n- tasks: []\n", want: FormatYAML},
+		{name: "bare key is yaml", data: "tasks: []\n", want: FormatYAML},
+		{name: "sequence dash is yaml", data: "- tasks: []\n", want: FormatYAML},
+		{name: "yaml comment is yaml", data: "# a recipe\n- tasks: []\n", want: FormatYAML},
+		{name: "empty is yaml", data: "", want: FormatYAML},
+		{name: "whitespace only is yaml", data: "  \n\t\r\n", want: FormatYAML},
+		{name: "lone slash at end of input is yaml", data: "/", want: FormatYAML},
+		{name: "slash then non-comment is yaml", data: "/x", want: FormatYAML},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SniffCodec([]byte(tt.data)).Name(); got != tt.want {
+				t.Errorf("SniffCodec(%q) = %q, want %q", tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCodecNamesAndExtensions pins the ordered lists the CLI surfaces
+// verbatim: CodecNames drives shell completion and the "must be one of
+// ..." rejection, CodecExtensions drives file completion and the
+// positional-recipe-path check. Reordering either is user-visible.
+func TestCodecNamesAndExtensions(t *testing.T) {
+	t.Parallel()
+	if got, want := CodecNames(), []string{"yaml", "json5"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("CodecNames() = %v, want %v", got, want)
+	}
+	if got, want := CodecExtensions(), []string{"yml", "yaml", "json", "json5"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("CodecExtensions() = %v, want %v", got, want)
+	}
+	if got := DefaultCodec().Name(); got != FormatYAML {
+		t.Errorf("DefaultCodec() = %q, want %q; YAML is what an unknown format resolves to", got, FormatYAML)
+	}
+}
+
+// TestCodecsIsACopy stops a caller from reordering the registry - and so
+// changing the default codec - through the slice Codecs hands back.
+func TestCodecsIsACopy(t *testing.T) {
+	t.Parallel()
+	got := Codecs()
+	if len(got) < 2 {
+		t.Fatalf("Codecs() = %d codecs, want at least 2", len(got))
+	}
+	got[0] = got[1]
+	if DefaultCodec().Name() != FormatYAML {
+		t.Errorf("mutating the Codecs() result changed DefaultCodec() to %q", DefaultCodec().Name())
+	}
+}
+
+// TestCodecMarshalVarsRoundTrip covers the vars-file pair, which had no
+// direct test before: every codec must read back what it writes.
+func TestCodecMarshalVarsRoundTrip(t *testing.T) {
+	t.Parallel()
+	vars := map[string]interface{}{"app": "web", "domain": "example.com"}
+	for _, codec := range Codecs() {
+		t.Run(codec.Name(), func(t *testing.T) {
+			out, err := codec.MarshalVars(vars)
+			if err != nil {
+				t.Fatalf("MarshalVars: %v", err)
+			}
+			back, err := codec.UnmarshalVars(out)
+			if err != nil {
+				t.Fatalf("UnmarshalVars(%q): %v", out, err)
+			}
+			if !reflect.DeepEqual(back, vars) {
+				t.Errorf("round trip = %#v, want %#v (via %q)", back, vars, out)
+			}
+		})
+	}
+}
+
+// TestYAMLCodecUnmarshalVarsShapes pins the edge cases the --vars-file
+// reader has always handled: an empty document is an empty mapping, and a
+// non-mapping document is a named error rather than a nil map.
+func TestYAMLCodecUnmarshalVarsShapes(t *testing.T) {
+	t.Parallel()
+	codec := yamlCodec{}
+
+	got, err := codec.UnmarshalVars([]byte(""))
+	if err != nil {
+		t.Fatalf("UnmarshalVars(empty): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("UnmarshalVars(empty) = %#v, want an empty mapping", got)
+	}
+
+	if _, err := codec.UnmarshalVars([]byte("- one\n- two\n")); err == nil {
+		t.Error("UnmarshalVars(sequence) = nil error, want a rejection")
+	} else if !strings.Contains(err.Error(), "must be a mapping") {
+		t.Errorf("UnmarshalVars(sequence) error %q should say the document must be a mapping", err)
+	}
+}
+
+// TestJSON5CodecUnmarshalVarsAcceptsJSON5 is the behaviour change in #519:
+// a vars-file with JSON5 syntax used to reach the YAML parser and fail.
+// Plain JSON still decodes to the same Go values, since json5.Unmarshal is
+// a superset of encoding/json.
+func TestJSON5CodecUnmarshalVarsAcceptsJSON5(t *testing.T) {
+	t.Parallel()
+	codec := json5Codec{}
+	want := map[string]interface{}{"app": "web", "port": float64(8080)}
+
+	for _, data := range []string{
+		`{"app": "web", "port": 8080}`,
+		"{\n  // the app\n  app: 'web',\n  port: 8080,\n}\n",
+	} {
+		got, err := codec.UnmarshalVars([]byte(data))
+		if err != nil {
+			t.Errorf("UnmarshalVars(%q): %v", data, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("UnmarshalVars(%q) = %#v, want %#v", data, got, want)
+		}
+	}
+}
+
+// TestJSON5CodecToYAMLReportsParseProblem pins the diagnostic a malformed
+// document produces. docs/json-output.md documents json5_parse as a stable
+// machine key, so the Code matters as much as the failure.
+func TestJSON5CodecToYAMLReportsParseProblem(t *testing.T) {
+	t.Parallel()
+	converted, problem := json5Codec{}.ToYAML([]byte("[{tasks: }"))
+	if problem == nil {
+		t.Fatal("ToYAML(malformed) = nil problem, want a json5_parse finding")
+	}
+	if problem.Code != "json5_parse" {
+		t.Errorf("problem code = %q, want json5_parse", problem.Code)
+	}
+	if converted != nil {
+		t.Errorf("ToYAML(malformed) returned %q, want nil bytes so a caller cannot parse a half-conversion", converted)
+	}
+}
+
+// TestJSON5CodecLintReadsOriginalBytes is why Lint is a separate method:
+// ToYAML's output has already lost the duplicate, so linting the converted
+// bytes would never find one.
+func TestJSON5CodecLintReadsOriginalBytes(t *testing.T) {
+	t.Parallel()
+	codec := json5Codec{}
+	src := []byte("[{name: 'a', name: 'b', tasks: []}]")
+
+	problems := codec.Lint(src)
+	if len(problems) != 1 {
+		t.Fatalf("Lint(duplicate) = %d problems, want 1", len(problems))
+	}
+	if problems[0].Code != "duplicate_key" {
+		t.Errorf("problem code = %q, want duplicate_key", problems[0].Code)
+	}
+
+	converted, problem := codec.ToYAML(src)
+	if problem != nil {
+		t.Fatalf("ToYAML: %s", problem.Message)
+	}
+	if got := codec.Lint(converted); len(got) != 0 {
+		t.Errorf("Lint(converted) = %v; the duplicate should already be gone, which is why Lint takes the original", got)
+	}
+}

--- a/tasks/codec_yaml.go
+++ b/tasks/codec_yaml.go
@@ -1,0 +1,92 @@
+package tasks
+
+import (
+	"fmt"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// FormatYAML is the canonical name of the YAML codec.
+const FormatYAML = "yaml"
+
+// yamlCodec reads and writes recipes as YAML, docket's original and
+// default surface syntax. It is codecs[0], which makes it the format an
+// empty or unrecognised format string resolves to.
+type yamlCodec struct{}
+
+func (yamlCodec) Name() string { return FormatYAML }
+
+func (yamlCodec) Aliases() []string { return []string{"yml"} }
+
+func (yamlCodec) Extensions() []string { return []string{"yml", "yaml"} }
+
+// Sniff never claims bytes. YAML is the default codec, so it is what
+// SniffCodec falls back to; claiming here as well would mean no other
+// codec is ever reached.
+func (yamlCodec) Sniff([]byte) bool { return false }
+
+// ToYAML is the identity: the rest of the pipeline already reads YAML.
+func (yamlCodec) ToYAML(data []byte) ([]byte, *Problem) { return data, nil }
+
+// Lint has nothing to add. A duplicate YAML key is rejected by yaml.v3
+// itself during the parse that follows normalisation.
+func (yamlCodec) Lint([]byte) []Problem { return nil }
+
+func (yamlCodec) Format(data []byte) ([]byte, error) { return Format(data) }
+
+// Marshal renders v as YAML and then canonicalises it, so an exported
+// recipe comes out byte-identical to one `docket fmt` has been run over.
+func (yamlCodec) Marshal(v interface{}) ([]byte, error) {
+	raw, err := yaml.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return Format(raw)
+}
+
+// MarshalVars emits the vars mapping as plain YAML. Unlike Marshal it gets
+// no canonical-form pass: a vars-file is a flat mapping of input name to
+// value, not a recipe, so the play/envelope key ordering has nothing to
+// say about it.
+func (yamlCodec) MarshalVars(v interface{}) ([]byte, error) { return yaml.Marshal(v) }
+
+// UnmarshalVars reads a vars-file back into a string-keyed map.
+//
+// yaml.v3 decodes mapping keys as interface{}, so the result is converted
+// to string keys and nested maps normalised, giving JSON-like consumers
+// the same shape regardless of which codec produced the file. Errors come
+// back unwrapped; the caller names the path.
+func (yamlCodec) UnmarshalVars(data []byte) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	var raw interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return out, nil
+	}
+	if asMap, ok := raw.(map[string]interface{}); ok {
+		return asMap, nil
+	}
+	// yaml.v3 returns map[string]interface{} for the common case but
+	// older fixtures sometimes round-trip as map[interface{}]interface{};
+	// normalise that path too.
+	if generic, ok := raw.(map[interface{}]interface{}); ok {
+		return normaliseYAMLMap(generic)
+	}
+	return nil, fmt.Errorf("top-level document must be a mapping of input names to values")
+}
+
+// normaliseYAMLMap converts an interface-keyed YAML mapping to a
+// string-keyed one, rejecting a key that is not a string.
+func normaliseYAMLMap(in map[interface{}]interface{}) (map[string]interface{}, error) {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		ks, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("non-string key %v", k)
+		}
+		out[ks] = v
+	}
+	return out, nil
+}

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -2,14 +2,12 @@ package tasks
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // AppExporter is implemented by a task type that can reconstruct its recipe
@@ -870,36 +868,17 @@ func sanitizeIdent(s string) string {
 	return b.String()
 }
 
-// MarshalRecipe renders the assembled recipe as canonical YAML (or JSON5 when
-// format is a JSON5 alias), using the same formatter as `docket fmt`.
+// MarshalRecipe renders the assembled recipe in the codec keyed by format,
+// canonicalised by the same formatter as `docket fmt`.
 func (res *ExportResult) MarshalRecipe(format string) ([]byte, error) {
-	raw, err := yaml.Marshal(res.plays)
-	if err != nil {
-		return nil, err
-	}
-	if IsJSON5Format(format) {
-		// Round-trip through YAML so the struct yaml tags drive the keys, then
-		// re-encode as JSON for the JSON5 formatter.
-		var generic interface{}
-		if err := yaml.Unmarshal(raw, &generic); err != nil {
-			return nil, err
-		}
-		jsonRaw, err := json.Marshal(generic)
-		if err != nil {
-			return nil, err
-		}
-		return FormatJSON5(jsonRaw)
-	}
-	return Format(raw)
+	return CodecFor(format).Marshal(res.plays)
 }
 
 // MarshalVars renders the companion vars-file (a flat mapping of input name to
-// value) in YAML or JSON to match the vars-output extension.
+// value) in the codec keyed by format, which the caller takes from --format or
+// from the vars-output extension.
 func (res *ExportResult) MarshalVars(format string) ([]byte, error) {
-	if IsJSON5Format(format) {
-		return json.MarshalIndent(res.Vars, "", "  ")
-	}
-	return yaml.Marshal(res.Vars)
+	return CodecFor(format).MarshalVars(res.Vars)
 }
 
 // HasVars reports whether the export lifted any values into the vars map.

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -1284,3 +1284,113 @@ func TestExportPortsEmitsNoTaskWithoutMappings(t *testing.T) {
 		t.Errorf("expected no exported task when the app has no mappings, got %v", bodies)
 	}
 }
+
+// TestMarshalRecipeJSON5 covers the format argument that every other
+// MarshalRecipe test passes as the literal "yaml": the JSON5 arm was only
+// ever reached end-to-end through `docket export`, so a codec-level
+// regression had nowhere to surface in this package.
+//
+// The assertions are about shape rather than an exact document: a
+// top-level array, unquoted identifier keys and a task type in the body,
+// none of which YAML output would satisfy.
+func TestMarshalRecipeJSON5(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
+
+	res, err := ExportRecipe(ctx, ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	recipe, err := res.MarshalRecipe(FormatNameJSON5)
+	if err != nil {
+		t.Fatalf("MarshalRecipe(json5): %v", err)
+	}
+	out := string(recipe)
+
+	if !strings.HasPrefix(out, "[") {
+		t.Errorf("JSON5 recipe should open with a top-level array, got:\n%s", out)
+	}
+	if strings.HasPrefix(out, "---") {
+		t.Error("JSON5 recipe must not carry the YAML document marker")
+	}
+	if !strings.Contains(out, "dokku_app") {
+		t.Errorf("JSON5 recipe should name the app task type, got:\n%s", out)
+	}
+
+	// What Marshal emits is already canonical, and it reads back as a
+	// recipe - the two properties `docket export | docket apply` needs.
+	formatted, err := FormatJSON5(recipe)
+	if err != nil {
+		t.Fatalf("FormatJSON5: %v", err)
+	}
+	if string(formatted) != out {
+		t.Errorf("MarshalRecipe(json5) output is not canonical:\ngot:\n%s\nformatted:\n%s", out, formatted)
+	}
+	if _, err := UnmarshalRecipe(recipe, FormatNameJSON5); err != nil {
+		t.Fatalf("UnmarshalRecipe of the JSON5 export: %v", err)
+	}
+
+	// The YAML and JSON5 renderings must describe the same recipe.
+	yamlRecipe, err := res.MarshalRecipe(FormatYAML)
+	if err != nil {
+		t.Fatalf("MarshalRecipe(yaml): %v", err)
+	}
+	fromYAML, err := UnmarshalRecipe(yamlRecipe, FormatYAML)
+	if err != nil {
+		t.Fatalf("UnmarshalRecipe(yaml): %v", err)
+	}
+	fromJSON5, err := UnmarshalRecipe(recipe, FormatNameJSON5)
+	if err != nil {
+		t.Fatalf("UnmarshalRecipe(json5): %v", err)
+	}
+	if len(fromYAML) != len(fromJSON5) {
+		t.Errorf("YAML export = %d plays, JSON5 export = %d; the two renderings must agree", len(fromYAML), len(fromJSON5))
+	}
+}
+
+// TestMarshalVarsMatchesTheCodec pins the vars-file side of the same
+// dispatch. YAML gets a plain mapping; JSON5 gets indented JSON, which is
+// valid YAML too - which is why a .yml vars-file holding JSON still loads
+// and why recipeOutputFormatMismatch deliberately says nothing about it.
+func TestMarshalVarsMatchesTheCodec(t *testing.T) {
+	t.Parallel()
+	ctx := subprocess.ContextWithRunner(testCtx(), fakeDokku(exportFixture()))
+
+	res, err := ExportRecipe(ctx, ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if !res.HasVars() {
+		t.Fatal("export fixture lifted no vars; nothing to marshal")
+	}
+
+	asYAML, err := res.MarshalVars(FormatYAML)
+	if err != nil {
+		t.Fatalf("MarshalVars(yaml): %v", err)
+	}
+	if strings.HasPrefix(strings.TrimSpace(string(asYAML)), "{") {
+		t.Errorf("YAML vars-file should be a plain mapping, got:\n%s", asYAML)
+	}
+
+	asJSON5, err := res.MarshalVars(FormatNameJSON5)
+	if err != nil {
+		t.Fatalf("MarshalVars(json5): %v", err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(string(asJSON5)), "{") {
+		t.Errorf("JSON5 vars-file should be a JSON object, got:\n%s", asJSON5)
+	}
+
+	// Both spellings must read back to the same values.
+	fromYAML, err := CodecFor(FormatYAML).UnmarshalVars(asYAML)
+	if err != nil {
+		t.Fatalf("UnmarshalVars(yaml): %v", err)
+	}
+	fromJSON5, err := CodecFor(FormatNameJSON5).UnmarshalVars(asJSON5)
+	if err != nil {
+		t.Fatalf("UnmarshalVars(json5): %v", err)
+	}
+	if !reflect.DeepEqual(fromYAML, fromJSON5) {
+		t.Errorf("vars round-trip differs by codec:\nyaml:  %#v\njson5: %#v", fromYAML, fromJSON5)
+	}
+}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -13,25 +13,14 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-// Task file format identifiers shared with the commands package.
-//
-// The empty string and any unrecognised value are treated as YAML so
-// existing call sites that pass no format keep their pre-#218 behaviour.
-const (
-	FormatYAML       = "yaml"
-	FormatNameJSON5  = "json5"
-)
-
-// IsJSON5Format returns true when format is one of the JSON5 aliases.
-// Centralised so the json/json5 split lives in exactly one place.
-func IsJSON5Format(format string) bool {
-	return format == FormatNameJSON5 || format == "json"
-}
-
-// UnmarshalRecipe decodes data as a Recipe using the parser keyed by
+// UnmarshalRecipe decodes data as a Recipe using the codec keyed by
 // format. Exposed because the commands package's input-extraction path
 // (parseInputDocument) needs the same dispatch and there is no benefit
-// to duplicating the switch.
+// to duplicating it.
+//
+// The codec's ToYAML runs but its Lint deliberately does not: this path
+// feeds parseInputDocument and countTasks, which accept a duplicate-keyed
+// JSON5 recipe today. normalizeRecipeBytes is the one that lints.
 //
 // JSON5 is normalised to YAML bytes and decoded by yaml.v3 rather than fed to
 // json5.Unmarshal directly, which is what the loader and the validator already
@@ -43,13 +32,12 @@ func IsJSON5Format(format string) bool {
 // declared - the #493 symptom reached through a second door.
 func UnmarshalRecipe(data []byte, format string) (Recipe, error) {
 	recipe := Recipe{}
-	if IsJSON5Format(format) {
-		converted, err := json5ToYAMLBytes(data)
-		if err != nil {
-			return nil, fmt.Errorf("json5 unmarshal error: %v", err.Error())
-		}
-		data = converted
+	codec := CodecFor(format)
+	converted, problem := codec.ToYAML(data)
+	if problem != nil {
+		return nil, fmt.Errorf("%s unmarshal error: %v", codec.Name(), problem.Message)
 	}
+	data = converted
 	if err := yaml.Unmarshal(data, &recipe); err != nil {
 		return nil, fmt.Errorf("unmarshal error: %v", err.Error())
 	}
@@ -576,7 +564,7 @@ func GetTasks(data []byte, context map[string]interface{}) (OrderedStringEnvelop
 // the evaluation context (file-level only, per the spec - the play's own
 // inputs are not visible to its own when).
 func GetPlays(data []byte, context map[string]interface{}, userSet map[string]bool) ([]*Play, error) {
-	return GetPlaysWithFormat(data, FormatYAML, context, userSet)
+	return GetPlaysWithFormat(data, DefaultCodec().Name(), context, userSet)
 }
 
 // GetPlaysWithFormat is the format-aware variant of GetPlays. format is

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -119,30 +119,21 @@ type parsedTaskEntry struct {
 }
 
 // normalizeRecipeBytes converts a recipe's on-disk surface syntax to YAML
-// bytes. JSON5 input is converted via json5ToYAMLBytes; YAML (and any
-// unknown format value) passes through unchanged. A conversion failure is
-// returned as a json5_parse problem.
+// bytes using the codec keyed by format, and reports the format-specific
+// findings that survive the conversion.
+//
+// Lint reads the original bytes, not the converted ones, because the
+// conversion is what threw the evidence away: json5.Unmarshal keeps the
+// last of a duplicated pair. Either failure returns nil bytes, so a caller
+// that ignores the problems cannot go on to parse a half-converted recipe.
 func normalizeRecipeBytes(data []byte, format string) ([]byte, []Problem) {
-	if !IsJSON5Format(format) {
-		return data, nil
+	codec := CodecFor(format)
+	converted, problem := codec.ToYAML(data)
+	if problem != nil {
+		return nil, []Problem{*problem}
 	}
-	converted, err := json5ToYAMLBytes(data)
-	if err != nil {
-		return nil, []Problem{{
-			Code:    "json5_parse",
-			Message: err.Error(),
-		}}
-	}
-	// json5.Unmarshal deduped any duplicate keys during the conversion
-	// above; scan the original bytes so a copy-pasted key is rejected the
-	// way yaml.v3 rejects a duplicate YAML key (#318).
-	if dup := detectJSON5DuplicateKeys(data); dup != nil {
-		return nil, []Problem{{
-			Code:    "duplicate_key",
-			Line:    dup.Line,
-			Column:  dup.Column,
-			Message: fmt.Sprintf("duplicate key %q", dup.Key),
-		}}
+	if problems := codec.Lint(data); len(problems) > 0 {
+		return nil, problems
 	}
 	return converted, nil
 }


### PR DESCRIPTION
A recipe's format was a bare string threaded through every layer, and every place that acted on it was an open-coded two-branch `if` keyed off `IsJSON5Format`, which is a boolean and so made the codebase read "JSON5 or else YAML" everywhere. A `Codec` now carries the name, aliases, extensions, content sniff, YAML normalisation, format-specific lint, canonical formatter, and the recipe and vars-file marshallers, and an ordered registry in the `tasks` package resolves a format string to one. Adding a format is writing an implementation and adding it to that slice.

`IsJSON5Format` is removed along with the format constants the `commands` package kept in parallel, and the empty format now resolves to an explicit default codec rather than falling through a boolean that happened to return false. The accepted spellings, extension mapping, sniff, rejection messages, completion sets and emitted bytes are unchanged, so there is no documentation to update; `--help` output is byte-identical and the bats suites pass untouched, which is the behaviour-preservation evidence.

One behaviour changes on purpose. `parseVarsFile` picked its decoder with a raw `filepath.Ext(path) == ".json"` compare that never learned about `.json5`, so a JSON5 vars-file - including the one `deriveVarsOutput` names for a `.json5` recipe - reached the YAML parser and died on its first comment. It now resolves through the registry. A `.json` vars-file decodes to the same Go values as before, because the JSON5 codec reads it with `json5.Unmarshal`, a superset of `encoding/json`.

The seam is narrower than the issue suggests for #418: it gives the conversion one place to hook the dispatch, but there is no `FromYAML` and the JSON5 `Marshal` path does not preserve comments, so comment-preserving cross-format conversion is still work that issue has to write. #407 is the case this makes cheap.

The new tests walk the registry rather than a fixed pair, so a third codec is checked the moment it is registered: conformance over names, aliases and extensions plus a marshal/format/read-back round trip, a guard that every codec ships `docket init` templates, one that every codec has a probe candidate that reads back as itself, and vars-file round trips per codec. The content sniff and `MarshalVars` had no direct tests at all before; the sniff table now covers the comment and end-of-input branches, one of which panics if the bounds check is dropped.

Closes #519
