### PR TITLE
feat: let docket fmt convert between yaml and json5

### DIFF
--- a/commands/fmt.go
+++ b/commands/fmt.go
@@ -64,6 +64,22 @@ type FmtCommand struct {
 	// tasksFormatFlag is the raw --tasks-format value, overriding both
 	// the per-file extension detection and the stdin content sniff.
 	tasksFormatFlag string
+
+	// formatFlag is the raw --format value: the format to WRITE. When it
+	// names a format the recipe was not read as, fmt converts rather than
+	// reformats. It is the same flag init and export take, and the output
+	// counterpart to --tasks-format.
+	formatFlag string
+
+	// output redirects the write to a named path instead of the file that
+	// was read; "-" streams to stdout. Empty means format in place.
+	output string
+
+	// force permits an --output that would overwrite an existing file.
+	// Formatting in place needs no such permission - clobbering the file it
+	// just read is what fmt has always done - so this guards only the new
+	// ability to write over a file the command did not read.
+	force bool
 }
 
 func (c *FmtCommand) Name() string {
@@ -91,6 +107,10 @@ func (c *FmtCommand) Examples() map[string]string {
 		"Format every yaml under recipes/":        fmt.Sprintf("%s %s 'recipes/*.yml'", appName, c.Name()),
 		"Format every JSON5 file under recipes/":  fmt.Sprintf("%s %s 'recipes/*.json5'", appName, c.Name()),
 		"Force colorized diff in a pipe":          fmt.Sprintf("%s %s --diff --color always", appName, c.Name()),
+		"Convert a recipe to JSON5 on stdout":     fmt.Sprintf("cat tasks.yml | %s %s --format json5 -", appName, c.Name()),
+		"Convert a recipe to a new file":          fmt.Sprintf("%s %s --format json5 --output tasks.json5 tasks.yml", appName, c.Name()),
+		"Convert a recipe in place":               fmt.Sprintf("%s %s --format json5 tasks.json", appName, c.Name()),
+		"Convert a flow-style YAML recipe":        fmt.Sprintf("cat tasks.yml | %s %s --tasks-format yaml --format json5 -", appName, c.Name()),
 	}
 }
 
@@ -111,7 +131,10 @@ func (c *FmtCommand) FlagSet() *flag.FlagSet {
 	f.BoolVar(&c.check, "check", false, "exit non-zero if any file is not canonically formatted; do not write")
 	f.BoolVar(&c.diff, "diff", false, "print a unified diff for any file that is not canonically formatted; do not write")
 	f.StringVar(&c.color, "color", "auto", "when to colorize diff output: auto, always, never")
-	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "format the recipe as this format ("+recipeFormatList()+") instead of detecting it from the file extension, or from the first byte when reading stdin. Needed for a flow-style YAML recipe, which starts with [ and would otherwise sniff as JSON5.")
+	f.StringVar(&c.tasksFormatFlag, "tasks-format", "", "read the recipe as this format ("+recipeFormatList()+") instead of detecting it from the file extension, or from the first byte when reading stdin. Needed for a flow-style YAML recipe, which starts with [ and would otherwise sniff as JSON5.")
+	f.StringVar(&c.formatFlag, "format", "", "write the recipe as this format ("+recipeFormatList()+"), converting it when that is not the format it was read as. Comments are preserved; YAML anchors and merge keys are inlined, since no other format has them.")
+	f.StringVar(&c.output, "output", "", "write to this path instead of formatting in place; pass - to write to stdout. Takes a single recipe.")
+	f.BoolVar(&c.force, "force", false, "overwrite an existing --output file")
 	return f
 }
 
@@ -123,6 +146,9 @@ func (c *FmtCommand) AutocompleteFlags() complete.Flags {
 			"--diff":         complete.PredictNothing,
 			"--color":        complete.PredictSet("auto", "always", "never"),
 			"--tasks-format": recipeFormatAutocomplete(),
+			"--format":       recipeFormatAutocomplete(),
+			"--output":       taskFileAutocomplete(),
+			"--force":        complete.PredictNothing,
 		},
 	)
 }
@@ -130,8 +156,11 @@ func (c *FmtCommand) AutocompleteFlags() complete.Flags {
 // Run executes fmt against the resolved file list and reports per-file
 // outcomes. Exit codes:
 //
-//	0 - every file is canonical (or was successfully formatted in place)
-//	1 - flag parse error, IO error, parse / round-trip failure, or
+//	0 - every file is canonical (or was successfully formatted, converted,
+//	    or written to --output)
+//	1 - flag parse error, a rejected flag combination, an --output that
+//	    would overwrite an existing file without --force, IO error, parse /
+//	    round-trip failure, a --check that would have to convert, or a
 //	    --check mismatch on at least one file
 func (c *FmtCommand) Run(args []string) int {
 	flags := c.FlagSet()
@@ -154,10 +183,24 @@ func (c *FmtCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
+	outputOverride, err := parseRecipeFormatFlag("--format", c.formatFlag)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	if err := c.checkFlagCombination(flags); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
 
 	positional := flags.Args()
 	if len(positional) == 1 && positional[0] == taskFileStdin {
-		return c.runStdin(formatOverride)
+		if err := c.checkOutputTarget(""); err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		return c.runStdin(formatOverride, outputOverride)
 	}
 	// stdin produces one stream, so it cannot be combined with named
 	// files. Without this the "-" falls through to expandPaths, matches
@@ -181,18 +224,79 @@ func (c *FmtCommand) Run(args []string) int {
 		c.Ui.Warn(ambiguousTaskFileWarning(paths[0], ambiguous))
 	}
 
+	if c.output != "" {
+		// --output names one destination, so it can only describe one
+		// source. Silently writing each file over the last would be worse
+		// than saying so.
+		if len(paths) != 1 {
+			c.Ui.Error(fmt.Sprintf("--output takes a single recipe, but %d paths were given", len(paths)))
+			return 1
+		}
+		if err := c.checkOutputTarget(paths[0]); err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	}
+
 	exit := 0
 	for _, path := range paths {
-		if status := c.formatPath(path, formatOverride); status > exit {
+		if status := c.formatPath(path, formatOverride, outputOverride); status > exit {
 			exit = status
 		}
 	}
 	return exit
 }
 
-// runStdin reads stdin, formats it, and writes the result to stdout in
-// the default mode. With --diff the diff goes to stdout; with --check
-// the exit code reflects whether the input was canonical.
+// checkFlagCombination rejects the flag pairs that cannot both be honoured.
+//
+// Each test is flags.Changed rather than the parsed value, so it fires on
+// the flag having been typed rather than on what it was set to - the
+// objection is to the combination, which is the same rule
+// stdoutInertFlagError applies for init and export (#419). A flag that
+// only means something in a mode the command is not in gets an error
+// rather than being quietly dropped.
+func (c *FmtCommand) checkFlagCombination(flags *flag.FlagSet) error {
+	if flags.Changed("force") && !flags.Changed("output") {
+		return fmt.Errorf("--force only applies to --output; formatting a recipe in place already overwrites it")
+	}
+	if flags.Changed("output") {
+		for _, name := range []string{"check", "diff"} {
+			if flags.Changed(name) {
+				return fmt.Errorf("--output cannot be used with --%s; --%s never writes a file", name, name)
+			}
+		}
+		// --force asks to replace a file, and a stream has none.
+		return stdoutInertFlagError(flags, c.output, []stdoutInertFlag{
+			{name: "force", reason: "a streamed recipe writes no files"},
+		})
+	}
+	return nil
+}
+
+// checkOutputTarget refuses an --output that would destroy a file the
+// command was not asked to touch.
+//
+// Formatting in place overwrites the file it read, which is fmt's whole
+// job, so an --output naming that same file needs no permission. Any other
+// existing path does: `docket fmt --output tasks.yml staging/tasks.yml`
+// would otherwise silently replace an unrelated recipe. The wording
+// matches init's, which guards the same hazard.
+func (c *FmtCommand) checkOutputTarget(sourcePath string) error {
+	if c.output == "" || c.output == taskFileStdin {
+		return nil
+	}
+	target := inDir(c.baseDir(), c.output)
+	if samePath(target, sourcePath) {
+		return nil
+	}
+	if _, err := os.Stat(target); err == nil && !c.force {
+		return fmt.Errorf("file %s already exists; pass --force to overwrite", c.output)
+	}
+	return nil
+}
+
+// runStdin reads stdin and formats or converts it. The result goes to
+// stdout, or to --output when one is named.
 //
 // Stdin has no filename to drive format detection, so it sniffs the
 // first non-trivia byte: a leading [ or { signals JSON5; anything else
@@ -200,27 +304,82 @@ func (c *FmtCommand) Run(args []string) int {
 // only YAML file) goes through the YAML formatter. formatOverride, from
 // --tasks-format, wins over the sniff - a flow-style YAML recipe starts
 // with [ and would otherwise be reformatted as JSON5.
-func (c *FmtCommand) runStdin(formatOverride string) int {
+func (c *FmtCommand) runStdin(formatOverride, outputOverride string) int {
 	src, err := c.stdinSource().recipe()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read stdin: %v", err))
 		return 1
 	}
-	formatted, err := tasks.CodecFor(taskFileFormatFor("", formatOverride, src)).Format(src)
+	inFormat := taskFileFormatFor("", formatOverride, src)
+	outFormat := taskFileOutputFormatFor(outputOverride, c.output, inFormat)
+
+	writePath := ""
+	if c.output != "" && c.output != taskFileStdin {
+		writePath = inDir(c.baseDir(), c.output)
+	}
+	return c.writeFormatted(taskFileDisplayName(taskFileStdin), src, inFormat, outFormat, writePath, "")
+}
+
+// formatPath formats a single file. Returns 0 on success, 1 on any
+// error or --check mismatch. Errors are reported via c.Ui and the
+// caller picks the worst-of exit code across all paths.
+func (c *FmtCommand) formatPath(path, formatOverride, outputOverride string) int {
+	src, err := os.ReadFile(path)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("format error: %v", err))
+		c.Ui.Error(fmt.Sprintf("read %s: %v", path, err))
+		return 1
+	}
+
+	inFormat := taskFileFormatFor(detectTaskFileFormat(path), formatOverride, src)
+	outFormat := taskFileOutputFormatFor(outputOverride, c.output, inFormat)
+
+	writePath := path
+	if c.output != "" {
+		writePath = ""
+		if c.output != taskFileStdin {
+			writePath = inDir(c.baseDir(), c.output)
+		}
+	}
+	return c.writeFormatted(path, src, inFormat, outFormat, writePath, path)
+}
+
+// writeFormatted is the one place a recipe is canonicalised and its result
+// disposed of, shared by the stdin and per-file paths so the two cannot
+// drift on what --check, --diff and a conversion mean.
+//
+// writePath is the file to write, or "" to stream to stdout. sourcePath is
+// the file the bytes came from, or "" for stdin; the two are equal for an
+// ordinary in-place format, which is what lets the mtime be left alone.
+func (c *FmtCommand) writeFormatted(display string, src []byte, inFormat, outFormat, writePath, sourcePath string) int {
+	converting := outFormat != inFormat
+
+	formatted, err := tasks.Convert(src, tasks.CodecFor(inFormat), tasks.CodecFor(outFormat))
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("%s: %v", display, err))
 		return 1
 	}
 
 	changed := !bytesEqual(src, formatted)
 
+	// The diff is rendered before the --check rejection below, so
+	// `--check --diff` still shows what it objected to.
 	if c.diff && changed {
-		_, _ = io.WriteString(c.stdout(), renderDiff("<stdin>", string(src), string(formatted), c.useColor))
+		_, _ = io.WriteString(c.stdout(), renderDiff(display, string(src), string(formatted), c.useColor))
 	}
 
 	if c.check {
+		if converting {
+			// --check asks whether a recipe is already canonical, and a
+			// conversion is never a no-op, so the answer would be "no" for
+			// every file however clean it is. Say that rather than exiting
+			// 1 and letting a CI lint job read it as a formatting failure.
+			c.Ui.Error(fmt.Sprintf("[error]   %s: --check cannot be combined with --format %s on a %s recipe; a conversion is never a no-op", display, outFormat, inFormat))
+			c.Ui.Error(fmt.Sprintf("          to check a recipe whose extension is misleading, use: %s fmt --check --tasks-format %s", appName(), outFormat))
+			return 1
+		}
 		if changed {
-			c.Ui.Error("[error]   stdin is not canonically formatted")
+			c.Ui.Error(fmt.Sprintf("[error]   %s is not canonically formatted", display))
+			c.Ui.Error(fmt.Sprintf("          run: %s fmt %s", appName(), display))
 			return 1
 		}
 		return 0
@@ -231,60 +390,54 @@ func (c *FmtCommand) runStdin(formatOverride string) int {
 		return 0
 	}
 
-	if _, err := c.stdout().Write(formatted); err != nil {
-		c.Ui.Error(fmt.Sprintf("write stdout: %v", err))
-		return 1
-	}
-	return 0
-}
-
-// formatPath formats a single file. Returns 0 on success, 1 on any
-// error or --check mismatch. Errors are reported via c.Ui and the
-// caller picks the worst-of exit code across all paths.
-func (c *FmtCommand) formatPath(path, formatOverride string) int {
-	src, err := os.ReadFile(path)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("read %s: %v", path, err))
-		return 1
-	}
-
-	formatted, err := tasks.CodecFor(taskFileFormatFor(detectTaskFileFormat(path), formatOverride, src)).Format(src)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("%s: %v", path, err))
-		return 1
-	}
-
-	changed := !bytesEqual(src, formatted)
-
-	if c.diff && changed {
-		_, _ = io.WriteString(c.stdout(), renderDiff(path, string(src), string(formatted), c.useColor))
-	}
-
-	if c.check {
-		if changed {
-			c.Ui.Error(fmt.Sprintf("[error]   %s is not canonically formatted", path))
-			c.Ui.Error(fmt.Sprintf("          run: %s fmt %s", appName(), path))
+	if writePath == "" {
+		if _, err := c.stdout().Write(formatted); err != nil {
+			c.Ui.Error(fmt.Sprintf("write stdout: %v", err))
 			return 1
 		}
 		return 0
 	}
 
-	if c.diff {
-		return 0
-	}
-
-	if !changed {
+	if samePath(writePath, sourcePath) && !changed {
 		// no-op preservation: leave the file untouched so mtime
 		// stays clean for make / file-watchers.
 		return 0
 	}
 
-	if err := os.WriteFile(path, formatted, 0o644); err != nil {
-		c.Ui.Error(fmt.Sprintf("write %s: %v", path, err))
+	// A conversion can leave a file whose extension no longer describes its
+	// contents, which nothing downstream can tell: a later `docket validate
+	// --tasks tasks.yml` picks its parser from the name. Say it once here
+	// rather than letting the user find out from a parse error. A write
+	// that is not converting says nothing, so `--tasks-format json5
+	// recipe.yml` stays as quiet as it has always been.
+	if converting {
+		if msg := recipeOutputFormatMismatch(writePath, outFormat); msg != "" {
+			c.Ui.Warn(msg)
+		}
+	}
+
+	if err := os.WriteFile(writePath, formatted, 0o644); err != nil {
+		c.Ui.Error(fmt.Sprintf("write %s: %v", writePath, err))
 		return 1
 	}
-	c.Ui.Output(fmt.Sprintf("==> Formatted %s", path))
+	if samePath(writePath, sourcePath) {
+		c.Ui.Output(fmt.Sprintf("==> Formatted %s", writePath))
+	} else {
+		c.Ui.Output(fmt.Sprintf("==> Wrote %s", writePath))
+	}
 	return 0
+}
+
+// samePath reports whether two paths name the same file, so `--output
+// ./tasks.yml tasks.yml` is recognised as the in-place write it is - by
+// the overwrite guard, which must not demand --force for it, and by the
+// write step, which reports it as formatted rather than written and leaves
+// the mtime alone when nothing changed. Two empty paths are not a path.
+func samePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 // expandPaths resolves the positional arguments to a sorted, deduped

--- a/commands/fmt_test.go
+++ b/commands/fmt_test.go
@@ -601,3 +601,416 @@ func withStdinAndStdout(t *testing.T, input string, fn func(in io.Reader, out io
 	exit := fn(strings.NewReader(input), &buf)
 	return buf.String(), exit
 }
+
+// --- conversion (#418) ---------------------------------------------------
+
+// commentedTasksYAML and its JSON5 twin carry a comment at each anchor
+// point, so a conversion that drops or duplicates one is visible. The two
+// are exact images of each other: each converts to the other byte for
+// byte, which is what makes them usable as both directions' expectation.
+//
+// The file-level comment sits inside the [ ] rather than above it because
+// that is where it actually belongs - yaml.v3 attaches a comment above the
+// first list item to that item, not to the list - and the JSON5 rendering
+// keeps it attached to the same play.
+const commentedTasksYAML = `# top of file
+- name: web # the public app
+  tasks:
+    # scale it up first
+    - name: scale
+      dokku_ps_scale:
+        app: web
+        web: 2
+`
+
+const commentedTasksJSON5 = `[
+  // top of file
+  {
+    name: "web", // the public app
+    tasks: [
+      // scale it up first
+      {
+        name: "scale",
+        dokku_ps_scale: {
+          app: "web",
+          web: 2,
+        },
+      },
+    ],
+  },
+]
+`
+
+func TestFmtStdinConvertsYAMLToJSON5(t *testing.T) {
+	t.Parallel()
+	out, exit := withStdinAndStdout(t, commentedTasksYAML, func(in io.Reader, w io.Writer) int {
+		c := newTestFmtCommand()
+		c.Stdin, c.Stdout = in, w
+		return c.Run([]string{"--format", "json5", "-"})
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if out != commentedTasksJSON5 {
+		t.Errorf("output mismatch:\nwant:\n%s\ngot:\n%s", commentedTasksJSON5, out)
+	}
+}
+
+func TestFmtStdinConvertsJSON5ToYAML(t *testing.T) {
+	t.Parallel()
+	out, exit := withStdinAndStdout(t, commentedTasksJSON5, func(in io.Reader, w io.Writer) int {
+		c := newTestFmtCommand()
+		c.Stdin, c.Stdout = in, w
+		return c.Run([]string{"--format", "yaml", "-"})
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	// The `---` marker is not restored: it is a property of the bytes that
+	// were read, and these came from JSON5. Everything else round-trips.
+	if out != commentedTasksYAML {
+		t.Errorf("output mismatch:\nwant:\n%s\ngot:\n%s", commentedTasksYAML, out)
+	}
+}
+
+// TestFmtStdinFormatComposesWithTasksFormat covers the explicit both-sides
+// form: --tasks-format states what was read, --format what to write.
+func TestFmtStdinFormatComposesWithTasksFormat(t *testing.T) {
+	t.Parallel()
+	// Flow style opens with [, so the sniff would call it JSON5 without
+	// --tasks-format saying otherwise.
+	const flowYAML = "[{name: web, tasks: []}]\n"
+	out, exit := withStdinAndStdout(t, flowYAML, func(in io.Reader, w io.Writer) int {
+		c := newTestFmtCommand()
+		c.Stdin, c.Stdout = in, w
+		return c.Run([]string{"--tasks-format", "yaml", "--format", "json5", "-"})
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if !strings.Contains(out, `name: "web"`) {
+		t.Errorf("output is not JSON5:\n%s", out)
+	}
+}
+
+func TestFmtConvertsInPlaceAndWarnsAboutTheExtension(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(commentedTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--format", "json5", path}); exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != commentedTasksJSON5 {
+		t.Errorf("file mismatch:\nwant:\n%s\ngot:\n%s", commentedTasksJSON5, got)
+	}
+	stderr := c.Ui.(*cli.MockUi).ErrorWriter.String()
+	if !strings.Contains(stderr, "--tasks-format json5") {
+		t.Errorf("expected a warning that the extension now lies, got:\n%s", stderr)
+	}
+}
+
+// TestFmtNonConvertingWriteStaysSilent is the guard on the warning's
+// condition. A --tasks-format that disagrees with the extension has always
+// been legal and quiet; --format must not make it start warning.
+func TestFmtNonConvertingWriteStaysSilent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recipe.yml")
+	if err := os.WriteFile(path, []byte(messyTasksJSON5), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--tasks-format", "json5", path}); exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if stderr := c.Ui.(*cli.MockUi).ErrorWriter.String(); strings.Contains(stderr, "does not match") {
+		t.Errorf("a non-converting write warned:\n%s", stderr)
+	}
+}
+
+func TestFmtOutputWritesNewFileAndLeavesSource(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "tasks.yml")
+	target := filepath.Join(dir, "tasks.json5")
+	if err := os.WriteFile(source, []byte(commentedTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--format", "json5", "--output", target, source}); exit != 0 {
+		t.Fatalf("exit = %d, want 0: %s", exit, c.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != commentedTasksJSON5 {
+		t.Errorf("target mismatch:\nwant:\n%s\ngot:\n%s", commentedTasksJSON5, got)
+	}
+	src, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if string(src) != commentedTasksYAML {
+		t.Errorf("source was modified:\n%s", src)
+	}
+}
+
+// TestFmtOutputInfersFormatFromExtension covers the resolution step below
+// --format: the target's own extension says what to write.
+func TestFmtOutputInfersFormatFromExtension(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "tasks.yml")
+	target := filepath.Join(dir, "tasks.json5")
+	if err := os.WriteFile(source, []byte(commentedTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--output", target, source}); exit != 0 {
+		t.Fatalf("exit = %d, want 0: %s", exit, c.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != commentedTasksJSON5 {
+		t.Errorf("target mismatch:\nwant:\n%s\ngot:\n%s", commentedTasksJSON5, got)
+	}
+}
+
+// TestFmtOutputStdoutKeepsTheInputFormat pins why resolveRecipeOutput could
+// not be reused: its stdout branch answers "yaml", which would convert a
+// JSON5 recipe the user only asked to print.
+func TestFmtOutputStdoutKeepsTheInputFormat(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "tasks.json")
+	if err := os.WriteFile(source, []byte(messyTasksJSON5), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, exit := captureStdout(t, func(w io.Writer) int {
+		c := newTestFmtCommand()
+		c.Stdout = w
+		return c.Run([]string{"--output", "-", source})
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if out != canonicalTasksJSON5 {
+		t.Errorf("streamed output mismatch:\nwant:\n%s\ngot:\n%s", canonicalTasksJSON5, out)
+	}
+}
+
+func TestFmtOutputRefusesToOverwriteWithoutForce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "tasks.yml")
+	target := filepath.Join(dir, "tasks.json5")
+	if err := os.WriteFile(source, []byte(commentedTasksYAML), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("// existing\n[]\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--format", "json5", "--output", target, source}); exit != 1 {
+		t.Fatalf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(c.Ui.(*cli.MockUi).ErrorWriter.String(), "pass --force to overwrite") {
+		t.Errorf("expected the --force hint, got:\n%s", c.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+	kept, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(kept) != "// existing\n[]\n" {
+		t.Errorf("target was overwritten anyway:\n%s", kept)
+	}
+
+	forced := newTestFmtCommand()
+	if exit := forced.Run([]string{"--format", "json5", "--output", target, "--force", source}); exit != 0 {
+		t.Fatalf("forced exit = %d, want 0: %s", exit, forced.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != commentedTasksJSON5 {
+		t.Errorf("target mismatch after --force:\n%s", got)
+	}
+}
+
+// TestFmtOutputEqualToSourceNeedsNoForce keeps the guard from firing on a
+// write that is in-place by another spelling.
+func TestFmtOutputEqualToSourceNeedsNoForce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--output", path, path}); exit != 0 {
+		t.Fatalf("exit = %d, want 0: %s", exit, c.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != canonicalTasksYAML {
+		t.Errorf("file mismatch:\n%s", got)
+	}
+}
+
+func TestFmtRejectedFlagCombinations(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"force without output", []string{"--force"}, "--force only applies to --output"},
+		{"output with check", []string{"--output", "x.json5", "--check"}, "--output cannot be used with --check"},
+		{"output with diff", []string{"--output", "x.json5", "--diff"}, "--output cannot be used with --diff"},
+		{"force with stdout output", []string{"--output", "-", "--force"}, "--force cannot be used with --output -"},
+		{"invalid format", []string{"--format", "toml"}, `invalid --format "toml"`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "tasks.yml"), []byte(messyTasksYAML), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			c := newTestFmtCommand(dir)
+			if exit := c.Run(tc.args); exit != 1 {
+				t.Fatalf("exit = %d, want 1", exit)
+			}
+			if stderr := c.Ui.(*cli.MockUi).ErrorWriter.String(); !strings.Contains(stderr, tc.want) {
+				t.Errorf("stderr = %q, want it to mention %q", stderr, tc.want)
+			}
+		})
+	}
+}
+
+func TestFmtOutputRejectsMultiplePaths(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, name := range []string{"a.yml", "b.yml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(messyTasksYAML), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	c := newTestFmtCommand(dir)
+	if exit := c.Run([]string{"--output", "out.json5", "a.yml", "b.yml"}); exit != 1 {
+		t.Fatalf("exit = %d, want 1", exit)
+	}
+	if !strings.Contains(c.Ui.(*cli.MockUi).ErrorWriter.String(), "--output takes a single recipe") {
+		t.Errorf("stderr = %q", c.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+}
+
+// TestFmtCheckRejectsAConvertingFormat covers the rule chosen for #418:
+// --check asks whether a recipe is already canonical, which a conversion
+// cannot answer, so it is refused rather than always reporting a failure.
+func TestFmtCheckRejectsAConvertingFormat(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(canonicalTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--check", "--format", "json5", path}); exit != 1 {
+		t.Fatalf("exit = %d, want 1", exit)
+	}
+	stderr := c.Ui.(*cli.MockUi).ErrorWriter.String()
+	if !strings.Contains(stderr, "a conversion is never a no-op") {
+		t.Errorf("stderr = %q", stderr)
+	}
+	if !strings.Contains(stderr, "--tasks-format json5") {
+		t.Errorf("expected the --tasks-format hint, got %q", stderr)
+	}
+}
+
+// TestFmtCheckAcceptsANonConvertingFormat is the other half: naming the
+// format a recipe is already in leaves --check doing exactly what it did.
+func TestFmtCheckAcceptsANonConvertingFormat(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(canonicalTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--check", "--format", "yaml", path}); exit != 0 {
+		t.Fatalf("exit = %d, want 0: %s", exit, c.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+}
+
+// TestFmtDiffOnAConversionWritesNothing keeps --diff useful as a preview of
+// what a conversion would do.
+func TestFmtDiffOnAConversionWritesNothing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(commentedTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, exit := captureStdout(t, func(w io.Writer) int {
+		c := newTestFmtCommand()
+		c.Stdout = w
+		return c.Run([]string{"--diff", "--format", "json5", path})
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if !strings.Contains(out, "@@") || !strings.Contains(out, `+    name: "web",`) {
+		t.Errorf("diff does not show the conversion:\n%s", out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != commentedTasksYAML {
+		t.Errorf("--diff wrote to the file:\n%s", got)
+	}
+}
+
+// TestFmtOutputSpelledDifferentlyIsStillInPlace covers samePath: an
+// --output that names the source by another spelling is the in-place write
+// it looks like, not an overwrite of a third file.
+func TestFmtOutputSpelledDifferentlyIsStillInPlace(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tasks.yml"), []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c := newTestFmtCommand(dir)
+	if exit := c.Run([]string{"--output", "./tasks.yml", "tasks.yml"}); exit != 0 {
+		t.Fatalf("exit = %d, want 0: %s", exit, c.Ui.(*cli.MockUi).ErrorWriter.String())
+	}
+	if out := c.Ui.(*cli.MockUi).OutputWriter.String(); !strings.Contains(out, "Formatted") {
+		t.Errorf("output = %q, want it reported as an in-place format", out)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "tasks.yml"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != canonicalTasksYAML {
+		t.Errorf("file mismatch:\n%s", got)
+	}
+}

--- a/commands/task_file.go
+++ b/commands/task_file.go
@@ -81,6 +81,37 @@ func taskFileFormatFor(detected, override string, data []byte) string {
 	return tasks.SniffCodec(data).Name()
 }
 
+// taskFileOutputFormatFor resolves the format a recipe should be WRITTEN
+// as, the counterpart to taskFileFormatFor on the reading side:
+//
+//  1. override - an explicit --format, already normalised by
+//     parseRecipeFormatFlag
+//  2. the extension of an explicit --output, when a codec claims it
+//  3. inFormat - the format it was read as, which is what `docket fmt`
+//     has always written back
+//
+// resolveRecipeOutput, which init and export use, cannot serve here. Its
+// stdout branch falls back to the default codec, because for those two
+// commands there is no input format to inherit - the recipe is being
+// generated. `docket fmt --output - tasks.json` does have one, and
+// answering "yaml" for it would silently convert a recipe the user only
+// asked to print.
+//
+// An --output extension no codec claims is passed over rather than
+// treated as the default format, for the same reason: `--output
+// recipe.txt` says nothing about format, so the input's format stands.
+func taskFileOutputFormatFor(override, output, inFormat string) string {
+	if override != "" {
+		return override
+	}
+	if output != "" && output != taskFileStdin {
+		if codec, ok := tasks.CodecForExtension(filepath.Ext(output)); ok {
+			return codec.Name()
+		}
+	}
+	return inFormat
+}
+
 // taskFileDisplayName renders a recipe source for human output. stdin
 // has no path, so it prints as <stdin> - the same spelling `docket fmt`
 // already uses in its diff headers.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -42,9 +42,11 @@ overrides both. Reach for it when the extension is absent or misleading (`--task
 URL whose path carries no extension), or when a YAML recipe written in flow style would be sniffed
 as JSON5 because it opens with `[`.
 
-`--tasks-format` is the reading side. On the writing side, `init` and `export` take
-`--format yaml|json5` to state the format of what they emit. Without it, stdout can only ever be
-YAML, since there is no extension to infer from.
+`--tasks-format` is the reading side. On the writing side, `init`, `export`, and `fmt` take
+`--format yaml|json5` to state the format of what they emit. Without it, `init` and `export` can
+only ever write YAML to stdout, since there is no extension to infer from. On `fmt` the two flags
+compose: `--tasks-format` says what the recipe already is, `--format` says what to write it as, and
+naming a different one converts the recipe between the two.
 
 Reading the recipe from stdin consumes it, so a `dokku` command that would otherwise have inherited
 the terminal's stdin sees end-of-file instead. No task depends on this - every task that streams
@@ -146,6 +148,10 @@ between top-level plays and task entries. It works on both YAML and JSON5, detec
 the extension, and both formats share the same canonical key order so a YAML recipe and its JSON5
 twin lay out identically. Comments are preserved in both formats.
 
+`--format` makes it a converter as well as a formatter. It states the format to write, so naming
+one the recipe is not already in rewrites it into that format, comments and all - the thing a trip
+out to another tool and back cannot do.
+
 ```bash
 # Rewrite ./tasks.yml in place (probes tasks.yml -> tasks.yaml -> tasks.json with no argument).
 docket fmt
@@ -161,6 +167,16 @@ cat tasks.yml | docket fmt -
 
 # Same, but keep a flow-style YAML recipe as YAML instead of sniffing it as JSON5.
 cat tasks.yml | docket fmt --tasks-format yaml -
+
+# Convert a recipe to JSON5 and write it to stdout, touching nothing on disk.
+cat tasks.yml | docket fmt --format json5 -
+
+# Convert to a new file, leaving the original alone. The extension alone would
+# have been enough; --format is what a name like recipe.txt would need.
+docket fmt --format json5 --output tasks.json5 tasks.yml
+
+# Convert in place, keeping the name. See the warning this prints, below.
+docket fmt --format json5 tasks.json
 ```
 
 | Flag | Effect |
@@ -169,7 +185,10 @@ cat tasks.yml | docket fmt --tasks-format yaml -
 | `--check` | Exit 1 if any file is not canonical; no writes. Composes with `--diff`. |
 | `--diff` | Print a unified diff against canonical; no writes. Composes with `--check`. |
 | `--color <when>` | Colorize the diff: `auto` (default), `always`, or `never`. |
-| `--tasks-format <fmt>` | Format the recipe as `yaml` or `json5` instead of detecting it. |
+| `--tasks-format <fmt>` | Read the recipe as `yaml` or `json5` instead of detecting it. |
+| `--format <fmt>` | Write the recipe as `yaml` or `json5`, converting it when that is not what it was read as. Cannot be combined with `--check`. |
+| `--output <path>` | Write to this path instead of in place; `-` writes to stdout. Takes a single recipe, and cannot be combined with `--check` or `--diff`. |
+| `--force` | Overwrite an existing `--output` file. |
 | `-` | Read from stdin, write canonical to stdout. Cannot be combined with other paths. |
 | `<path...>` | Format the named files; each argument is expanded as a glob. |
 
@@ -180,6 +199,52 @@ the result does not match the input, so a formatting bug can never corrupt a rec
 `fmt` operates on single-document recipes. An empty or comment-only file is left untouched, and a
 YAML file containing more than one document (separated by `---`) is rejected rather than having its
 trailing documents silently dropped.
+
+### Converting between YAML and JSON5
+
+Without `--output`, `--format` converts the file in place and keeps its name, which leaves a
+`tasks.yml` holding JSON5. `fmt` says so once, on stderr, because nothing downstream can tell: a
+later `docket validate --tasks tasks.yml` picks its parser from the extension and fails. Prefer
+`--output` when the name should follow the format:
+
+```bash
+docket fmt --format json5 --output tasks.json5 tasks.yml && rm tasks.yml
+```
+
+`--output` never overwrites an existing file without `--force`, and takes a single recipe, so it
+cannot be combined with a glob. Writing back over the file that was read is the ordinary in-place
+case and needs no `--force`.
+
+`--check` cannot be combined with a `--format` that converts. It asks whether a recipe is already
+canonical, and a conversion is never a no-op, so every file would be reported as unformatted. To
+check a recipe whose extension is misleading, use `--tasks-format`. `--diff` does compose with a
+converting `--format`, and previews the conversion without writing anything.
+
+A conversion is not byte-reversible, and is not meant to be. Comments survive, and so does every
+value, but four things are normalised on the way:
+
+- **Comments change syntax.** A `# note` becomes `// note` and back. A JSON5 block comment
+  `/* note */` comes back as `// note`, since a line comment cannot be terminated early by its own
+  text.
+- **YAML anchors, aliases, and merge keys are inlined.** JSON5 has no way to write sharing down, so
+  `<<: *base` is expanded into the keys it merges in, following YAML's own precedence. The recipe
+  means the same thing; the fact that a block was written once does not survive.
+- **Numbers are normalised to decimal.** YAML accepts `0o17`, `0b1010`, and `1_000`, none of which
+  JSON5 has, so they are written as `15`, `10`, and `1000`. A JSON5 `0x1F` becomes `31` even though
+  YAML would take the hex, because that is what `validate` already reads it as, and `fmt` must not
+  disagree with `validate` about what a recipe says.
+- **A leading `---` is not restored.** The marker describes the bytes that were read, and a recipe
+  arriving from JSON5 had none.
+
+A YAML timestamp is the one value whose type changes: JSON5 has no date literal, so `2015-01-01`
+becomes the string `"2015-01-01"`. Nothing in a recipe reads it as anything else - every task field
+holding one is a string already.
+
+Quoting is preserved where it carries meaning. A value holding an interpolation stays double-quoted,
+because `"{{ .app | dq }}"` and `'{{ .app | dq }}'` do not render the same way - see
+[Inputs](inputs.md). The reverse has no safe spelling: canonical JSON5 has no single-quoted string,
+so a YAML `'{{ .app }}'` converts to `"{{ .app }}"`, which `docket validate` then reports as
+`unsafe_input_value`. Add `| dq` before converting such a recipe.
 
 ## docket plan
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -41,6 +41,23 @@ is equivalent to this JSON5 recipe:
 ]
 ```
 
+### Converting between the two
+
+`docket fmt --format` rewrites a recipe from either format into the other, keeping the comments:
+
+```bash
+# To stdout, touching nothing on disk.
+cat tasks.yml | docket fmt --format json5 -
+
+# To a new file, leaving the original in place.
+docket fmt --format json5 --output tasks.json5 tasks.yml
+```
+
+A conversion is not byte-reversible: comments change syntax, YAML anchors and merge keys are
+inlined, numbers are normalised to decimal, and a leading `---` is not restored. See
+[Converting between YAML and JSON5](command-reference.md#converting-between-yaml-and-json5) for the
+full list and for what happens to an interpolation's quoting.
+
 ## How docket finds your recipe
 
 When you do not pass `--tasks`, docket looks in the current directory for these files, in order,

--- a/tasks/codec.go
+++ b/tasks/codec.go
@@ -1,6 +1,10 @@
 package tasks
 
-import "strings"
+import (
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
 
 // Codec is everything docket needs to know about one recipe surface
 // syntax. A recipe's format is a string on the wire - the --tasks-format /
@@ -58,6 +62,38 @@ type Codec interface {
 	// Format returns the canonical rendering of data - what `docket fmt`
 	// writes back.
 	Format(data []byte) ([]byte, error)
+
+	// DecodeDocument parses data into a comment-carrying yaml.Node
+	// document. That tree is the neutral interchange every cross-format
+	// conversion passes through, which is what keeps conversion O(codecs)
+	// rather than O(codec pairs): a new format implements this pair and
+	// gets conversion to and from every other format for free.
+	//
+	// yaml.Node is the interchange rather than a tree of docket's own
+	// because it is the richest model in play - anchors, tags, styles and
+	// head/line/foot comments - so information is only ever lost on the
+	// way OUT of it, in EncodeDocument, where the codec that cannot
+	// represent something is the one deciding what to do about it. It also
+	// makes the YAML codec's own pair free.
+	//
+	// A nil node with a nil error means data holds no document at all, for
+	// a format that has an empty form: YAML's empty and comment-only
+	// files, which Format already returns untouched. A format with no
+	// empty representation returns an error instead, exactly as its Format
+	// does today - parseJSON5 rejects empty input, so `docket fmt
+	// empty.json` fails now and keeps failing.
+	DecodeDocument(data []byte) (*yaml.Node, error)
+
+	// EncodeDocument renders that document as a canonically formatted
+	// recipe in this surface syntax - the same bytes Format would produce
+	// for it. A nil document is an error; Convert screens for one first.
+	//
+	// This is where a format states what it cannot carry. JSON5 has no
+	// anchors, so Convert flattens them before calling; it has no date
+	// type, so a !!timestamp widens to a string; it has no complex keys,
+	// so a non-scalar mapping key is refused outright rather than
+	// stringified into something that means less.
+	EncodeDocument(doc *yaml.Node) ([]byte, error)
 
 	// Marshal renders v as a canonically formatted recipe document, the
 	// same bytes Format would produce for it.

--- a/tasks/codec_json5.go
+++ b/tasks/codec_json5.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -73,6 +74,40 @@ func (json5Codec) Lint(data []byte) []Problem {
 }
 
 func (json5Codec) Format(data []byte) ([]byte, error) { return FormatJSON5(data) }
+
+// DecodeDocument parses the JSON5 document with the same comment-carrying
+// parser the formatter uses, then walks it into the interchange tree. It
+// deliberately does not go through ToYAML, which decodes to plain Go
+// values and so arrives with every comment already gone.
+//
+// Empty input is an error rather than the (nil, nil) the YAML codec
+// answers with: JSON5 has no empty document, and parseJSON5 already
+// rejects it, so `docket fmt empty.json` fails today and keeps failing.
+func (json5Codec) DecodeDocument(data []byte) (*yaml.Node, error) {
+	root, err := parseJSON5(data)
+	if err != nil {
+		return nil, fmt.Errorf("json5 parse error: %w", err)
+	}
+	return json5DocumentToYAML(root)
+}
+
+// EncodeDocument walks the interchange tree back into the JSON5 AST, emits
+// it, and hands the bytes to FormatJSON5.
+//
+// Running the formatter over its own emitter's output costs one parse and
+// buys the canonical key order, the blank lines between plays and tasks,
+// and the round-trip guard, all of them verbatim rather than
+// reimplemented - so a converted recipe is canonical the moment it is
+// written and `docket fmt --check` passes over it.
+func (json5Codec) EncodeDocument(doc *yaml.Node) ([]byte, error) {
+	node, err := yamlDocumentToJSON5(doc)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	emitJSON5(&buf, node, 0)
+	return FormatJSON5(buf.Bytes())
+}
 
 // Marshal renders v as a canonically formatted JSON5 recipe.
 //

--- a/tasks/codec_test.go
+++ b/tasks/codec_test.go
@@ -85,6 +85,30 @@ func TestCodecConformance(t *testing.T) {
 			if len(recipe) != 1 {
 				t.Errorf("round-tripped recipe = %d plays, want 1", len(recipe))
 			}
+
+			// The interchange pair has to be faithful in both directions,
+			// or cross-format conversion silently loses whatever the walk
+			// dropped. Byte equality is the crispest available signal:
+			// marshalled is already canonical, and EncodeDocument ends in
+			// the same canonicaliser Format does, so anything the tree
+			// failed to carry shows up as a diff.
+			doc, err := codec.DecodeDocument(marshalled)
+			if err != nil {
+				t.Fatalf("DecodeDocument: %v", err)
+			}
+			if doc == nil {
+				t.Fatal("DecodeDocument returned no document for a non-empty recipe")
+			}
+			if documentBody(doc) == nil {
+				t.Fatal("DecodeDocument returned a document with no body")
+			}
+			encoded, err := codec.EncodeDocument(doc)
+			if err != nil {
+				t.Fatalf("EncodeDocument: %v", err)
+			}
+			if string(encoded) != string(marshalled) {
+				t.Errorf("EncodeDocument(DecodeDocument(x)) != x:\nwant:\n%s\ngot:\n%s", marshalled, encoded)
+			}
 		})
 	}
 }
@@ -340,5 +364,61 @@ func TestJSON5CodecLintReadsOriginalBytes(t *testing.T) {
 	}
 	if got := codec.Lint(converted); len(got) != 0 {
 		t.Errorf("Lint(converted) = %v; the duplicate should already be gone, which is why Lint takes the original", got)
+	}
+}
+
+// TestCodecDecodeDocumentRejectsGarbage pins that a codec reports a broken
+// recipe rather than handing back a half-built tree.
+func TestCodecDecodeDocumentRejectsGarbage(t *testing.T) {
+	t.Parallel()
+	for _, codec := range Codecs() {
+		codec := codec
+		t.Run(codec.Name(), func(t *testing.T) {
+			t.Parallel()
+			doc, err := codec.DecodeDocument([]byte("{[}\x00 not a recipe"))
+			if err == nil {
+				t.Fatalf("DecodeDocument accepted garbage, returned %v", doc)
+			}
+			if doc != nil {
+				t.Errorf("DecodeDocument returned a document alongside an error: %v", doc)
+			}
+		})
+	}
+}
+
+// TestCodecEncodeDocumentRejectsNil pins the other half of the contract:
+// Convert screens for an absent document, and a codec must not be relied
+// on to invent one.
+func TestCodecEncodeDocumentRejectsNil(t *testing.T) {
+	t.Parallel()
+	for _, codec := range Codecs() {
+		codec := codec
+		t.Run(codec.Name(), func(t *testing.T) {
+			t.Parallel()
+			if out, err := codec.EncodeDocument(nil); err == nil {
+				t.Errorf("EncodeDocument(nil) = %q, want an error", out)
+			}
+		})
+	}
+}
+
+// TestCodecDecodeDocumentEmptyInput records where the two codecs
+// deliberately differ. YAML has an empty document and answers (nil, nil)
+// for one, which is what lets `docket fmt` leave an empty file alone.
+// JSON5 has no such thing and errors, which is what `docket fmt
+// empty.json` already did before any of this existed.
+func TestCodecDecodeDocumentEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	doc, err := CodecFor(FormatYAML).DecodeDocument(nil)
+	if err != nil {
+		t.Errorf("yaml DecodeDocument(empty) = %v, want no error", err)
+	}
+	if doc != nil {
+		t.Errorf("yaml DecodeDocument(empty) returned a document, want nil")
+	}
+
+	if _, err := CodecFor(FormatNameJSON5).DecodeDocument(nil); err == nil {
+		t.Error("json5 DecodeDocument(empty) = nil error, want a parse error")
 	}
 }

--- a/tasks/codec_yaml.go
+++ b/tasks/codec_yaml.go
@@ -34,6 +34,23 @@ func (yamlCodec) Lint([]byte) []Problem { return nil }
 
 func (yamlCodec) Format(data []byte) ([]byte, error) { return Format(data) }
 
+// DecodeDocument and EncodeDocument are the two halves Format is built
+// from, so the interchange tree for a YAML recipe is the same tree the
+// formatter has always walked and there is no second parser to keep in
+// step.
+//
+// The one thing Format does that EncodeDocument does not is restore a
+// leading `---`, which it reads off the original bytes. A document handed
+// over from another format has no such bytes, so conversion into YAML
+// never emits a marker.
+func (yamlCodec) DecodeDocument(data []byte) (*yaml.Node, error) {
+	return decodeSingleYAMLDocument(data)
+}
+
+func (yamlCodec) EncodeDocument(doc *yaml.Node) ([]byte, error) {
+	return encodeCanonicalYAML(doc)
+}
+
 // Marshal renders v as YAML and then canonicalises it, so an exported
 // recipe comes out byte-identical to one `docket fmt` has been run over.
 func (yamlCodec) Marshal(v interface{}) ([]byte, error) {

--- a/tasks/convert.go
+++ b/tasks/convert.go
@@ -1,0 +1,385 @@
+package tasks
+
+import (
+	"fmt"
+	"strconv"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// mergeTag is the tag yaml.v3 resolves the `<<` merge key to.
+const mergeTag = "!!merge"
+
+// maxAliasDepth and maxAliasNodes bound alias expansion. A YAML alias can
+// only refer to an anchor already parsed, so the reference graph is a DAG
+// and cannot cycle - but a DAG expands exponentially when each level
+// aliases the one above it, so a small file can still ask for an enormous
+// tree. Refuse rather than exhaust memory.
+const (
+	maxAliasDepth = 100
+	maxAliasNodes = 100000
+)
+
+// Convert renders a recipe written in the from codec as the same recipe in
+// the to codec, canonically formatted.
+//
+// Comments survive, which is the whole point: `docket fmt` preserves them
+// within a format, so a conversion that dropped them would be no better
+// than the trip through an external tool that #418 exists to replace.
+func Convert(data []byte, from, to Codec) ([]byte, error) {
+	if from == nil {
+		from = DefaultCodec()
+	}
+	if to == nil {
+		to = DefaultCodec()
+	}
+
+	// Same format in and out is exactly what `docket fmt` has always done,
+	// and it must keep producing the same bytes: every invocation that
+	// predates --format lands here.
+	if from.Name() == to.Name() {
+		return from.Format(data)
+	}
+
+	// A source the reading codec already considers malformed is refused
+	// here, where the problem can still be named. A duplicate-keyed JSON5
+	// object is the case that matters: parseJSON5 keeps both members, so
+	// without this the conversion runs to completion and dies at the
+	// cross-format guard reporting that the recipe changed - true, but
+	// useless. Formatting such a file in place is untouched; it returned
+	// above, and has always failed with the JSON5 formatter's own
+	// round-trip message.
+	if problems := from.Lint(data); len(problems) > 0 {
+		return nil, fmt.Errorf("cannot convert this %s recipe: %s", from.Name(), problems[0].Message)
+	}
+
+	doc, err := from.DecodeDocument(data)
+	if err != nil {
+		return nil, err
+	}
+	if doc == nil {
+		// No document to convert - an empty or comment-only file. `fmt`
+		// leaves those alone, and inventing an empty recipe in the target
+		// format would be a worse answer than doing nothing.
+		return from.Format(data)
+	}
+
+	// Anchors, aliases and merge keys are YAML-only spellings, so the
+	// flattening runs here rather than in a codec: any target that cannot
+	// express sharing needs the same treatment. Neither pass is reachable
+	// from a non-YAML source, and same-format formatting returned above,
+	// so today's `docket fmt` never runs either one.
+	if err := inlineAliases(doc); err != nil {
+		return nil, err
+	}
+	if err := expandMergeKeys(doc); err != nil {
+		return nil, err
+	}
+
+	out, err := to.EncodeDocument(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	// The cross-format guard. Each codec's own Format already re-parses its
+	// output and checks it against its own AST, but that only proves the
+	// emitter did not corrupt what it was handed. This is the only check
+	// that the walk between the two formats was faithful.
+	back, err := to.DecodeDocument(out)
+	if err != nil {
+		return nil, fmt.Errorf("converted %s failed to parse back: %w", to.Name(), err)
+	}
+	if !equivalentConvertedNodes(documentBody(doc), documentBody(back)) {
+		return nil, fmt.Errorf("%s to %s conversion changed the recipe; refusing to write", from.Name(), to.Name())
+	}
+
+	return out, nil
+}
+
+// inlineAliases replaces every alias with a copy of what it points at and
+// drops the anchors that named them.
+//
+// Inlining rather than refusing is the right trade because it is what
+// docket already does with the recipe: UnmarshalRecipe resolves anchors
+// and merges during the parse, so nothing downstream can tell an inlined
+// document from the original. What is lost is the fact that two blocks
+// were once written once - which is exactly the thing a format with no
+// anchors cannot record.
+func inlineAliases(root *yaml.Node) error {
+	return (&aliasInliner{budget: maxAliasNodes}).walk(root, 0)
+}
+
+type aliasInliner struct{ budget int }
+
+func (in *aliasInliner) walk(n *yaml.Node, depth int) error {
+	if n == nil {
+		return nil
+	}
+	if depth > maxAliasDepth {
+		return fmt.Errorf("YAML alias nesting is deeper than %d levels; too deep to convert", maxAliasDepth)
+	}
+	// The anchor declaration goes away; the value it named stays put.
+	n.Anchor = ""
+	for i, child := range n.Content {
+		if child.Kind == yaml.AliasNode {
+			if child.Alias == nil {
+				return fmt.Errorf("YAML alias *%s does not resolve to an anchor", child.Value)
+			}
+			replacement, err := in.copy(child.Alias)
+			if err != nil {
+				return err
+			}
+			// A comment written beside the alias is about the alias site,
+			// not about the anchor it borrows from, so it stays here.
+			replacement.HeadComment = child.HeadComment
+			replacement.LineComment = child.LineComment
+			replacement.FootComment = child.FootComment
+			n.Content[i] = replacement
+			child = replacement
+		}
+		if err := in.walk(child, depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copy deep-copies an anchored subtree, charging each node against the
+// expansion budget.
+func (in *aliasInliner) copy(n *yaml.Node) (*yaml.Node, error) {
+	if n == nil {
+		return nil, nil
+	}
+	in.budget--
+	if in.budget < 0 {
+		return nil, fmt.Errorf("YAML alias expansion exceeds %d nodes; too large to convert", maxAliasNodes)
+	}
+	out := *n
+	out.Anchor = ""
+	out.Content = nil
+	for _, child := range n.Content {
+		copied, err := in.copy(child)
+		if err != nil {
+			return nil, err
+		}
+		out.Content = append(out.Content, copied)
+	}
+	return &out, nil
+}
+
+// expandMergeKeys rewrites every `<<:` into the keys it merges in.
+//
+// Precedence is YAML 1.1's: a key the mapping states itself beats a merged
+// one, and an earlier merge source beats a later one. The walk is
+// post-order so a source that merges something itself is already flat by
+// the time it is read.
+func expandMergeKeys(n *yaml.Node) error {
+	if n == nil {
+		return nil
+	}
+	for _, child := range n.Content {
+		if err := expandMergeKeys(child); err != nil {
+			return err
+		}
+	}
+	if n.Kind != yaml.MappingNode || !hasMergeKey(n) {
+		return nil
+	}
+
+	own := make(map[string]bool, len(n.Content)/2)
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Tag != mergeTag {
+			own[n.Content[i].Value] = true
+		}
+	}
+
+	var out []*yaml.Node
+	emitted := make(map[string]bool, len(n.Content)/2)
+	// A merge key that contributes nothing still carries its comment;
+	// pending holds it until there is a real key to attach it to.
+	var pending string
+
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		key, value := n.Content[i], n.Content[i+1]
+
+		if key.Tag != mergeTag {
+			if emitted[key.Value] {
+				continue
+			}
+			emitted[key.Value] = true
+			if pending != "" {
+				key.HeadComment = joinComments(pending, key.HeadComment)
+				pending = ""
+			}
+			out = append(out, key, value)
+			continue
+		}
+
+		sources, err := mergeSources(value)
+		if err != nil {
+			return err
+		}
+		attached := false
+		for _, source := range sources {
+			for j := 0; j+1 < len(source.Content); j += 2 {
+				sourceKey, sourceValue := source.Content[j], source.Content[j+1]
+				if own[sourceKey.Value] || emitted[sourceKey.Value] {
+					continue
+				}
+				emitted[sourceKey.Value] = true
+				// The source may be merged into more than one mapping, so
+				// each insertion gets its own copy.
+				copiedKey, copiedValue := deepCopyNode(sourceKey), deepCopyNode(sourceValue)
+				if !attached {
+					copiedKey.HeadComment = joinComments(pending, key.HeadComment, copiedKey.HeadComment)
+					if key.LineComment != "" {
+						copiedKey.LineComment = key.LineComment
+					}
+					pending = ""
+					attached = true
+				}
+				out = append(out, copiedKey, copiedValue)
+			}
+		}
+		if !attached {
+			pending = joinComments(pending, key.HeadComment)
+		}
+	}
+
+	if pending != "" {
+		n.HeadComment = joinComments(pending, n.HeadComment)
+	}
+	n.Content = out
+	return nil
+}
+
+// hasMergeKey reports whether a mapping carries a `<<` pair.
+func hasMergeKey(n *yaml.Node) bool {
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Tag == mergeTag {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeSources returns the mappings a `<<:` value merges in, left to right.
+func mergeSources(value *yaml.Node) ([]*yaml.Node, error) {
+	switch value.Kind {
+	case yaml.MappingNode:
+		return []*yaml.Node{value}, nil
+	case yaml.SequenceNode:
+		out := make([]*yaml.Node, 0, len(value.Content))
+		for _, item := range value.Content {
+			if item.Kind != yaml.MappingNode {
+				return nil, fmt.Errorf("merge key << at line %d: every entry must be a mapping", value.Line)
+			}
+			out = append(out, item)
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("merge key << at line %d must be a mapping or a sequence of mappings", value.Line)
+}
+
+// deepCopyNode copies a node and everything under it.
+func deepCopyNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	out := *n
+	out.Content = nil
+	for _, child := range n.Content {
+		out.Content = append(out.Content, deepCopyNode(child))
+	}
+	return &out
+}
+
+// equivalentConvertedNodes compares two trees by what their scalars mean
+// rather than by how they are spelled.
+//
+// equivalentNodes, which guards each formatter against its own emitter,
+// compares Value and tag literally and so cannot be reused here: a
+// conversion normalises 0x1F to 31 on purpose, and widens a !!timestamp to
+// the string JSON5 can carry. Both must compare equal. A lost key, a
+// dropped escape or a changed type must not.
+func equivalentConvertedNodes(a, b *yaml.Node) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case yaml.ScalarNode:
+		return scalarValueKey(a) == scalarValueKey(b)
+	case yaml.SequenceNode:
+		if len(a.Content) != len(b.Content) {
+			return false
+		}
+		for i := range a.Content {
+			if !equivalentConvertedNodes(a.Content[i], b.Content[i]) {
+				return false
+			}
+		}
+		return true
+	case yaml.MappingNode:
+		if len(a.Content) != len(b.Content) {
+			return false
+		}
+		index := make(map[string]*yaml.Node, len(b.Content)/2)
+		for i := 0; i+1 < len(b.Content); i += 2 {
+			index[convertedKeyText(b.Content[i])] = b.Content[i+1]
+		}
+		for i := 0; i+1 < len(a.Content); i += 2 {
+			other, ok := index[convertedKeyText(a.Content[i])]
+			if !ok || !equivalentConvertedNodes(a.Content[i+1], other) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// convertedKeyText renders a mapping key for comparison, applying the same
+// widening to a string that the conversion does, so a !!int key and the
+// string it becomes still line up.
+func convertedKeyText(n *yaml.Node) string {
+	text, err := yamlKeyText(n)
+	if err != nil {
+		return n.Value
+	}
+	return text
+}
+
+// scalarValueKey renders a scalar as a comparable string carrying its type
+// and decoded value, so two spellings of one number match and a number and
+// the string of it do not.
+func scalarValueKey(n *yaml.Node) string {
+	switch n.Tag {
+	case "!!null":
+		return "z"
+	case "!!bool":
+		var b bool
+		if err := n.Decode(&b); err == nil {
+			return "b:" + strconv.FormatBool(b)
+		}
+	case "!!int":
+		var i int64
+		if err := n.Decode(&i); err == nil {
+			return "i:" + strconv.FormatInt(i, 10)
+		}
+		var u uint64
+		if err := n.Decode(&u); err == nil {
+			return "i:" + strconv.FormatUint(u, 10)
+		}
+	case "!!float":
+		var f float64
+		if err := n.Decode(&f); err == nil {
+			return "f:" + formatFloatForJSON5(f)
+		}
+	}
+	// !!str, !!timestamp, !!binary and anything unrecognised compare as
+	// text, which is what makes the timestamp widening equal to itself.
+	return "s:" + n.Value
+}

--- a/tasks/convert_comments.go
+++ b/tasks/convert_comments.go
@@ -1,0 +1,141 @@
+package tasks
+
+import "strings"
+
+// Comment translation between the two surface syntaxes.
+//
+// YAML and JSON5 both let a recipe carry commentary, and `docket fmt`
+// preserves it within a format, so a conversion that dropped it would be
+// no better than the round trip through an external tool that #418 exists
+// to replace. The two formatters store comments differently, though:
+// yaml.v3 keeps one string per anchor point with the `#` included and
+// embedded newlines for a multi-line run, while the JSON5 AST keeps a
+// slice of raw tokens with their `//` or `/* */` delimiters intact.
+
+// json5CommentsToYAML renders a run of raw JSON5 comment tokens as the
+// single `#`-prefixed string yaml.v3 wants, one source line per output
+// line.
+func json5CommentsToYAML(raws []string) string {
+	var lines []string
+	for _, raw := range raws {
+		// An absent comment is the empty string - json5Member.LineComment
+		// is not a slice, so "no trailing comment" arrives as one. Rendering
+		// it would put a bare "#" beside every key that had nothing to say.
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		lines = append(lines, json5CommentBodyLines(raw)...)
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	for i, line := range lines {
+		lines[i] = yamlCommentLine(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// json5CommentBodyLines strips a raw comment token's delimiters and
+// returns its text, one entry per line. A block comment spanning several
+// lines yields several entries; the delimiters themselves never survive,
+// since the YAML side has only one comment syntax to render into.
+func json5CommentBodyLines(raw string) []string {
+	switch {
+	case strings.HasPrefix(raw, "//"):
+		return []string{strings.TrimRight(strings.TrimPrefix(raw, "//"), " \t")}
+	case strings.HasPrefix(raw, "/*"):
+		body := strings.TrimPrefix(raw, "/*")
+		body = strings.TrimSuffix(body, "*/")
+		lines := strings.Split(body, "\n")
+		out := make([]string, 0, len(lines))
+		for _, line := range lines {
+			out = append(out, strings.TrimRight(line, " \t"))
+		}
+		// A `/* ... */` written across lines usually opens and closes on
+		// blank fragments; dropping those keeps the YAML from gaining two
+		// empty comment lines it never had.
+		return trimEmptyEdges(out)
+	}
+	return []string{raw}
+}
+
+// yamlCommentLine turns one line of comment text into the form yaml.v3
+// stores and re-emits.
+//
+// An empty line has to come back as a bare "#", never "". The emitter
+// writes an empty comment line through as a real blank line, which on
+// re-parse ends the comment and splits what was one head comment in two -
+// so a converted recipe would stop being idempotent under `docket fmt`.
+func yamlCommentLine(text string) string {
+	trimmed := strings.TrimRight(text, " \t")
+	if strings.TrimSpace(trimmed) == "" {
+		return "#"
+	}
+	if strings.HasPrefix(strings.TrimSpace(trimmed), "#") {
+		return strings.TrimSpace(trimmed)
+	}
+	if strings.HasPrefix(trimmed, " ") {
+		return "#" + trimmed
+	}
+	return "# " + trimmed
+}
+
+// yamlCommentToJSON5 renders a yaml.v3 comment string as JSON5 comment
+// tokens, one per line.
+//
+// Always `//`, never `/* */`: a line comment runs to end of line, so no
+// comment text can terminate it early, while a `*/` sitting inside the
+// text would close a block comment in the middle and turn the remainder
+// into syntax. The cost is that a JSON5 `/* x */` comes back as `// x`
+// after a round trip, which is a normalisation rather than a loss.
+func yamlCommentToJSON5(comment string) []string {
+	if strings.TrimSpace(comment) == "" {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(comment, "\n") {
+		out = append(out, json5CommentLine(line))
+	}
+	return trimEmptyEdges(out)
+}
+
+// json5CommentLine turns one line of YAML comment text into a `//` token.
+func json5CommentLine(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "#") {
+		return "//" + strings.TrimSuffix(strings.TrimPrefix(trimmed, "#"), " ")
+	}
+	return "// " + trimmed
+}
+
+// flattenComment collapses a multi-line comment onto one line, for the
+// trailing-comment slots that only hold one.
+//
+// Flattening keeps the comment where the author put it. Demoting it to a
+// head comment instead would preserve every word but move it above the
+// thing it was annotating, which reads worse than a long line.
+func flattenComment(comment string) string {
+	fields := strings.Fields(strings.ReplaceAll(comment, "\n", " "))
+	return strings.Join(fields, " ")
+}
+
+// trimEmptyEdges drops leading and trailing empty entries, leaving any
+// interior ones alone - a deliberate blank line inside a comment block is
+// the author's paragraph break and survives.
+func trimEmptyEdges(lines []string) []string {
+	start := 0
+	for start < len(lines) && strings.TrimSpace(lines[start]) == "" {
+		start++
+	}
+	end := len(lines)
+	for end > start && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+	if start >= end {
+		return nil
+	}
+	return lines[start:end]
+}

--- a/tasks/convert_test.go
+++ b/tasks/convert_test.go
@@ -1,0 +1,648 @@
+package tasks
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// convertFixtureYAML and convertFixtureJSON5 are the same recipe in both
+// surface syntaxes, carrying every shape the walkers have to survive:
+// head, line and foot comments, a nested tasks list, a block scalar, a
+// string that would resolve as a number and one that would resolve as a
+// bool, an inline scalar array, and a sigil template.
+const convertFixtureYAML = `# top of file
+- name: web
+  # about the tasks
+  tasks:
+    - name: create app # trailing note
+      dokku_app:
+        app: '{{ .app }}'
+        state: present
+
+    - name: config
+      dokku_config:
+        app: web
+        keys:
+          PORT: "5000"
+          DEBUG: "true"
+          NOTE: |
+            first line
+            second line
+        restart: false
+        order: [1, 2, 3]
+`
+
+const convertFixtureJSON5 = `// top of file
+[
+  {
+    name: "web",
+    // about the tasks
+    tasks: [
+      {
+        name: "create app", // trailing note
+        dokku_app: {
+          app: "{{ .app }}",
+          state: "present",
+        },
+      },
+
+      {
+        name: "config",
+        dokku_config: {
+          app: "web",
+          keys: {
+            PORT: "5000",
+            DEBUG: "true",
+            NOTE: "first line\nsecond line\n",
+          },
+          restart: false,
+          order: [1, 2, 3],
+        },
+      },
+    ],
+  },
+]
+`
+
+// fixtureFor returns the fixture written in the given codec's syntax.
+func fixtureFor(t *testing.T, name string) string {
+	t.Helper()
+	switch name {
+	case FormatYAML:
+		return convertFixtureYAML
+	case FormatNameJSON5:
+		return convertFixtureJSON5
+	}
+	t.Fatalf("no conversion fixture for codec %q; add one when adding a format", name)
+	return ""
+}
+
+// TestConvertSameFormatIsFormat pins the property every pre-existing
+// `docket fmt` invocation depends on: converting to the format a recipe is
+// already in is byte-for-byte what the formatter alone would have done.
+func TestConvertSameFormatIsFormat(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]map[string]string{
+		FormatYAML: {
+			"recipe":        convertFixtureYAML,
+			"empty":         "",
+			"comment only":  "# just a note\n",
+			"marker":        "---\n- name: web\n  tasks: []\n",
+			"non-canonical": "- tasks: []\n  name: web\n",
+		},
+		FormatNameJSON5: {
+			"recipe":        convertFixtureJSON5,
+			"non-canonical": "[{tasks: [], name: \"web\"}]\n",
+		},
+	}
+
+	for _, codec := range Codecs() {
+		codec := codec
+		for label, input := range cases[codec.Name()] {
+			label, input := label, input
+			t.Run(codec.Name()+"/"+label, func(t *testing.T) {
+				t.Parallel()
+				want, wantErr := codec.Format([]byte(input))
+				got, gotErr := Convert([]byte(input), codec, codec)
+				if (wantErr == nil) != (gotErr == nil) {
+					t.Fatalf("Format err = %v, Convert err = %v", wantErr, gotErr)
+				}
+				if string(got) != string(want) {
+					t.Errorf("Convert != Format:\nwant:\n%s\ngot:\n%s", want, got)
+				}
+			})
+		}
+	}
+}
+
+// TestConvertMatrix runs every ordered pair of registered codecs. A new
+// format joining the registry is checked against all of these without
+// anyone editing the test.
+func TestConvertMatrix(t *testing.T) {
+	t.Parallel()
+
+	for _, from := range Codecs() {
+		for _, to := range Codecs() {
+			if from.Name() == to.Name() {
+				continue
+			}
+			from, to := from, to
+			t.Run(from.Name()+"_to_"+to.Name(), func(t *testing.T) {
+				t.Parallel()
+				input := []byte(fixtureFor(t, from.Name()))
+
+				out, err := Convert(input, from, to)
+				if err != nil {
+					t.Fatalf("Convert: %v", err)
+				}
+
+				// The conversion writes canonical bytes, so a converted
+				// file passes `docket fmt --check` without a second pass.
+				formatted, err := to.Format(out)
+				if err != nil {
+					t.Fatalf("Format of converted output: %v", err)
+				}
+				if string(formatted) != string(out) {
+					t.Errorf("converted output is not canonical:\nconverted:\n%s\nformatted:\n%s", out, formatted)
+				}
+
+				if problems := to.Lint(out); len(problems) > 0 {
+					t.Errorf("Lint of converted output = %v, want none", problems)
+				}
+
+				// And it means the same recipe.
+				before, err := UnmarshalRecipe(input, from.Name())
+				if err != nil {
+					t.Fatalf("UnmarshalRecipe(input): %v", err)
+				}
+				after, err := UnmarshalRecipe(out, to.Name())
+				if err != nil {
+					t.Fatalf("UnmarshalRecipe(converted): %v", err)
+				}
+				if !reflect.DeepEqual(before, after) {
+					t.Errorf("converted recipe differs:\nbefore: %#v\nafter:  %#v", before, after)
+				}
+			})
+		}
+	}
+}
+
+// TestConvertPreservesCommentText is the property that makes conversion
+// worth doing at all. It compares comment bodies as a multiset rather than
+// asserting on placement, which catches a comment being dropped and a
+// comment being printed twice with one assertion, and stays true for a
+// format whose comment anchors do not line up exactly with YAML's.
+func TestConvertPreservesCommentText(t *testing.T) {
+	t.Parallel()
+
+	for _, from := range Codecs() {
+		for _, to := range Codecs() {
+			if from.Name() == to.Name() {
+				continue
+			}
+			from, to := from, to
+			t.Run(from.Name()+"_to_"+to.Name(), func(t *testing.T) {
+				t.Parallel()
+				input := []byte(fixtureFor(t, from.Name()))
+
+				out, err := Convert(input, from, to)
+				if err != nil {
+					t.Fatalf("Convert: %v", err)
+				}
+
+				want := commentBodies(t, from, input)
+				got := commentBodies(t, to, out)
+				if len(want) == 0 {
+					t.Fatal("fixture carries no comments; the test would prove nothing")
+				}
+				if !reflect.DeepEqual(want, got) {
+					t.Errorf("comments changed:\nwant %q\ngot  %q\noutput:\n%s", want, got, out)
+				}
+			})
+		}
+	}
+}
+
+// TestConvertRoundTripConverges checks that comment attachment settles
+// after one pass: a second full round trip reproduces the first exactly.
+func TestConvertRoundTripConverges(t *testing.T) {
+	t.Parallel()
+
+	for _, from := range Codecs() {
+		for _, to := range Codecs() {
+			if from.Name() == to.Name() {
+				continue
+			}
+			from, to := from, to
+			t.Run(from.Name()+"_to_"+to.Name(), func(t *testing.T) {
+				t.Parallel()
+				input := []byte(fixtureFor(t, from.Name()))
+
+				there, err := Convert(input, from, to)
+				if err != nil {
+					t.Fatalf("Convert out: %v", err)
+				}
+				back, err := Convert(there, to, from)
+				if err != nil {
+					t.Fatalf("Convert back: %v", err)
+				}
+				thereAgain, err := Convert(back, from, to)
+				if err != nil {
+					t.Fatalf("Convert out again: %v", err)
+				}
+				if string(thereAgain) != string(there) {
+					t.Errorf("round trip does not converge:\nfirst:\n%s\nsecond:\n%s", there, thereAgain)
+				}
+
+				backAgain, err := Convert(thereAgain, to, from)
+				if err != nil {
+					t.Fatalf("Convert back again: %v", err)
+				}
+				if string(backAgain) != string(back) {
+					t.Errorf("reverse round trip does not converge:\nfirst:\n%s\nsecond:\n%s", back, backAgain)
+				}
+			})
+		}
+	}
+}
+
+// TestConvertEmptyAndCommentOnlyIsNoOp pins that a file with no recipe in
+// it is left exactly as it was, rather than becoming an empty document in
+// the other format.
+func TestConvertEmptyAndCommentOnlyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{"", "# just a note\n", "\n\n"} {
+		got, err := Convert([]byte(input), CodecFor(FormatYAML), CodecFor(FormatNameJSON5))
+		if err != nil {
+			t.Fatalf("Convert(%q): %v", input, err)
+		}
+		if string(got) != input {
+			t.Errorf("Convert(%q) = %q, want it untouched", input, got)
+		}
+	}
+}
+
+// TestConvertRejectsMultiDocument keeps Format's rule: a file holding more
+// than one YAML document is refused rather than half-converted.
+func TestConvertRejectsMultiDocument(t *testing.T) {
+	t.Parallel()
+	in := []byte("- name: a\n  tasks: []\n---\n- name: b\n  tasks: []\n")
+	if out, err := Convert(in, CodecFor(FormatYAML), CodecFor(FormatNameJSON5)); err == nil {
+		t.Errorf("Convert accepted a multi-document file: %s", out)
+	}
+}
+
+// TestConvertNonSequenceRoot covers the shapes `fmt` accepts that are not
+// recipes. It formats any document today and must keep converting any
+// document too.
+func TestConvertNonSequenceRoot(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"mapping root", "a: 1\n", "{\n  a: 1,\n}\n"},
+		{"scalar root", "hi\n", "\"hi\"\n"},
+		{"empty sequence", "[]\n", "[]\n"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Convert([]byte(tc.in), CodecFor(FormatYAML), CodecFor(FormatNameJSON5))
+			if err != nil {
+				t.Fatalf("Convert: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Convert(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConvertInlinesAliases covers the anchor policy: sharing is expanded
+// into copies, which is what the loader already does when it unmarshals,
+// and the anchor declarations disappear.
+func TestConvertInlinesAliases(t *testing.T) {
+	t.Parallel()
+
+	in := []byte("- name: &n web\n  tasks: []\n- name: *n\n  tasks: []\n")
+	out, err := Convert(in, CodecFor(FormatYAML), CodecFor(FormatNameJSON5))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if strings.Contains(string(out), "&n") || strings.Contains(string(out), "*n") {
+		t.Errorf("anchor or alias survived into json5:\n%s", out)
+	}
+	if n := strings.Count(string(out), `name: "web"`); n != 2 {
+		t.Errorf("alias expanded %d times, want 2:\n%s", n, out)
+	}
+}
+
+// TestConvertExpandsMergeKeys walks the YAML 1.1 merge precedence rules:
+// a key the mapping states itself beats a merged one, and an earlier merge
+// source beats a later one.
+func TestConvertExpandsMergeKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{
+			name: "own keys win",
+			in:   "defaults: &d\n  host: shared\n  sudo: \"yes\"\nplay:\n  <<: *d\n  host: mine\n",
+			want: map[string]string{"host": "mine", "sudo": "yes"},
+		},
+		{
+			name: "earlier source wins",
+			in:   "a: &a\n  k: first\nb: &b\n  k: second\nplay:\n  <<: [*a, *b]\n",
+			want: map[string]string{"k": "first"},
+		},
+		{
+			name: "nested merge resolves first",
+			in:   "base: &base\n  k: deep\nmid: &mid\n  <<: *base\nplay:\n  <<: *mid\n",
+			want: map[string]string{"k": "deep"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := Convert([]byte(tc.in), CodecFor(FormatYAML), CodecFor(FormatNameJSON5))
+			if err != nil {
+				t.Fatalf("Convert: %v", err)
+			}
+			if strings.Contains(string(out), "<<") {
+				t.Errorf("merge key survived into json5:\n%s", out)
+			}
+			var decoded map[string]interface{}
+			yamlBytes, problem := CodecFor(FormatNameJSON5).ToYAML(out)
+			if problem != nil {
+				t.Fatalf("ToYAML: %s", problem.Message)
+			}
+			if err := yaml.Unmarshal(yamlBytes, &decoded); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			play, _ := decoded["play"].(map[string]interface{})
+			for key, want := range tc.want {
+				if got, _ := play[key].(string); got != want {
+					t.Errorf("play[%q] = %q, want %q (output:\n%s)", key, got, want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestConvertRejectsBadMergeValue keeps a malformed merge from being
+// quietly ignored.
+func TestConvertRejectsBadMergeValue(t *testing.T) {
+	t.Parallel()
+	in := []byte("play:\n  <<: not-a-mapping\n")
+	if out, err := Convert(in, CodecFor(FormatYAML), CodecFor(FormatNameJSON5)); err == nil {
+		t.Errorf("Convert accepted a scalar merge value: %s", out)
+	}
+}
+
+// TestConvertRejectsUnrepresentable covers the constructs a target format
+// cannot carry. Each has to be reported, never guessed at.
+func TestConvertRejectsUnrepresentable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		from string
+		to   string
+		in   string
+		want string
+	}{
+		{
+			name: "complex mapping key",
+			from: FormatYAML,
+			to:   FormatNameJSON5,
+			in:   "? [a, b]\n: value\n",
+			want: "not a scalar",
+		},
+		{
+			name: "custom tag",
+			from: FormatYAML,
+			to:   FormatNameJSON5,
+			in:   "key: !Foo bar\n",
+			want: "no json5 representation",
+		},
+		{
+			name: "bare json5 identifier",
+			from: FormatNameJSON5,
+			to:   FormatYAML,
+			in:   "{ key: web }\n",
+			want: "not valid json5",
+		},
+		{
+			name: "duplicate json5 key",
+			from: FormatNameJSON5,
+			to:   FormatYAML,
+			in:   "{ key: 1, key: 2 }\n",
+			want: "duplicate key",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := Convert([]byte(tc.in), CodecFor(tc.from), CodecFor(tc.to))
+			if err == nil {
+				t.Fatalf("Convert accepted %q: %s", tc.in, out)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to mention %q", err, tc.want)
+			}
+			if out != nil {
+				t.Errorf("Convert returned bytes alongside an error: %q", out)
+			}
+		})
+	}
+}
+
+// TestConvertNamesTheDuplicateKey pins what the Lint screen buys. The
+// same file is refused either way - the JSON5 formatter's own round-trip
+// guard has always rejected a duplicate-keyed object, and same-format
+// formatting still gets exactly that - but a conversion says which key is
+// duplicated instead of reporting that the recipe changed.
+func TestConvertNamesTheDuplicateKey(t *testing.T) {
+	t.Parallel()
+	in := []byte("{ key: 1, key: 2 }\n")
+
+	_, sameErr := Convert(in, CodecFor(FormatNameJSON5), CodecFor(FormatNameJSON5))
+	_, formatErr := CodecFor(FormatNameJSON5).Format(in)
+	if sameErr == nil || formatErr == nil || sameErr.Error() != formatErr.Error() {
+		t.Errorf("same-format Convert err = %v, Format err = %v; want them identical", sameErr, formatErr)
+	}
+
+	_, convertErr := Convert(in, CodecFor(FormatNameJSON5), CodecFor(FormatYAML))
+	if convertErr == nil {
+		t.Fatal("cross-format Convert accepted a duplicate-keyed recipe")
+	}
+	if !strings.Contains(convertErr.Error(), `duplicate key "key"`) {
+		t.Errorf("cross-format error = %q, want it to name the duplicated key", convertErr)
+	}
+}
+
+// TestConvertRejectsDeepAliasNest keeps a small file from asking for an
+// enormous tree.
+func TestConvertRejectsDeepAliasNest(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	b.WriteString("a0: &a0 [x]\n")
+	for i := 1; i < 40; i++ {
+		b.WriteString("a")
+		b.WriteString(itoa(i))
+		b.WriteString(": &a")
+		b.WriteString(itoa(i))
+		b.WriteString(" [*a")
+		b.WriteString(itoa(i - 1))
+		b.WriteString(", *a")
+		b.WriteString(itoa(i - 1))
+		b.WriteString("]\n")
+	}
+	if out, err := Convert([]byte(b.String()), CodecFor(FormatYAML), CodecFor(FormatNameJSON5)); err == nil {
+		t.Errorf("Convert accepted an exponential alias nest, produced %d bytes", len(out))
+	}
+}
+
+// TestEquivalentConvertedNodes pins the comparator the cross-format guard
+// leans on: a deliberate normalisation compares equal, a change in meaning
+// does not.
+func TestEquivalentConvertedNodes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"hex and decimal", "k: 0x1F", "k: 31", true},
+		{"underscored int", "k: 1_000", "k: 1000", true},
+		{"octal", "k: 0o17", "k: 15", true},
+		{"timestamp widened to string", "k: 2015-01-01", `k: "2015-01-01"`, true},
+		{"float spellings", "k: 1.50", "k: 1.5", true},
+		{"string is not int", `k: "5"`, "k: 5", false},
+		{"bool is not string", "k: true", `k: "true"`, false},
+		{"different value", "k: 1", "k: 2", false},
+		{"missing key", "k: 1\nj: 2", "k: 1", false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var a, b yaml.Node
+			if err := yaml.Unmarshal([]byte(tc.a), &a); err != nil {
+				t.Fatalf("unmarshal a: %v", err)
+			}
+			if err := yaml.Unmarshal([]byte(tc.b), &b); err != nil {
+				t.Fatalf("unmarshal b: %v", err)
+			}
+			if got := equivalentConvertedNodes(documentBody(&a), documentBody(&b)); got != tc.want {
+				t.Errorf("equivalentConvertedNodes(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// commentBodies returns every comment in a recipe as sorted, delimiter-
+// stripped text, so two formats' comments can be compared directly.
+func commentBodies(t *testing.T, codec Codec, data []byte) []string {
+	t.Helper()
+	doc, err := codec.DecodeDocument(data)
+	if err != nil {
+		t.Fatalf("DecodeDocument: %v", err)
+	}
+	var out []string
+	collectComments(doc, &out)
+	sort.Strings(out)
+	return out
+}
+
+// collectComments walks a node tree gathering head, line and foot comment
+// text, one entry per line.
+func collectComments(n *yaml.Node, out *[]string) {
+	if n == nil {
+		return
+	}
+	for _, comment := range []string{n.HeadComment, n.LineComment, n.FootComment} {
+		for _, line := range strings.Split(comment, "\n") {
+			line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "#"))
+			if line != "" {
+				*out = append(*out, line)
+			}
+		}
+	}
+	for _, child := range n.Content {
+		collectComments(child, out)
+	}
+}
+
+// itoa keeps the alias-nest fixture readable without dragging strconv into
+// the test's import list for one call.
+func itoa(i int) string {
+	if i < 10 {
+		return string(rune('0' + i))
+	}
+	return itoa(i/10) + string(rune('0'+i%10))
+}
+
+// FuzzConvertRoundTrip is the backstop for the scalar and comment tables:
+// they cover what was thought of, this covers what was not.
+//
+// The contract is deliberately weak, because most random input is not a
+// recipe at all. Convert may refuse anything it likes; what it may not do
+// is panic, or produce output that means something other than what it was
+// given.
+func FuzzConvertRoundTrip(f *testing.F) {
+	f.Add(convertFixtureYAML)
+	f.Add(convertFixtureJSON5)
+	f.Add("- name: web\n  tasks: []\n")
+	f.Add("[{ name: \"web\", tasks: [] }]\n")
+	f.Add("# comment only\n")
+	f.Add("")
+	f.Add("k: <<\n")
+	f.Add("- &a [1]\n- *a\n")
+	f.Add("a: &a {k: v}\nb:\n  <<: *a\n")
+	f.Add("{ a: 0x1F, b: Infinity, c: \"true\" }")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		for _, from := range Codecs() {
+			for _, to := range Codecs() {
+				if from.Name() == to.Name() {
+					continue
+				}
+				out, err := Convert([]byte(input), from, to)
+				if err != nil {
+					if out != nil {
+						t.Errorf("%s to %s returned bytes alongside an error %v: %q", from.Name(), to.Name(), err, out)
+					}
+					continue
+				}
+				// Whatever came out has to be readable as the format it
+				// claims to be, and has to mean what went in. Convert's own
+				// guard checks the second; re-checking here catches a guard
+				// that stopped running.
+				before, err := from.DecodeDocument([]byte(input))
+				if err != nil || before == nil {
+					continue
+				}
+				// Compare against the flattened tree, not the raw one:
+				// inlining an alias is a deliberate rewrite, so a document
+				// that still holds the alias node is not the thing the
+				// output should equal.
+				if err := inlineAliases(before); err != nil {
+					continue
+				}
+				if err := expandMergeKeys(before); err != nil {
+					continue
+				}
+				after, err := to.DecodeDocument(out)
+				if err != nil {
+					t.Fatalf("%s to %s produced unreadable %s: %v\ninput:\n%s\noutput:\n%s",
+						from.Name(), to.Name(), to.Name(), err, input, out)
+				}
+				if !equivalentConvertedNodes(documentBody(before), documentBody(after)) {
+					t.Fatalf("%s to %s changed the recipe\ninput:\n%s\noutput:\n%s",
+						from.Name(), to.Name(), input, out)
+				}
+			}
+		}
+	})
+}

--- a/tasks/document_json5.go
+++ b/tasks/document_json5.go
@@ -1,0 +1,468 @@
+package tasks
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// The bridge between the JSON5 AST in format_json5.go and the yaml.Node
+// interchange every cross-format conversion passes through.
+//
+// Both formatters already keep comments; these walkers are what let a
+// conversion keep them too, instead of round-tripping through plain Go
+// values and coming out stripped.
+
+// json5DocumentToYAML converts a parsed JSON5 document into the yaml.Node
+// document the interchange is made of.
+func json5DocumentToYAML(root *json5Node) (*yaml.Node, error) {
+	if root == nil {
+		return nil, fmt.Errorf("empty json5 document")
+	}
+	body, err := json5NodeToYAMLNode(root)
+	if err != nil {
+		return nil, err
+	}
+	// Comments sitting above the whole document attach to the body node
+	// rather than to the DocumentNode, because that is where yaml.v3 puts
+	// them when it parses a document with no explicit `---`; matching it
+	// keeps a converted recipe stable under a second `docket fmt`.
+	body.HeadComment = joinComments(json5CommentsToYAML(root.HeadComments), body.HeadComment)
+	body.FootComment = joinComments(body.FootComment, json5CommentsToYAML(root.AfterComments))
+
+	return &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{body}}, nil
+}
+
+// json5NodeToYAMLNode converts one JSON5 AST node and everything under it.
+func json5NodeToYAMLNode(n *json5Node) (*yaml.Node, error) {
+	switch n.Kind {
+	case json5Object:
+		out := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		seen := make(map[string]bool, len(n.Members))
+		for _, m := range n.Members {
+			if seen[m.Key] {
+				return nil, fmt.Errorf("duplicate key %q", m.Key)
+			}
+			seen[m.Key] = true
+
+			key := yamlStringNode(m.Key)
+			key.HeadComment = json5CommentsToYAML(m.HeadComments)
+			// The trailing comment goes on the KEY, not the value. yaml.v3
+			// stashes a key's line comment and replays it in the right
+			// place for either shape: beside the value for `name: web #
+			// note`, and straight after the colon for a block value, as
+			// `tasks: # note`. Putting it on the value instead would push
+			// a container's comment down past the entire block.
+			key.LineComment = flattenComment(json5CommentsToYAML([]string{m.LineComment}))
+
+			value, err := json5NodeToYAMLNode(m.Value)
+			if err != nil {
+				return nil, fmt.Errorf("key %q: %w", m.Key, err)
+			}
+			out.Content = append(out.Content, key, value)
+		}
+		out.FootComment = json5CommentsToYAML(n.FootComments)
+		return out, nil
+
+	case json5Array:
+		out := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for i, e := range n.Elements {
+			value, err := json5NodeToYAMLNode(e.Value)
+			if err != nil {
+				return nil, fmt.Errorf("element %d: %w", i, err)
+			}
+			value.HeadComment = joinComments(json5CommentsToYAML(e.HeadComments), value.HeadComment)
+			if lc := flattenComment(json5CommentsToYAML([]string{e.LineComment})); lc != "" {
+				value.LineComment = lc
+			}
+			out.Content = append(out.Content, value)
+		}
+		out.FootComment = json5CommentsToYAML(n.FootComments)
+		return out, nil
+
+	case json5Scalar:
+		return json5ScalarToYAMLNode(n.Raw)
+	}
+	return nil, fmt.Errorf("unknown json5 node kind %d", n.Kind)
+}
+
+// json5ScalarToYAMLNode turns a raw JSON5 scalar token into a typed YAML
+// scalar node.
+func json5ScalarToYAMLNode(raw string) (*yaml.Node, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("empty json5 scalar")
+	}
+	if raw[0] == '"' || raw[0] == '\'' {
+		decoded, ok := decodeJSON5String(raw)
+		if !ok {
+			return nil, fmt.Errorf("invalid json5 string literal %s", raw)
+		}
+		return yamlStringNode(decoded), nil
+	}
+
+	switch raw {
+	case "true", "false":
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: raw}, nil
+	case "null":
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}, nil
+	case "Infinity", "+Infinity":
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: ".inf"}, nil
+	case "-Infinity":
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: "-.inf"}, nil
+	case "NaN", "+NaN", "-NaN":
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: ".nan"}, nil
+	}
+
+	if c := raw[0]; c == '+' || c == '-' || c == '.' || (c >= '0' && c <= '9') {
+		return json5NumberToYAMLNode(raw)
+	}
+
+	// A bare word that is not one of the JSON5 keywords. parseValue accepts
+	// any identifier as a scalar, so the AST will happily carry `web` where
+	// `"web"` was meant, but titanous/json5 rejects it and so does every
+	// other JSON5 reader - the file is already broken. Passing it through as
+	// a string would invent a value rather than report one.
+	return nil, fmt.Errorf("unquoted value %q is not valid json5", raw)
+}
+
+// json5NumberToYAMLNode types a JSON5 numeric literal.
+//
+// Hex is normalised to decimal rather than passed through, even though
+// YAML would accept `0x1F`: json5ToYAMLBytes, which is what `validate`
+// reads a JSON5 recipe through, already decodes to a number and re-emits
+// it in decimal, and `fmt` must not disagree with `validate` about what a
+// recipe says.
+func json5NumberToYAMLNode(raw string) (*yaml.Node, error) {
+	negative := strings.HasPrefix(raw, "-")
+	digits := strings.TrimLeft(raw, "+-")
+
+	if len(digits) > 2 && digits[0] == '0' && (digits[1] == 'x' || digits[1] == 'X') {
+		magnitude, err := strconv.ParseUint(digits[2:], 16, 64)
+		if err != nil {
+			return nil, fmt.Errorf("json5 number %s is out of range", raw)
+		}
+		text := strconv.FormatUint(magnitude, 10)
+		if negative {
+			text = "-" + text
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: text}, nil
+	}
+
+	if !strings.ContainsAny(digits, ".eE") {
+		if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.FormatInt(i, 10)}, nil
+		}
+		if !negative {
+			if u, err := strconv.ParseUint(digits, 10, 64); err == nil {
+				return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.FormatUint(u, 10)}, nil
+			}
+		}
+		return nil, fmt.Errorf("json5 number %s is out of range", raw)
+	}
+
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid json5 number %s", raw)
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: formatFloatForYAML(f)}, nil
+}
+
+// yamlStringNode builds the string scalar every piece of text entering the
+// interchange becomes.
+//
+// The explicit !!str tag does most of the work: yaml.v3 compares it
+// against what the bare value would resolve to and force-quotes on a
+// mismatch, so "true", "5", "null", "~" and "" come out quoted and read
+// back as strings. Style is left at zero so the emitter keeps its own good
+// judgement - a value holding a newline becomes a literal block scalar,
+// and degrades to a quoted one when the block form cannot carry it.
+//
+// The tag alone is not quite enough, though. A value of "<<" is written
+// plain, because the encoder's quoting check does not consider the merge
+// tag, and `g: <<` reads back as !!merge rather than as the string it was.
+// Rather than enumerate the escapees, stringScalarSurvivesEncoding asks
+// yaml.v3 directly and only forces quotes where the answer comes back
+// wrong, which keeps a sigil template as the single-quoted '{{ .app }}'
+// the emitter would have chosen on its own.
+func yamlStringNode(s string) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}
+	if containsInterpolation(s) || !stringScalarSurvivesEncoding(s) {
+		node.Style = yaml.DoubleQuotedStyle
+	}
+	return node
+}
+
+// containsInterpolation reports whether a value holds a sigil template.
+//
+// The quote characters around one are load-bearing, not cosmetic, because
+// a recipe is rendered as TEXT and only then parsed: the `dq` filter
+// escapes a value for a double-quoted scalar, JSON-style, so `"{{ .app |
+// dq }}"` renders to `"we\"b"` and reads back as `we"b`. Left to itself
+// the emitter picks single quotes for a value starting with `{`, and
+// `'we\"b'` reads back as `we\"b` - a literal backslash, silently.
+//
+// JSON5 strings are double-quoted, so a double-quoted YAML scalar is the
+// faithful rendering of one, and forcing the style here is what keeps a
+// converted recipe meaning what it meant. The reverse direction has a
+// matching gap that cannot be closed the same way: canonical JSON5 has no
+// single-quoted string, so a YAML `'{{ .app }}'` - safe precisely because
+// single quotes tolerate a double quote in the value - becomes the
+// double-quoted form, which `docket validate` then reports as
+// unsafe_input_value. That is #538.
+func containsInterpolation(s string) bool {
+	return strings.Contains(s, "{{")
+}
+
+// stringScalarSurvivesEncoding reports whether yaml.v3 writes s in a form
+// that reads back as the same string, left to its own devices.
+//
+// Asking by doing is deliberate. The alternative is a list of values the
+// encoder mishandles, which would be right until the day yaml.v3 changes
+// or a format adds a new special token, and wrong silently thereafter.
+func stringScalarSurvivesEncoding(s string) bool {
+	out, err := yaml.Marshal(&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s})
+	if err != nil {
+		return false
+	}
+	var back yaml.Node
+	if err := yaml.Unmarshal(out, &back); err != nil {
+		return false
+	}
+	body := documentBody(&back)
+	return body != nil && body.Kind == yaml.ScalarNode && body.Tag == "!!str" && body.Value == s
+}
+
+// formatFloatForYAML renders a float in a spelling that resolves back to
+// !!float rather than !!int.
+func formatFloatForYAML(f float64) string {
+	switch {
+	case math.IsInf(f, 1):
+		return ".inf"
+	case math.IsInf(f, -1):
+		return "-.inf"
+	case math.IsNaN(f):
+		return ".nan"
+	}
+	text := strconv.FormatFloat(f, 'g', -1, 64)
+	if !strings.ContainsAny(text, ".eE") {
+		text += ".0"
+	}
+	return text
+}
+
+// yamlDocumentToJSON5 converts an interchange document into the JSON5 AST
+// the emitter in format_json5.go writes.
+func yamlDocumentToJSON5(doc *yaml.Node) (*json5Node, error) {
+	body := documentBody(doc)
+	if body == nil {
+		return nil, fmt.Errorf("cannot convert an empty document")
+	}
+	out, err := yamlNodeToJSON5Node(body)
+	if err != nil {
+		return nil, err
+	}
+
+	head := yamlCommentToJSON5(body.HeadComment)
+	if doc != nil && doc.Kind == yaml.DocumentNode {
+		head = append(yamlCommentToJSON5(doc.HeadComment), head...)
+	}
+	out.HeadComments = append(head, out.HeadComments...)
+
+	// Comments after the value entirely live in AfterComments, kept apart
+	// from a container's own FootComments so emitJSON5 writes each exactly
+	// once - one inside the closing bracket, one after it.
+	after := yamlCommentToJSON5(body.FootComment)
+	if doc != nil && doc.Kind == yaml.DocumentNode {
+		after = append(after, yamlCommentToJSON5(doc.FootComment)...)
+	}
+	out.AfterComments = append(out.AfterComments, after...)
+
+	return out, nil
+}
+
+// yamlNodeToJSON5Node converts one interchange node and everything below.
+func yamlNodeToJSON5Node(n *yaml.Node) (*json5Node, error) {
+	switch n.Kind {
+	case yaml.DocumentNode:
+		return yamlDocumentToJSON5(n)
+
+	case yaml.AliasNode:
+		// Convert inlines every alias before it gets here, so reaching this
+		// means the flattening pass was skipped or missed a node.
+		return nil, fmt.Errorf("internal: unresolved YAML alias *%s reached the json5 writer", n.Value)
+
+	case yaml.MappingNode:
+		out := &json5Node{Kind: json5Object}
+		seen := make(map[string]bool, len(n.Content)/2)
+		var pending []string
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			keyNode, valueNode := n.Content[i], n.Content[i+1]
+			key, err := yamlKeyText(keyNode)
+			if err != nil {
+				return nil, err
+			}
+			if seen[key] {
+				return nil, fmt.Errorf("duplicate key %q after conversion", key)
+			}
+			seen[key] = true
+
+			value, err := yamlNodeToJSON5Node(valueNode)
+			if err != nil {
+				return nil, fmt.Errorf("key %q: %w", key, err)
+			}
+			// A container value carries its own head comments in the JSON5
+			// AST only for the root; for a member they belong to the member,
+			// so they are hoisted here and cleared to avoid a double print.
+			head := append(pending, yamlCommentToJSON5(keyNode.HeadComment)...)
+			head = append(head, yamlCommentToJSON5(valueNode.HeadComment)...)
+			head = append(head, value.HeadComments...)
+			value.HeadComments = nil
+			pending = nil
+
+			member := &json5Member{Key: key, Value: value, HeadComments: head}
+			member.LineComment = firstComment(valueNode.LineComment, keyNode.LineComment)
+			out.Members = append(out.Members, member)
+
+			// yaml.v3 migrates a value's foot comment onto its key, and a
+			// foot comment has no anchor of its own in JSON5, so it becomes
+			// the head of whatever pair follows - or the container's foot
+			// comment when nothing does.
+			pending = append(pending, yamlCommentToJSON5(keyNode.FootComment)...)
+		}
+		out.FootComments = append(pending, yamlCommentToJSON5(n.FootComment)...)
+		return out, nil
+
+	case yaml.SequenceNode:
+		out := &json5Node{Kind: json5Array}
+		var pending []string
+		for i, item := range n.Content {
+			value, err := yamlNodeToJSON5Node(item)
+			if err != nil {
+				return nil, fmt.Errorf("element %d: %w", i, err)
+			}
+			head := append(pending, yamlCommentToJSON5(item.HeadComment)...)
+			head = append(head, value.HeadComments...)
+			value.HeadComments = nil
+			pending = nil
+
+			element := &json5Element{Value: value, HeadComments: head}
+			element.LineComment = firstComment(item.LineComment)
+			out.Elements = append(out.Elements, element)
+
+			pending = append(pending, yamlCommentToJSON5(item.FootComment)...)
+		}
+		out.FootComments = append(pending, yamlCommentToJSON5(n.FootComment)...)
+		return out, nil
+
+	case yaml.ScalarNode:
+		raw, err := yamlScalarToJSON5Raw(n)
+		if err != nil {
+			return nil, err
+		}
+		return &json5Node{Kind: json5Scalar, Raw: raw}, nil
+	}
+	return nil, fmt.Errorf("unsupported YAML node kind %d", n.Kind)
+}
+
+// yamlScalarToJSON5Raw renders a YAML scalar as a JSON5 token.
+//
+// Dispatch is on the tag and never on the style: yaml.v3 resolves any
+// quoted or block scalar to !!str, so the tag already answers the question
+// a style inspection would be asking, including for `|` and `>`.
+//
+// !!timestamp and !!binary widen to strings. JSON5 has no date or binary
+// literal, and docket's own recipe structs hold both as strings, so the
+// widening is invisible to everything downstream - but it is a widening,
+// and equivalentConvertedNodes knows to accept it.
+func yamlScalarToJSON5Raw(n *yaml.Node) (string, error) {
+	switch n.Tag {
+	case "", "!!str", "!!timestamp", "!!binary":
+		return quoteJSON5String(n.Value), nil
+	case "!!null":
+		return "null", nil
+	case "!!bool":
+		var b bool
+		if err := n.Decode(&b); err != nil {
+			return "", fmt.Errorf("invalid boolean %q: %w", n.Value, err)
+		}
+		return strconv.FormatBool(b), nil
+	case "!!int":
+		// Decoding through yaml.v3 rather than re-lexing the spelling here
+		// is what keeps `fmt` and the loader agreeing on a value: YAML
+		// accepts 0o17, 0b1010, 1_000 and +5 as ints and JSON5 accepts none
+		// of them, and the only authority on which integer each means is
+		// the resolver the loader itself uses.
+		var i int64
+		if err := n.Decode(&i); err == nil {
+			return strconv.FormatInt(i, 10), nil
+		}
+		var u uint64
+		if err := n.Decode(&u); err == nil {
+			return strconv.FormatUint(u, 10), nil
+		}
+		return "", fmt.Errorf("integer %q is out of range for json5", n.Value)
+	case "!!float":
+		var f float64
+		if err := n.Decode(&f); err != nil {
+			return "", fmt.Errorf("invalid float %q: %w", n.Value, err)
+		}
+		return formatFloatForJSON5(f), nil
+	}
+	return "", fmt.Errorf("YAML tag %s has no json5 representation", n.Tag)
+}
+
+// formatFloatForJSON5 renders a float using JSON5's spellings for the
+// non-finite values.
+func formatFloatForJSON5(f float64) string {
+	switch {
+	case math.IsInf(f, 1):
+		return "Infinity"
+	case math.IsInf(f, -1):
+		return "-Infinity"
+	case math.IsNaN(f):
+		return "NaN"
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// yamlKeyText renders a mapping key as the string a JSON5 object key is.
+//
+// A non-scalar key - YAML's `? [a, b] : v` - is refused rather than
+// stringified: there is no spelling of it JSON5 could read back, and
+// inventing one would quietly change what the recipe says.
+func yamlKeyText(n *yaml.Node) (string, error) {
+	if n.Kind != yaml.ScalarNode {
+		return "", fmt.Errorf("mapping key at line %d is not a scalar; json5 object keys must be strings", n.Line)
+	}
+	switch n.Tag {
+	case "", "!!str", "!!timestamp", "!!binary":
+		return n.Value, nil
+	}
+	return yamlScalarToJSON5Raw(n)
+}
+
+// firstComment returns the first non-empty comment, rendered as a single
+// JSON5 line comment.
+func firstComment(comments ...string) string {
+	for _, c := range comments {
+		if strings.TrimSpace(c) == "" {
+			continue
+		}
+		return json5CommentLine(flattenComment(c))
+	}
+	return ""
+}
+
+// joinComments concatenates comment blocks, skipping empty ones.
+func joinComments(parts ...string) string {
+	var kept []string
+	for _, p := range parts {
+		if strings.TrimSpace(p) != "" {
+			kept = append(kept, p)
+		}
+	}
+	return strings.Join(kept, "\n")
+}

--- a/tasks/document_json5_test.go
+++ b/tasks/document_json5_test.go
@@ -1,0 +1,375 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// TestJSON5ScalarToYAMLNode is the JSON5 side of the scalar mapping. The
+// lookalike strings are the rows that matter most: a quoted "true" or "5"
+// has to arrive tagged !!str, or the YAML emitter writes it bare and the
+// recipe quietly changes type.
+func TestJSON5ScalarToYAMLNode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw     string
+		wantTag string
+		wantVal string
+		// forcedQuotes marks the rows yamlStringNode has to override the
+		// style for: a value yaml.v3 would emit plain and then misread on
+		// the way back, and any value holding a sigil template, whose
+		// quote characters are part of what the recipe means. Every other
+		// row leaves the choice to the emitter, which makes a better one
+		// than this code could.
+		forcedQuotes bool
+	}{
+		{`"web"`, "!!str", "web", false},
+		{`'web'`, "!!str", "web", false},
+		{`""`, "!!str", "", false},
+		{`"true"`, "!!str", "true", false},
+		{`"5"`, "!!str", "5", false},
+		{`"null"`, "!!str", "null", false},
+		{`"~"`, "!!str", "~", false},
+		{`"<<"`, "!!str", "<<", true},
+		{`"0x1F"`, "!!str", "0x1F", false},
+		{`"2015-01-01"`, "!!str", "2015-01-01", false},
+		{`"{{ .app }}"`, "!!str", "{{ .app }}", true},
+		{`"first\nsecond"`, "!!str", "first\nsecond", false},
+		{`"tab\there"`, "!!str", "tab\there", false},
+		{`"café"`, "!!str", "café", false},
+		{"true", "!!bool", "true", false},
+		{"false", "!!bool", "false", false},
+		{"null", "!!null", "null", false},
+		{"0", "!!int", "0", false},
+		{"42", "!!int", "42", false},
+		{"-42", "!!int", "-42", false},
+		{"+7", "!!int", "7", false},
+		{"0x1F", "!!int", "31", false},
+		{"-0x10", "!!int", "-16", false},
+		{"0X0A", "!!int", "10", false},
+		{"1.5", "!!float", "1.5", false},
+		{"-0.25", "!!float", "-0.25", false},
+		{".5", "!!float", "0.5", false},
+		{"5.", "!!float", "5.0", false},
+		{"1e3", "!!float", "1000.0", false},
+		{"1.5e-3", "!!float", "0.0015", false},
+		{"Infinity", "!!float", ".inf", false},
+		{"+Infinity", "!!float", ".inf", false},
+		{"-Infinity", "!!float", "-.inf", false},
+		{"NaN", "!!float", ".nan", false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+			node, err := json5ScalarToYAMLNode(tc.raw)
+			if err != nil {
+				t.Fatalf("json5ScalarToYAMLNode(%s): %v", tc.raw, err)
+			}
+			if node.Tag != tc.wantTag {
+				t.Errorf("tag = %q, want %q", node.Tag, tc.wantTag)
+			}
+			if node.Value != tc.wantVal {
+				t.Errorf("value = %q, want %q", node.Value, tc.wantVal)
+			}
+			wantStyle := yaml.Style(0)
+			if tc.forcedQuotes {
+				wantStyle = yaml.DoubleQuotedStyle
+			}
+			if node.Style != wantStyle {
+				t.Errorf("style = %d, want %d", node.Style, wantStyle)
+			}
+		})
+	}
+}
+
+// TestJSON5ScalarToYAMLNodeRejects covers the tokens the lenient JSON5
+// parser accepts but no JSON5 reader does.
+func TestJSON5ScalarToYAMLNodeRejects(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{"web", "undefined", "0x", "-", ""} {
+		if node, err := json5ScalarToYAMLNode(raw); err == nil {
+			t.Errorf("json5ScalarToYAMLNode(%q) = %v, want an error", raw, node)
+		}
+	}
+}
+
+// TestJSON5LookalikeStringsStayQuoted is the end-to-end version of the
+// rows above: the emitted YAML has to quote them, and reading it back has
+// to give strings.
+func TestJSON5LookalikeStringsStayQuoted(t *testing.T) {
+	t.Parallel()
+
+	in := []byte(`{a: "true", b: "5", c: "null", d: "~", e: "", f: "2015-01-01", g: "<<"}`)
+	out, err := Convert(in, CodecFor(FormatNameJSON5), CodecFor(FormatYAML))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	want := map[string]string{"a": "true", "b": "5", "c": "null", "d": "~", "e": "", "f": "2015-01-01", "g": "<<"}
+	for key, wantValue := range want {
+		got, ok := decoded[key].(string)
+		if !ok {
+			t.Errorf("%s = %#v (%T), want the string %q\noutput:\n%s", key, decoded[key], decoded[key], wantValue, out)
+			continue
+		}
+		if got != wantValue {
+			t.Errorf("%s = %q, want %q", key, got, wantValue)
+		}
+	}
+}
+
+// TestYAMLScalarToJSON5Raw is the YAML side. The integer rows are the ones
+// that earn their keep: YAML accepts four spellings JSON5 has never heard
+// of, and every one has to come out as a plain decimal.
+func TestYAMLScalarToJSON5Raw(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain string", "k: web", `"web"`},
+		{"quoted number", `k: "5"`, `"5"`},
+		{"quoted bool", `k: "true"`, `"true"`},
+		{"empty string", `k: ""`, `""`},
+		{"sigil template", `k: '{{ .app }}'`, `"{{ .app }}"`},
+		{"escaped sigil", `k: "{{ .app | dq }}"`, `"{{ .app | dq }}"`},
+		{"string with quote", `k: 'say "hi"'`, `"say \"hi\""`},
+		{"block scalar", "k: |\n  first\n  second\n", `"first\nsecond\n"`},
+		{"folded scalar", "k: >\n  first\n  second\n", `"first second\n"`},
+		{"bool true", "k: true", "true"},
+		{"bool yes uppercase", "k: TRUE", "true"},
+		{"bool false", "k: false", "false"},
+		{"null tilde", "k: ~", "null"},
+		{"null word", "k: null", "null"},
+		{"empty value", "k:", "null"},
+		{"int", "k: 42", "42"},
+		{"negative int", "k: -42", "-42"},
+		{"hex int", "k: 0x1F", "31"},
+		{"octal int", "k: 0o17", "15"},
+		{"underscored int", "k: 1_000", "1000"},
+		{"signed int", "k: +5", "5"},
+		{"float", "k: 1.5", "1.5"},
+		{"float trailing zero", "k: 1.50", "1.5"},
+		{"exponent", "k: 1e3", "1000"},
+		{"infinity", "k: .inf", "Infinity"},
+		{"negative infinity", "k: -.inf", "-Infinity"},
+		{"nan", "k: .nan", "NaN"},
+		{"timestamp widens", "k: 2015-01-01", `"2015-01-01"`},
+		{"emoji", `k: "hi 🎉"`, `"hi 🎉"`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tc.in), &doc); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			value := documentBody(&doc).Content[1]
+			got, err := yamlScalarToJSON5Raw(value)
+			if err != nil {
+				t.Fatalf("yamlScalarToJSON5Raw: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("yamlScalarToJSON5Raw(%s) = %s, want %s (tag %s)", tc.in, got, tc.want, value.Tag)
+			}
+		})
+	}
+}
+
+// TestYAMLScalarToJSON5RawRejectsCustomTag keeps an unrecognised tag from
+// being silently stringified.
+func TestYAMLScalarToJSON5RawRejectsCustomTag(t *testing.T) {
+	t.Parallel()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte("k: !Foo bar"), &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if raw, err := yamlScalarToJSON5Raw(documentBody(&doc).Content[1]); err == nil {
+		t.Errorf("yamlScalarToJSON5Raw of a !Foo scalar = %s, want an error", raw)
+	}
+}
+
+// TestCommentTranslation covers the delimiter mapping in both directions.
+func TestCommentTranslation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("json5 to yaml", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name string
+			in   []string
+			want string
+		}{
+			{"line comment", []string{"// hello"}, "# hello"},
+			{"no space", []string{"//hello"}, "# hello"},
+			{"two lines", []string{"// a", "// b"}, "# a\n# b"},
+			{"block comment", []string{"/* a\n   b */"}, "# a\n#   b"},
+			{"blank interior line", []string{"/* a\n\nb */"}, "# a\n#\n# b"},
+			{"empty token", []string{""}, ""},
+		}
+		for _, tc := range cases {
+			if got := json5CommentsToYAML(tc.in); got != tc.want {
+				t.Errorf("%s: json5CommentsToYAML(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("yaml to json5", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name string
+			in   string
+			want []string
+		}{
+			{"one line", "# hello", []string{"// hello"}},
+			{"two lines", "# a\n# b", []string{"// a", "// b"}},
+			{"no hash", "bare", []string{"// bare"}},
+			{"empty", "", nil},
+		}
+		for _, tc := range cases {
+			got := yamlCommentToJSON5(tc.in)
+			if strings.Join(got, "|") != strings.Join(tc.want, "|") {
+				t.Errorf("%s: yamlCommentToJSON5(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+			}
+		}
+	})
+}
+
+// TestBlankCommentLineStaysAHash guards the one comment rule that is not
+// cosmetic: an empty line inside a converted comment has to come back as a
+// bare "#". Emitted as "", the YAML writer produces a real blank line,
+// which ends the comment on re-parse and splits one head comment in two -
+// so the converted recipe would stop being idempotent under `docket fmt`.
+func TestBlankCommentLineStaysAHash(t *testing.T) {
+	t.Parallel()
+
+	in := []byte("/* first\n\nsecond */\n[{ name: \"web\", tasks: [] }]\n")
+	out, err := Convert(in, CodecFor(FormatNameJSON5), CodecFor(FormatYAML))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if strings.Contains(string(out), "\n\n#") {
+		t.Errorf("a blank line split the head comment:\n%s", out)
+	}
+	again, err := CodecFor(FormatYAML).Format(out)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if string(again) != string(out) {
+		t.Errorf("converted output is not fmt-stable:\nfirst:\n%s\nsecond:\n%s", out, again)
+	}
+}
+
+// TestKeyLineCommentLandsAfterColon pins the choice to hang a member's
+// trailing comment on the key node. yaml.v3 replays a key's line comment
+// beside a scalar value and directly after the colon for a block one; on
+// the value node instead, a container's comment would be pushed down past
+// the whole block it was introducing.
+func TestKeyLineCommentLandsAfterColon(t *testing.T) {
+	t.Parallel()
+
+	in := []byte("[{ name: \"web\", tasks: [{ name: \"a\" }], // about the tasks\n}]\n")
+	out, err := Convert(in, CodecFor(FormatNameJSON5), CodecFor(FormatYAML))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if !strings.Contains(string(out), "tasks: # about the tasks") {
+		t.Errorf("comment did not land beside the tasks key:\n%s", out)
+	}
+}
+
+// TestMergeTokenStringSurvives pins the one value the !!str tag does not
+// protect on its own. yaml.v3 writes a plain `g: <<`, which reads back as
+// !!merge, so yamlStringNode has to force quotes around it.
+//
+// Before that fix the recipe was not corrupted - the YAML formatter's own
+// round-trip guard caught it - but the conversion was refused outright,
+// which is a poor answer for a recipe that merely mentions "<<".
+func TestMergeTokenStringSurvives(t *testing.T) {
+	t.Parallel()
+
+	out, err := Convert([]byte(`{ g: "<<" }`), CodecFor(FormatNameJSON5), CodecFor(FormatYAML))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got, ok := decoded["g"].(string); !ok || got != "<<" {
+		t.Errorf("g = %#v, want the string \"<<\" (output: %q)", decoded["g"], out)
+	}
+}
+
+// TestOrdinaryStringsAreNotOverQuoted guards against over-correcting the
+// forced-quote rules: a value the emitter already handles keeps the style
+// it picked, so converted YAML does not come out wrapped in quotes it
+// never needed.
+func TestOrdinaryStringsAreNotOverQuoted(t *testing.T) {
+	t.Parallel()
+
+	out, err := Convert([]byte(`{ app: "web", state: "present" }`), CodecFor(FormatNameJSON5), CodecFor(FormatYAML))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if want := "app: web\nstate: present\n"; string(out) != want {
+		t.Errorf("ordinary strings were quoted:\nwant:\n%s\ngot:\n%s", want, out)
+	}
+}
+
+// TestConvertKeepsDqInterpolationsDoubleQuoted is a semantic regression
+// test, not a formatting one. A recipe is rendered as text and only then
+// parsed, so the quotes around an interpolation decide how the value is
+// escaped: `dq` emits JSON-style escaping, which a double-quoted YAML
+// scalar undoes and a single-quoted one does not.
+//
+// Left to its own judgement the YAML emitter single-quotes a value opening
+// with `{`, which turned `"{{ .app | dq }}"` into `'{{ .app | dq }}'` and
+// silently rendered `we"b` as the literal `we\"b`. `docket init`'s own
+// scaffold uses `dq`, so a round trip through JSON5 corrupted it.
+func TestConvertKeepsDqInterpolationsDoubleQuoted(t *testing.T) {
+	t.Parallel()
+
+	in := []byte(`[{ name: "web", tasks: [{ dokku_app: { app: "{{ .app | dq }}" } }] }]`)
+	out, err := Convert(in, CodecFor(FormatNameJSON5), CodecFor(FormatYAML))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if !strings.Contains(string(out), `"{{ .app | dq }}"`) {
+		t.Fatalf("interpolation lost its double quotes:\n%s", out)
+	}
+
+	// The assertion that matters is what the value becomes after the render
+	// the quotes exist to serve.
+	rendered, err := RenderTemplate(out, map[string]interface{}{"app": `we"b`}, "recipe")
+	if err != nil {
+		t.Fatalf("RenderTemplate: %v", err)
+	}
+	plays, err := UnmarshalRecipe(rendered.Bytes(), FormatYAML)
+	if err != nil {
+		t.Fatalf("UnmarshalRecipe: %v\n%s", err, rendered.String())
+	}
+	if len(plays) != 1 || len(plays[0].Tasks) != 1 {
+		t.Fatalf("recipe shape changed: %d plays", len(plays))
+	}
+	var app string
+	if spec, ok := plays[0].Tasks[0]["dokku_app"].(map[string]interface{}); ok {
+		app, _ = spec["app"].(string)
+	}
+	if app != `we"b` {
+		t.Errorf("app = %q, want %q; the quote style around the interpolation was not preserved:\n%s", app, `we"b`, rendered.String())
+	}
+}

--- a/tasks/format.go
+++ b/tasks/format.go
@@ -58,6 +58,42 @@ var envelopeKeySet = func() map[string]bool {
 //     canonical AST trees are structurally equivalent (defends against
 //     yaml.v3 emitter edge cases with anchors / complex flow scalars).
 func Format(data []byte) ([]byte, error) {
+	root, err := decodeSingleYAMLDocument(data)
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		// Empty or comment-only file: there is nothing to canonicalize.
+		// Return the input untouched so `docket fmt` is a no-op and
+		// `fmt --check` passes rather than failing the round-trip guard.
+		return data, nil
+	}
+
+	out, err := encodeCanonicalYAML(root)
+	if err != nil {
+		return nil, err
+	}
+
+	// The document marker is restored here rather than in
+	// encodeCanonicalYAML because it is a property of the bytes that were
+	// read, not of the tree. A document arriving from another format has
+	// no marker to preserve, so conversion into YAML never emits one.
+	if hasDocumentMarker(data) && !hasDocumentMarker(out) {
+		out = append([]byte("---\n"), out...)
+	}
+
+	return out, nil
+}
+
+// decodeSingleYAMLDocument is Format's reading half, split out so the YAML
+// codec's DecodeDocument and Format cannot drift apart on what counts as a
+// parse error, a multi-document file, or an empty one.
+//
+// A nil node with a nil error means the source holds no document at all -
+// an empty or comment-only file. That is not a failure: Format returns
+// such a file untouched, and Convert does the same rather than inventing
+// an empty recipe in the target format.
+func decodeSingleYAMLDocument(data []byte) (*yaml.Node, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	var root yaml.Node
 	err := dec.Decode(&root)
@@ -67,10 +103,7 @@ func Format(data []byte) ([]byte, error) {
 
 	doc := documentBody(&root)
 	if err == io.EOF || isEmptyDocument(doc) {
-		// Empty or comment-only file: there is nothing to canonicalize.
-		// Return the input untouched so `docket fmt` is a no-op and
-		// `fmt --check` passes rather than failing the round-trip guard.
-		return data, nil
+		return nil, nil
 	}
 
 	// docket recipes are single-document. Reject a file with more than one
@@ -85,6 +118,22 @@ func Format(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("yaml parse error: %w", extraErr)
 	}
 
+	return &root, nil
+}
+
+// encodeCanonicalYAML is Format's writing half: canonical key order, a
+// 2-space indent, the whitespace pass, and the round-trip equivalence
+// guard. It takes the document node decodeSingleYAMLDocument returned, so
+// the YAML codec's EncodeDocument is this function and nothing else.
+func encodeCanonicalYAML(root *yaml.Node) ([]byte, error) {
+	if root == nil {
+		return nil, fmt.Errorf("cannot encode a nil document")
+	}
+
+	doc := documentBody(root)
+	if doc == nil {
+		return nil, fmt.Errorf("cannot encode an empty document")
+	}
 	if doc.Kind == yaml.SequenceNode {
 		canonicalizeRecipe(doc)
 	}
@@ -92,7 +141,7 @@ func Format(data []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
-	if err := enc.Encode(&root); err != nil {
+	if err := enc.Encode(root); err != nil {
 		_ = enc.Close()
 		return nil, fmt.Errorf("yaml encode error: %w", err)
 	}
@@ -102,10 +151,6 @@ func Format(data []byte) ([]byte, error) {
 
 	out := postProcess(buf.Bytes())
 
-	if hasDocumentMarker(data) && !hasDocumentMarker(out) {
-		out = append([]byte("---\n"), out...)
-	}
-
 	// Round-trip equivalence guard: re-parse the canonical output and
 	// require structural equivalence to the input. Catches yaml.v3
 	// emitter edge cases before the caller writes anything to disk.
@@ -113,7 +158,7 @@ func Format(data []byte) ([]byte, error) {
 	if err := yaml.Unmarshal(out, &roundTrip); err != nil {
 		return nil, fmt.Errorf("round-trip parse error: %w", err)
 	}
-	if !equivalentNodes(documentBody(&root), documentBody(&roundTrip)) {
+	if !equivalentNodes(doc, documentBody(&roundTrip)) {
 		return nil, fmt.Errorf("round-trip equivalence check failed; refusing to write")
 	}
 

--- a/tasks/format_json5.go
+++ b/tasks/format_json5.go
@@ -572,6 +572,21 @@ func (l *json5Lexer) readNumber() (json5Tok, error) {
 	if l.src[l.pos] == '+' || l.src[l.pos] == '-' {
 		l.pos++
 	}
+	// JSON5 spells the non-finite numbers Infinity and NaN, and allows a
+	// sign in front of them. They have to be recognised here rather than
+	// left to readIdent, because the sign has already been consumed: the
+	// digit loop below stops dead on the "I", which used to yield a lone
+	// "-" token with "Infinity" following it as a separate identifier.
+	// Nothing rejected that pair - parseArray and parseObject treat the
+	// comma between entries as optional (#537) - so `[-Infinity]` parsed as
+	// two elements. An unsigned Infinity / NaN never reaches here at all; it
+	// starts with a letter, so the lexer sends it to readIdent.
+	for _, word := range []string{"Infinity", "NaN"} {
+		if l.hasWordAt(l.pos, word) {
+			l.pos += len(word)
+			return json5Tok{Kind: tokNumber, Raw: string(l.src[start:l.pos])}, nil
+		}
+	}
 	if l.pos+1 < len(l.src) && l.src[l.pos] == '0' && (l.src[l.pos+1] == 'x' || l.src[l.pos+1] == 'X') {
 		l.pos += 2
 		for l.pos < len(l.src) && isHexDigit(l.src[l.pos]) {
@@ -591,6 +606,23 @@ func (l *json5Lexer) readNumber() (json5Tok, error) {
 		return json5Tok{}, fmt.Errorf("invalid number at offset %d", start)
 	}
 	return json5Tok{Kind: tokNumber, Raw: string(l.src[start:l.pos])}, nil
+}
+
+// hasWordAt reports whether the source holds word at pos and does not
+// continue into a longer identifier, so "NaN" matches but "NaNny" does
+// not.
+func (l *json5Lexer) hasWordAt(pos int, word string) bool {
+	if pos+len(word) > len(l.src) {
+		return false
+	}
+	if string(l.src[pos:pos+len(word)]) != word {
+		return false
+	}
+	if pos+len(word) == len(l.src) {
+		return true
+	}
+	r, _ := utf8.DecodeRune(l.src[pos+len(word):])
+	return !isIdentPart(r)
 }
 
 func (l *json5Lexer) readIdent() json5Tok {

--- a/tasks/format_json5_test.go
+++ b/tasks/format_json5_test.go
@@ -319,3 +319,82 @@ func TestFormatJSON5RootInsideAndAfterComments(t *testing.T) {
 		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", body, again)
 	}
 }
+
+// TestLexJSON5SignedNonFiniteNumbers pins the fix for a lexer bug that
+// only surfaced once cross-format conversion started emitting JSON5:
+// readNumber consumed the sign and then stopped on the "I", handing back
+// a lone "-" token with "Infinity" trailing it as a separate identifier.
+// parseArray does not require a comma between elements, so nothing
+// rejected the pair and `[-Infinity]` silently parsed as two elements.
+func TestLexJSON5SignedNonFiniteNumbers(t *testing.T) {
+	toks, err := lexJSON5([]byte("[-Infinity, +Infinity, Infinity, -NaN, NaN]"))
+	if err != nil {
+		t.Fatalf("lexJSON5: %v", err)
+	}
+	var values []string
+	for _, tok := range toks {
+		if tok.Kind == tokNumber || tok.Kind == tokIdent {
+			values = append(values, tok.Raw)
+		}
+	}
+	want := []string{"-Infinity", "+Infinity", "Infinity", "-NaN", "NaN"}
+	if len(values) != len(want) {
+		t.Fatalf("lexed %d value tokens %q, want %d %q", len(values), values, len(want), want)
+	}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Errorf("token %d = %q, want %q", i, values[i], want[i])
+		}
+	}
+
+	node, err := parseJSON5([]byte("[-Infinity, +Infinity, Infinity, -NaN, NaN]"))
+	if err != nil {
+		t.Fatalf("parseJSON5: %v", err)
+	}
+	if len(node.Elements) != len(want) {
+		t.Errorf("parsed %d elements, want %d", len(node.Elements), len(want))
+	}
+}
+
+// TestLexJSON5SignedWordPrefixIsNotSwallowed guards the boundary check in
+// hasWordAt: an identifier that merely starts with Infinity or NaN is not
+// one of them, so the sign is not glued onto it.
+//
+// The assertion is on the tokens rather than on parseJSON5 returning an
+// error, because it does not: the lexer yields "-" and "Infinities" as
+// two tokens and parseArray accepts them as two elements, the comma
+// between entries being optional. That leniency is #537; what matters here
+// is that hasWordAt did not claim the longer word.
+func TestLexJSON5SignedWordPrefixIsNotSwallowed(t *testing.T) {
+	toks, err := lexJSON5([]byte("-Infinities"))
+	if err != nil {
+		t.Fatalf("lexJSON5: %v", err)
+	}
+	for _, tok := range toks {
+		if tok.Raw == "-Infinities" {
+			t.Errorf("hasWordAt swallowed a longer identifier: %q", tok.Raw)
+		}
+	}
+}
+
+// TestFormatJSON5RoundTripsNonFiniteNumbers is the formatter-level half:
+// the canonical form keeps the signed spellings and is idempotent.
+func TestFormatJSON5RoundTripsNonFiniteNumbers(t *testing.T) {
+	in := []byte("[-Infinity, Infinity, NaN]\n")
+	out, err := FormatJSON5(in)
+	if err != nil {
+		t.Fatalf("FormatJSON5: %v", err)
+	}
+	for _, want := range []string{"-Infinity", "Infinity", "NaN"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	again, err := FormatJSON5(out)
+	if err != nil {
+		t.Fatalf("FormatJSON5 second pass: %v", err)
+	}
+	if string(again) != string(out) {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", out, again)
+	}
+}

--- a/tests/bats/fmt.bats
+++ b/tests/bats/fmt.bats
@@ -173,3 +173,130 @@ EOF
   run grep -c "configure the second app" tasks.yml
   assert_output "1"
 }
+
+@test "docket fmt --format json5 - converts a piped YAML recipe" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >input.yml <<'EOF'
+---
+- name: web
+  tasks:
+    # scale it up first
+    - name: scale
+      dokku_ps_scale:
+        app: web
+EOF
+  run bash -c "\"$(docket_bin)\" fmt --format json5 - <input.yml"
+  assert_success
+  assert_output --partial 'name: "web",'
+  assert_output --partial "// scale it up first"
+  refute_output --partial "# scale it up first"
+  assert [ ! -f tasks.yml ]
+}
+
+@test "docket fmt --format yaml - converts a piped JSON5 recipe" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >input.json5 <<'EOF'
+[
+  {
+    name: "web",
+    // scale it up first
+    tasks: [{ name: "scale", dokku_ps_scale: { app: "web" } }],
+  },
+]
+EOF
+  run bash -c "\"$(docket_bin)\" fmt --format yaml - <input.json5"
+  assert_success
+  assert_output --partial "- name: web"
+  assert_output --partial "# scale it up first"
+  refute_output --partial "// scale it up first"
+}
+
+@test "docket fmt --format converts a recipe in place and warns about the extension" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  run "$(docket_bin)" fmt --format json5 tasks.yml
+  assert_success
+  assert_output --partial "does not match"
+  assert_output --partial "--tasks-format json5"
+  run head -n 1 tasks.yml
+  assert_output "["
+}
+
+@test "docket fmt --output writes a converted recipe that validate reads" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  run "$(docket_bin)" fmt --format json5 --output tasks.json5 tasks.yml
+  assert_success
+  assert_output --partial "Wrote tasks.json5"
+  # The source is left exactly as it was.
+  run "$(docket_bin)" fmt --check tasks.yml
+  assert_success
+  # And the converted file is canonical and loadable on its own.
+  run "$(docket_bin)" fmt --check tasks.json5
+  assert_success
+  run "$(docket_bin)" validate --tasks tasks.json5
+  assert_success
+}
+
+@test "docket fmt --output refuses to overwrite without --force" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  echo "// keep me" >tasks.json5
+  run "$(docket_bin)" fmt --format json5 --output tasks.json5 tasks.yml
+  assert_failure
+  assert_output --partial "pass --force to overwrite"
+  run cat tasks.json5
+  assert_output "// keep me"
+
+  run "$(docket_bin)" fmt --format json5 --output tasks.json5 --force tasks.yml
+  assert_success
+  run "$(docket_bin)" validate --tasks tasks.json5
+  assert_success
+}
+
+@test "docket fmt --check rejects a --format that would convert" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  run "$(docket_bin)" fmt --check --format json5 tasks.yml
+  assert_failure
+  assert_output --partial "a conversion is never a no-op"
+  # The recipe is untouched: --check never writes.
+  run head -n 1 tasks.yml
+  assert_output "---"
+}
+
+@test "docket fmt round-trips a recipe through JSON5 and back" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  "$(docket_bin)" fmt --format json5 --output tasks.json5 tasks.yml
+  run bash -c "\"$(docket_bin)\" fmt --format yaml - <tasks.json5 >back.yml"
+  assert_success
+  run "$(docket_bin)" validate --tasks back.yml
+  assert_success
+  run "$(docket_bin)" fmt --check back.yml
+  assert_success
+
+  # Equivalence is asserted by converting both to the same format rather
+  # than by diffing the YAML. A round trip is deliberately not byte-exact:
+  # the --- marker belongs to the bytes that were read, and quoting a value
+  # that needs no quotes, or writing a sequence in flow style, are choices
+  # the canonical form does not preserve.
+  run bash -c "\"$(docket_bin)\" fmt --format json5 - <back.yml >back.json5"
+  assert_success
+  run diff tasks.json5 back.json5
+  assert_success
+}
+
+@test "docket fmt keeps a dq interpolation double-quoted across a round trip" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  "$(docket_bin)" fmt --format json5 --output tasks.json5 tasks.yml
+  run bash -c "\"$(docket_bin)\" fmt --format yaml - <tasks.json5 >back.yml"
+  assert_success
+  # The quotes around an interpolation are part of what the recipe means:
+  # dq escapes for a double-quoted scalar, and a single-quoted one would
+  # leave the backslashes in the rendered value.
+  run grep -c "\"{{ .app | dq }}\"" back.yml
+  refute_output "0"
+  refute_output --partial "'{{ .app | dq }}'"
+}


### PR DESCRIPTION
`docket fmt` gains `--format`, the output-side counterpart to `--tasks-format`: it states the format to write, and converts the recipe when that is not the format it was read as. Conversion works on stdin, in place under the existing name, and to a new `--output` path that will not overwrite an existing file without `--force`, and it keeps the comments both formatters already preserve, so changing a recipe's format no longer means a trip out to another tool and back. `--check` is refused alongside a converting `--format`, since a conversion is never a no-op and every file would otherwise report as unformatted, while `--diff` previews one without writing. A conversion is deliberately not byte-reversible: YAML anchors and merge keys are inlined and numbers are normalised to decimal, neither having a JSON5 spelling, and a leading `---` describes the bytes that were read rather than the recipe. Quoting around an interpolation is preserved, because `dq` escapes for a double-quoted scalar and a single-quoted one would leave the backslashes in the rendered value.

Two things found along the way are filed rather than fixed here. #537 is the JSON5 parser treating the comma between entries as optional, which is why a lexer bug that split `-Infinity` into two tokens went unnoticed; tightening it changes how existing files parse. #538 is the one gap conversion cannot close in both directions, since canonical JSON5 has no single-quoted string for a YAML `'{{ .app }}'` to become.

Closes #418
